### PR TITLE
TEAL v2 support

### DIFF
--- a/examples/atomic_swap.py
+++ b/examples/atomic_swap.py
@@ -28,4 +28,4 @@ def htlc(tmpl_seller=alice,
 			   type_cond,
 			   Or(recv_cond, esc_cond))
 
-print(compileTeal(htlc()))
+print(compileTeal(htlc(), Mode.Signature))

--- a/examples/dutch_auction.py
+++ b/examples/dutch_auction.py
@@ -89,4 +89,4 @@ dutch = Cond([Global.group_size() == Int(5), bid],
              [Global.group_size() == Int(4), redeem],
              [Global.group_size() == Int(1), wrapup])
 
-print(compileTeal(dutch))
+print(compileTeal(dutch, Mode.Signature))

--- a/examples/periodic_payment.py
+++ b/examples/periodic_payment.py
@@ -29,4 +29,4 @@ def periodic_payment(tmpl_fee=tmpl_fee,
 
     return And(periodic_pay_core, periodic_pay_transfer)
 
-# print(compileTeal(periodic_payment()))
+# print(compileTeal(periodic_payment(), Mode.Signature))

--- a/examples/recurring_swap.py
+++ b/examples/recurring_swap.py
@@ -49,6 +49,6 @@ def recurring_swap(tmpl_buyer=tmpl_buyer,
                      Txn.amount() == Int(0),
                      Txn.first_valid() >= tmpl_timeout)
 
-    return compileTeal(And(fee_cond, type_cond, Or(recv_cond, close_cond)))
+    return compileTeal(And(fee_cond, type_cond, Or(recv_cond, close_cond)), Mode.Signature)
 
 # print(recurring_swap())

--- a/examples/split.py
+++ b/examples/split.py
@@ -34,4 +34,4 @@ split = And(split_core,
                split_transfer,
                split_close))
 
-print(split.teal())
+print(compileTeal(split, Mode.Signature))

--- a/pyteal/__init__.py
+++ b/pyteal/__init__.py
@@ -1,5 +1,7 @@
 from .ast import *
+from .ir import *
 from .compiler import compileTeal
+from .types import TealType
 from .errors import TealInternalError, TealTypeError, TealInputError
 from .util import execute
 from .config import MAX_GROUP_SIZE

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -6,28 +6,37 @@ from .leafexpr import LeafExpr
 from .addr import Addr
 from .bytes import Bytes
 from .err import Err
-from .int import Int
+from .int import Int, EnumInt
 
 # properties
 from .arg import Arg
-from .txn import Txn, TxnField
+from .txn import TxnType, TxnField, Txn, Txna
 from .gtxn import Gtxn
-from .global_ import Global
+from .global_ import Global, GlobalField
+from .app import App, AppField, OnComplete
+from .asset import AssetHolding, AssetParam
 
 # meta
 from .tmpl import Tmpl
 from .nonce import Nonce
 
 # unary ops
-from .unaryexpr import UnaryExpr, Btoi, Itob, Len, Sha256, Sha512_256, Keccak256, Pop
+from .unaryexpr import UnaryExpr, Btoi, Itob, Len, Sha256, Sha512_256, Keccak256, Not, BitwiseNot, Pop, Return, Balance
 
 # binary ops
-from .binaryexpr import BinaryExpr, Add, Minus, Mul, Div, Mod, Eq, Lt, Le, Gt, Ge
+from .binaryexpr import BinaryExpr, Add, Minus, Mul, Div, BitwiseAnd, BitwiseOr, BitwiseXor, Mod, Eq, Neq, Lt, Le, Gt, Ge
 
 # more ops
 from .ed25519verify import Ed25519Verify
-from .naryexpr import NaryExpr, And, Or
+from .substring import Substring
+from .naryexpr import NaryExpr, And, Or, Concat
 
 # control flow
 from .if_ import If
 from .cond import Cond
+from .seq import Seq
+from .assert_ import Assert
+
+# misc
+from .scratch import ScratchSlot, ScratchLoad, ScratchStore
+from .maybe import MaybeValue

--- a/pyteal/ast/addr.py
+++ b/pyteal/ast/addr.py
@@ -1,12 +1,13 @@
 from ..types import TealType, valid_address
+from ..ir import TealOp, Op
 from .leafexpr import LeafExpr
 
 class Addr(LeafExpr):
     """An expression that represents an Algorand address."""
-     
+
     def __init__(self, address: str) -> None:
         """Create a new Addr expression.
-        
+
         Args:
             address: A string containing a valid base32 Algorand address
         """
@@ -14,7 +15,7 @@ class Addr(LeafExpr):
         self.address = address
 
     def __teal__(self):
-        return [["addr", self.address]]
+        return [TealOp(Op.addr, self.address)]
 
     def __str__(self):
         return "(address: {})".format(self.address)

--- a/pyteal/ast/addr_test.py
+++ b/pyteal/ast/addr_test.py
@@ -4,8 +4,9 @@ from .. import *
 
 def test_addr():
     expr = Addr("NJUWK3DJNZTWU2LFNRUW4Z3KNFSWY2LOM5VGSZLMNFXGO2TJMVWGS3THMF")
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["addr", "NJUWK3DJNZTWU2LFNRUW4Z3KNFSWY2LOM5VGSZLMNFXGO2TJMVWGS3THMF"]
+        TealOp(Op.addr, "NJUWK3DJNZTWU2LFNRUW4Z3KNFSWY2LOM5VGSZLMNFXGO2TJMVWGS3THMF")
     ]
 
 def test_addr_invalid():

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -1,0 +1,185 @@
+from enum import Enum
+
+from ..types import TealType, require_type
+from ..ir import TealOp, Op
+from .leafexpr import LeafExpr
+from .expr import Expr
+from .maybe import MaybeValue
+from .int import EnumInt
+from .global_ import Global
+
+class OnComplete:
+    """An enum of values that Txn.on_completion() may return."""
+    NoOp = EnumInt("NoOp")
+    OptIn = EnumInt("OptIn")
+    CloseOut = EnumInt("CloseOut")
+    ClearState = EnumInt("ClearState")
+    UpdateApplication = EnumInt("UpdateApplication")
+    DeleteApplication = EnumInt("DeleteApplication")
+
+class AppField(Enum):
+    optedIn = (Op.app_opted_in, TealType.uint64)
+    localGet = (Op.app_local_get, TealType.anytype)
+    localGetEx = (Op.app_local_get_ex, TealType.none)
+    globalGet = (Op.app_global_get, TealType.anytype)
+    globalGetEx = (Op.app_global_get_ex, TealType.none)
+    localPut = (Op.app_local_put, TealType.none)
+    globalPut = (Op.app_global_put, TealType.none)
+    localDel = (Op.app_local_del, TealType.none)
+    globalDel = (Op.app_global_del, TealType.none)
+
+    def __init__(self, op: Op, type: TealType) -> None:
+        self.op = op
+        self.ret_type = type
+    
+    def get_op(self) -> Op:
+        return self.op
+    
+    def type_of(self) -> TealType:
+        return self.ret_type
+
+class App(LeafExpr):
+    """An expression related to applications."""
+
+    def __init__(self, field:AppField, args) -> None:
+        self.field = field
+        self.args = args
+
+    def __str__(self):
+        ret_str = "({}".format(self.field.get_op())
+        for a in self.args:
+            ret_str += " " + a.__str__()
+        ret_str += ")"
+        return ret_str
+
+    def __teal__(self):
+        teal = []
+        for arg in self.args:
+            teal += arg.__teal__()
+        teal += [TealOp(self.field.get_op())]
+        return teal
+
+    def type_of(self):
+        return self.field.type_of()
+
+    @classmethod
+    def id(cls):
+        """Get the ID of the current running application.
+        
+        This is the same as Global.current_application_id().
+        """
+        return Global.current_application_id()
+
+    @classmethod
+    def optedIn(cls, account: Expr, app: Expr):
+        """Check if an account has opted in for an application.
+
+        Args:
+            account: An index into Txn.Accounts that corresponds to the account to check. Must
+            evaluate to uint64.
+            app: The ID of the application being checked. Must evaluate to uint64.
+        """
+        require_type(account.type_of(), TealType.uint64)
+        require_type(app.type_of(), TealType.uint64)
+        return cls(AppField.optedIn, [account, app])
+    
+    @classmethod
+    def localGet(cls, account: Expr, key: Expr):
+        """Read from an account's local state for the current application.
+
+        Args:
+            account: An index into Txn.Accounts that corresponds to the account to read from. Must
+            evaluate to uint64.
+            key: The key to read from the account's local state. Must evaluate to bytes.
+        """
+        require_type(account.type_of(), TealType.uint64)
+        require_type(key.type_of(), TealType.bytes)
+        return cls(AppField.localGet, [account, key])
+    
+    @classmethod
+    def localGetEx(cls, account: Expr, app: Expr, key: Expr):
+        """Read from an account's local state for an application.
+
+        Args:
+            account: An index into Txn.Accounts that corresponds to the account to read from. Must
+            evaluate to uint64.
+            app: The ID of the application being checked. Must evaluate to uint64.
+            key: The key to read from the account's local state. Must evaluate to bytes.
+        """
+        require_type(account.type_of(), TealType.uint64)
+        require_type(app.type_of(), TealType.uint64)
+        require_type(key.type_of(), TealType.bytes)
+        return MaybeValue(AppField.localGetEx.get_op(), TealType.anytype, args=[account, app, key])
+
+    @classmethod
+    def globalGet(cls, key: Expr):
+        """Read from the global state of the current application.
+
+        Args:
+            key: The key to read from the global application state. Must evaluate to bytes.
+        """
+        require_type(key.type_of(), TealType.bytes)
+        return cls(AppField.globalGet, [key])
+    
+    @classmethod
+    def globalGetEx(cls, app: Expr, key: Expr):
+        """Read from the global state of an application.
+
+        Args:
+            app: An index into Txn.ForeignApps that corresponds to the application to read from.
+            Must evaluate to uint64.
+            key: The key to read from the global application state. Must evaluate to bytes.
+        """
+        require_type(app.type_of(), TealType.uint64)
+        require_type(key.type_of(), TealType.bytes)
+        return MaybeValue(AppField.globalGetEx.get_op(), TealType.anytype, args=[app, key])
+
+    @classmethod
+    def localPut(cls, account: Expr, key: Expr, value: Expr):
+        """Write to an account's local state for the current application.
+
+        Args:
+            account: An index into Txn.Accounts that corresponds to the account to write to. Must
+            evaluate to uint64.
+            key: The key to write in the account's local state. Must evaluate to bytes.
+            value: The value to write in the account's local state. Can evaluate to any type.
+        """
+        require_type(account.type_of(), TealType.uint64)
+        require_type(key.type_of(), TealType.bytes)
+        require_type(value.type_of(), TealType.anytype)
+        return cls(AppField.localPut, [account, key, value])
+    
+    @classmethod
+    def globalPut(cls, key: Expr, value: Expr):
+        """Write to the global state of the current application.
+
+        Args:
+            key: The key to write in the global application state. Must evaluate to bytes.
+            value: THe value to write in the global application state. Can evaluate to any type.
+        """
+        require_type(key.type_of(), TealType.bytes)
+        require_type(value.type_of(), TealType.anytype)
+        return cls(AppField.globalPut, [key, value])
+
+    @classmethod
+    def localDel(cls, account: Expr, key: Expr):
+        """Delete a key from an account's local state for the current application.
+
+        Args:
+            account: An index into Txn.Accounts that corresponds to the account from which the key
+            should be deleted. Must evaluate to uint64.
+            key: The key to delete from the account's local state. Must evaluate to bytes.
+        """
+        require_type(account.type_of(), TealType.uint64)
+        require_type(key.type_of(), TealType.bytes)
+        return cls(AppField.localDel, [account, key])
+    
+    @classmethod
+    def globalDel(cls, key: Expr):
+        """Delete a key from the global state of the current application.
+
+        Args:
+            key: The key to delete from the global application state. Must evaluate to bytes.
+        """
+        require_type(key.type_of(), TealType.bytes)
+        return cls(AppField.globalDel, [key])

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -1,0 +1,176 @@
+import pytest
+
+from .. import *
+
+def test_on_complete():
+    assert OnComplete.NoOp.__teal__() == [
+        TealOp(Op.int, "NoOp")
+    ]
+
+    assert OnComplete.OptIn.__teal__() == [
+        TealOp(Op.int, "OptIn")
+    ]
+
+    assert OnComplete.CloseOut.__teal__() == [
+        TealOp(Op.int, "CloseOut")
+    ]
+
+    assert OnComplete.ClearState.__teal__() == [
+        TealOp(Op.int, "ClearState")
+    ]
+
+    assert OnComplete.UpdateApplication.__teal__() == [
+        TealOp(Op.int, "UpdateApplication")
+    ]
+
+    assert OnComplete.DeleteApplication.__teal__() == [
+        TealOp(Op.int, "DeleteApplication")
+    ]
+
+def test_app_id():
+    expr = App.id()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == Global.current_application_id().__teal__()
+
+def test_opted_in():
+    expr = App.optedIn(Int(1), Int(12))
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 12),
+        TealOp(Op.app_opted_in)
+    ]
+
+def test_local_get():
+    expr = App.localGet(Int(0), Bytes("key"))
+    assert expr.type_of() == TealType.anytype
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.app_local_get)
+    ]
+
+def test_local_get_invalid():
+    with pytest.raises(TealTypeError):
+        App.localGet(Txn.sender(), Bytes("key"))
+    
+    with pytest.raises(TealTypeError):
+        App.localGet(Int(0), Int(1))
+
+def test_local_get_ex():
+    expr = App.localGetEx(Int(0), Int(6), Bytes("key"))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.anytype
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.int, 6),
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.app_local_get_ex),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_local_get_ex_invalid():
+    with pytest.raises(TealTypeError):
+        App.localGetEx(Txn.sender(), Int(0), Bytes("key"))
+    
+    with pytest.raises(TealTypeError):
+        App.localGetEx(Int(0), Bytes("app"), Bytes("key"))
+
+    with pytest.raises(TealTypeError):
+        App.localGetEx(Int(0), Int(0), Int(1))
+
+def test_global_get():
+    expr = App.globalGet(Bytes("key"))
+    assert expr.type_of() == TealType.anytype
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.app_global_get)
+    ]
+
+def test_global_get_invalid():
+    with pytest.raises(TealTypeError):
+        App.globalGet(Int(7))
+
+def test_global_get_ex():
+    expr = App.globalGetEx(Int(6), Bytes("key"))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.anytype
+    assert expr.__teal__() == [
+        TealOp(Op.int, 6),
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.app_global_get_ex),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_global_get_ex_invalid():
+    with pytest.raises(TealTypeError):
+        App.globalGetEx(Bytes("app"), Bytes("key"))
+
+    with pytest.raises(TealTypeError):
+        App.globalGetEx(Int(0), Int(1))
+
+def test_local_put():
+    expr = App.localPut(Int(0), Bytes("key"), Int(5))
+    assert expr.type_of() == TealType.none
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.int, 5),
+        TealOp(Op.app_local_put)
+    ]
+
+def test_local_put_invalid():
+    with pytest.raises(TealTypeError):
+        App.localPut(Txn.sender(), Bytes("key"), Int(5))
+    
+    with pytest.raises(TealTypeError):
+        App.localPut(Int(1), Int(0), Int(5))
+    
+    with pytest.raises(TealTypeError):
+        App.localPut(Int(1), Bytes("key"), Pop(Int(1)))
+
+def test_global_put():
+    expr = App.globalPut(Bytes("key"), Int(5))
+    assert expr.type_of() == TealType.none
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.int, 5),
+        TealOp(Op.app_global_put)
+    ]
+
+def test_global_put_invalid():
+    with pytest.raises(TealTypeError):
+        App.globalPut(Int(0), Int(5))
+    
+    with pytest.raises(TealTypeError):
+        App.globalPut(Bytes("key"), Pop(Int(1)))
+
+def test_local_del():
+    expr = App.localDel(Int(0), Bytes("key"))
+    assert expr.type_of() == TealType.none
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.app_local_del)
+    ]
+
+def test_local_del_invalid():
+    with pytest.raises(TealTypeError):
+        App.localDel(Txn.sender(), Bytes("key"))
+    
+    with pytest.raises(TealTypeError):
+        App.localDel(Int(1), Int(2))
+
+def test_global_del():
+    expr = App.globalDel(Bytes("key"))
+    assert expr.type_of() == TealType.none
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.app_global_del)
+    ]
+
+def test_global_del_invalid():
+    with pytest.raises(TealTypeError):
+        App.globalDel(Int(2))

--- a/pyteal/ast/arg.py
+++ b/pyteal/ast/arg.py
@@ -1,13 +1,17 @@
 from ..types import TealType
+from ..ir import TealOp, Op
 from ..errors import TealInputError
 from .leafexpr import LeafExpr
 
 class Arg(LeafExpr):
-    """An expression to get an argument."""
-    
-    def __init__(self, index:int) -> None:
+    """An expression to get an argument when running in signature verification mode."""
+
+    def __init__(self, index: int) -> None:
         """Get an argument for this program.
         
+        Should only be used in signature verification mode. For application mode arguments, see
+        Txn.application_args.
+
         Args:
             index: The integer index of the argument to get. Must be between 0 and 255 inclusive.
         """
@@ -20,7 +24,7 @@ class Arg(LeafExpr):
         self.index = index
 
     def __teal__(self):
-        return [["arg", str(self.index)]]
+        return [TealOp(Op.arg, self.index)]
         
     def __str__(self):
         return "(arg {})".format(self.index)

--- a/pyteal/ast/arg_test.py
+++ b/pyteal/ast/arg_test.py
@@ -4,8 +4,9 @@ from .. import *
 
 def test_arg():
     expr = Arg(0)
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["arg", "0"]
+        TealOp(Op.arg, 0)
     ]
 
 def test_arg_invalid():

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -1,0 +1,31 @@
+from ..types import TealType, require_type
+from ..ir import TealOp, Op, TealLabel
+from ..util import new_label
+from .expr import Expr
+
+class Assert(Expr):
+    """A control flow expression to verify that a condition is true."""
+
+    def __init__(self, cond: Expr) -> None:
+        """Create an assert statement that raises an error if the condition is false.
+
+        Args:
+            cond: The condition to check. Must evaluate to a uint64.
+        """
+        require_type(cond.type_of(), TealType.uint64)
+        self.cond = cond
+    
+    def __teal__(self):
+        end = new_label()
+        teal = self.cond.__teal__()
+        teal.append(TealOp(Op.bnz, end))
+        teal.append(TealOp(Op.err))
+        teal.append(TealLabel(end))
+
+        return teal
+
+    def __str__(self):
+        return "(Assert {})".format(self.cond)
+
+    def type_of(self):
+        return TealType.none

--- a/pyteal/ast/assert_test.py
+++ b/pyteal/ast/assert_test.py
@@ -1,0 +1,21 @@
+import pytest
+
+from .. import *
+
+def test_assert():
+    expr = Assert(Int(1))
+    assert expr.type_of() == TealType.none
+    teal = expr.__teal__()
+    assert len(teal) == 4
+    label = teal[3]
+    assert isinstance(label, TealLabel)
+    assert teal == [
+        TealOp(Op.int, 1),
+        TealOp(Op.bnz, label.label),
+        TealOp(Op.err),
+        label
+    ]
+
+def test_assert_invalid():
+    with pytest.raises(TealTypeError):
+        Assert(Txn.receiver())

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -1,0 +1,158 @@
+from enum import Enum
+
+from ..types import TealType, require_type
+from ..ir import TealOp, Op
+from .expr import Expr
+from .leafexpr import LeafExpr
+from .maybe import MaybeValue
+
+class AssetHolding:
+    
+    @classmethod
+    def balance(cls, account: Expr, asset: Expr):
+        """Get the amount of an asset held by an account.
+
+        Args:
+            account: An index into Txn.Accounts that corresponds to the account to check. Must
+            evaluate to uint64.
+            asset: The ID of the asset to get. Must evaluate to uint64.
+        """
+        require_type(account.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetBalance"], args=[account, asset])
+    
+    @classmethod
+    def frozen(cls, account: Expr, asset: Expr):
+        """Check if an asset is frozen for an account.
+
+        Args:
+            account: An index into Txn.Accounts that corresponds to the account to check. Must
+            evaluate to uint64.
+            asset: The ID of the asset to check. Must evaluate to uint64.
+        """
+        require_type(account.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetFrozen"], args=[account, asset])
+
+class AssetParam:
+
+    @classmethod
+    def total(cls, asset: Expr):
+        """Get the total number of units of an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetTotal"], args=[asset])
+    
+    @classmethod
+    def decimals(cls, asset: Expr):
+        """Get the number of decimals for an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDecimals"], args=[asset])
+    
+    @classmethod
+    def defaultFrozen(cls, asset: Expr):
+        """Check if an asset is frozen by default.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDefaultFrozen"], args=[asset])
+    
+    @classmethod
+    def unitName(cls, asset: Expr):
+        """Get the unit name of an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetUnitName"], args=[asset])
+    
+    @classmethod
+    def name(cls, asset: Expr):
+        """Get the name of an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetName"], args=[asset])
+    
+    @classmethod
+    def url(cls, asset: Expr):
+        """Get the URL of an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetURL"], args=[asset])
+    
+    @classmethod
+    def metadataHash(cls, asset: Expr):
+        """Get the arbitrary commitment for an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetMetadataHash"], args=[asset])
+    
+    @classmethod
+    def manager(cls, asset: Expr):
+        """Get the manager commitment for an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetManager"], args=[asset])
+    
+    @classmethod
+    def reserve(cls, asset: Expr):
+        """Get the reserve address for an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetReserve"], args=[asset])
+    
+    @classmethod
+    def freeze(cls, asset: Expr):
+        """Get the freeze address for an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetFreeze"], args=[asset])
+    
+    @classmethod
+    def clawback(cls, asset: Expr):
+        """Get the clawback address for an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+            evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetClawback"], args=[asset])

--- a/pyteal/ast/asset_test.py
+++ b/pyteal/ast/asset_test.py
@@ -1,0 +1,206 @@
+import pytest
+
+from .. import *
+
+def test_asset_holding_balance():
+    expr = AssetHolding.balance(Int(0), Int(17))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.int, 17),
+        TealOp(Op.asset_holding_get, "AssetBalance"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_holding_balance_invalid():
+    with pytest.raises(TealTypeError):
+        AssetHolding.balance(Txn.sender(), Int(17))
+    
+    with pytest.raises(TealTypeError):
+        AssetHolding.balance(Int(0), Txn.receiver())
+
+def test_asset_holding_frozen():
+    expr = AssetHolding.frozen(Int(0), Int(17))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.int, 17),
+        TealOp(Op.asset_holding_get, "AssetFrozen"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_holding_frozen_invalid():
+    with pytest.raises(TealTypeError):
+        AssetHolding.frozen(Txn.sender(), Int(17))
+    
+    with pytest.raises(TealTypeError):
+        AssetHolding.frozen(Int(0), Txn.receiver())
+
+def test_asset_param_total():
+    expr = AssetParam.total(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetTotal"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_total_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.total(Txn.sender())
+
+def test_asset_param_decimals():
+    expr = AssetParam.decimals(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetDecimals"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_decimals_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.decimals(Txn.sender())
+
+def test_asset_param_default_frozen():
+    expr = AssetParam.defaultFrozen(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetDefaultFrozen"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_default_frozen_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.defaultFrozen(Txn.sender())
+
+def test_asset_param_unit_name():
+    expr = AssetParam.unitName(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetUnitName"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_unit_name_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.unitName(Txn.sender())
+
+def test_asset_param_name():
+    expr = AssetParam.name(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetName"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_name_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.name(Txn.sender())
+
+def test_asset_param_url():
+    expr = AssetParam.url(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetURL"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_url_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.url(Txn.sender())
+
+def test_asset_param_metadata_hash():
+    expr = AssetParam.metadataHash(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetMetadataHash"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_metadata_hash_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.metadataHash(Txn.sender())
+
+def test_asset_param_manager():
+    expr = AssetParam.manager(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetManager"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_manager_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.manager(Txn.sender())
+
+def test_asset_param_reserve():
+    expr = AssetParam.reserve(Int(2))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.int, 2),
+        TealOp(Op.asset_params_get, "AssetReserve"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_reserve_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.reserve(Txn.sender())
+
+def test_asset_param_freeze():
+    expr = AssetParam.freeze(Int(0))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.asset_params_get, "AssetFreeze"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_freeze_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.freeze(Txn.sender())
+
+def test_asset_param_clawback():
+    expr = AssetParam.clawback(Int(1))
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.asset_params_get, "AssetClawback"),
+        TealOp(Op.store, expr.slotOk),
+        TealOp(Op.store, expr.slotValue)
+    ]
+
+def test_asset_param_clawback_invalid():
+    with pytest.raises(TealTypeError):
+        AssetParam.clawback(Txn.sender())

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -1,25 +1,26 @@
 from ..types import TealType, require_type
+from ..ir import TealOp, Op
 from .expr import Expr
 
 class BinaryExpr(Expr):
     """An expression with two arguments."""
 
-    def __init__(self, op: str, inputType: TealType, outputType: TealType, argLeft: Expr, argRight: Expr) -> None:
+    def __init__(self, op: Op, inputType: TealType, outputType: TealType, argLeft: Expr, argRight: Expr) -> None:
         require_type(argLeft.type_of(), inputType)
         require_type(argRight.type_of(), inputType)
         self.op = op
         self.outputType = outputType
         self.argLeft = argLeft
         self.argRight = argRight
-    
+
     def __teal__(self):
         teal = self.argLeft.__teal__() + self.argRight.__teal__()
-        teal.append([self.op])
+        teal.append(TealOp(self.op))
         return teal
-
+    
     def __str__(self):
-        return "({} {} {})".format(self.op, self.argLeft, self.argRight)
-
+        return "({} {} {})".format(self.op.value, self.argLeft, self.argRight)
+    
     def type_of(self):
         return self.outputType
 
@@ -32,7 +33,7 @@ def Add(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr("+", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.add, TealType.uint64, TealType.uint64, left, right)
 
 def Minus(left: Expr, right: Expr):
     """Subtract two numbers.
@@ -43,7 +44,7 @@ def Minus(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr("-", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.minus, TealType.uint64, TealType.uint64, left, right)
 
 def Mul(left: Expr, right: Expr):
     """Multiply two numbers.
@@ -54,7 +55,7 @@ def Mul(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr("*", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.mul, TealType.uint64, TealType.uint64, left, right)
 
 def Div(left: Expr, right: Expr):
     """Divide two numbers.
@@ -65,7 +66,7 @@ def Div(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr("/", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.div, TealType.uint64, TealType.uint64, left, right)
 
 def Mod(left: Expr, right: Expr):
     """Modulo expression.
@@ -76,7 +77,34 @@ def Mod(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr("%", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.mod, TealType.uint64, TealType.uint64, left, right)
+
+def BitwiseAnd(left: Expr, right: Expr):
+    """Bitwise and expression.
+
+    Args:
+        left: Must evaluate to uint64.
+        right: Must evaluate to uint64.
+    """
+    return BinaryExpr(Op.bitwise_and, TealType.uint64, TealType.uint64, left, right)
+
+def BitwiseOr(left: Expr, right: Expr):
+    """Bitwise or expression.
+
+    Args:
+        left: Must evaluate to uint64.
+        right: Must evaluate to uint64.
+    """
+    return BinaryExpr(Op.bitwise_or, TealType.uint64, TealType.uint64, left, right)
+
+def BitwiseXor(left: Expr, right: Expr):
+    """Bitwise xor expression.
+
+    Args:
+        left: Must evaluate to uint64.
+        right: Must evaluate to uint64.
+    """
+    return BinaryExpr(Op.bitwise_xor, TealType.uint64, TealType.uint64, left, right)
 
 def Eq(left: Expr, right: Expr):
     """Equality expression.
@@ -87,7 +115,18 @@ def Eq(left: Expr, right: Expr):
         left: A value to check.
         right: The other value to check. Must evaluate to the same type as left.
     """
-    return BinaryExpr("==", right.type_of(), TealType.uint64, left, right)
+    return BinaryExpr(Op.eq, right.type_of(), TealType.uint64, left, right)
+
+def Neq(left: Expr, right: Expr):
+    """Difference expression.
+    
+    Checks if left != right.
+
+    Args:
+        left: A value to check.
+        right: The other value to check. Must evaluate to the same type as left.
+    """
+    return BinaryExpr(Op.neq, right.type_of(), TealType.uint64, left, right)
 
 def Lt(left: Expr, right: Expr):
     """Less than expression.
@@ -98,7 +137,7 @@ def Lt(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr("<", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.lt, TealType.uint64, TealType.uint64, left, right)
 
 def Le(left: Expr, right: Expr):
     """Less than or equal to expression.
@@ -109,7 +148,7 @@ def Le(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr("<=", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.le, TealType.uint64, TealType.uint64, left, right)
 
 def Gt(left: Expr, right: Expr):
     """Greater than expression.
@@ -120,7 +159,7 @@ def Gt(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr(">", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.gt, TealType.uint64, TealType.uint64, left, right)
 
 def Ge(left: Expr, right: Expr):
     """Greater than or equal to expression.
@@ -131,4 +170,4 @@ def Ge(left: Expr, right: Expr):
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
-    return BinaryExpr(">=", TealType.uint64, TealType.uint64, left, right)
+    return BinaryExpr(Op.ge, TealType.uint64, TealType.uint64, left, right)

--- a/pyteal/ast/binaryexpr_test.py
+++ b/pyteal/ast/binaryexpr_test.py
@@ -4,20 +4,22 @@ from .. import *
 
 def test_add():
     expr = Add(Int(2), Int(3))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "2"],
-        ["int", "3"],
-        ["+"]
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.add)
     ]
 
 def test_add_overload():
     expr = Int(2) + Int(3) + Int(4)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "2"],
-        ["int", "3"],
-        ["+"],
-        ["int", "4"],
-        ["+"]
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.add),
+        TealOp(Op.int, 4),
+        TealOp(Op.add)
     ]
 
 def test_add_invalid():
@@ -29,20 +31,22 @@ def test_add_invalid():
 
 def test_minus():
     expr = Minus(Int(5), Int(6))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "5"],
-        ["int", "6"],
-        ["-"]
+        TealOp(Op.int, 5),
+        TealOp(Op.int, 6),
+        TealOp(Op.minus)
     ]
 
 def test_minus_overload():
     expr = Int(10) - Int(1) - Int(2)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "10"],
-        ["int", "1"],
-        ["-"],
-        ["int", "2"],
-        ["-"]
+        TealOp(Op.int, 10),
+        TealOp(Op.int, 1),
+        TealOp(Op.minus),
+        TealOp(Op.int, 2),
+        TealOp(Op.minus)
     ]
 
 def test_minus_invalid():
@@ -54,20 +58,22 @@ def test_minus_invalid():
 
 def test_mul():
     expr = Mul(Int(3), Int(8))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "3"],
-        ["int", "8"],
-        ["*"]
+        TealOp(Op.int, 3),
+        TealOp(Op.int, 8),
+        TealOp(Op.mul)
     ]
 
 def test_mul_overload():
     expr = Int(3) * Int(8) * Int(10)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "3"],
-        ["int", "8"],
-        ["*"],
-        ["int", "10"],
-        ["*"]
+        TealOp(Op.int, 3),
+        TealOp(Op.int, 8),
+        TealOp(Op.mul),
+        TealOp(Op.int, 10),
+        TealOp(Op.mul)
     ]
 
 def test_mul_invalid():
@@ -79,20 +85,22 @@ def test_mul_invalid():
 
 def test_div():
     expr = Div(Int(9), Int(3))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "9"],
-        ["int", "3"],
-        ["/"]
+        TealOp(Op.int, 9),
+        TealOp(Op.int, 3),
+        TealOp(Op.div)
     ]
 
 def test_div_overload():
     expr = Int(9) / Int(3) / Int(3)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "9"],
-        ["int", "3"],
-        ["/"],
-        ["int", "3"],
-        ["/"],
+        TealOp(Op.int, 9),
+        TealOp(Op.int, 3),
+        TealOp(Op.div),
+        TealOp(Op.int, 3),
+        TealOp(Op.div),
     ]
 
 def test_div_invalid():
@@ -104,20 +112,22 @@ def test_div_invalid():
 
 def test_mod():
     expr = Mod(Int(10), Int(9))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "10"],
-        ["int", "9"],
-        ["%"]
+        TealOp(Op.int, 10),
+        TealOp(Op.int, 9),
+        TealOp(Op.mod)
     ]
 
 def test_mod_overload():
     expr = Int(10) % Int(9) % Int(100)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "10"],
-        ["int", "9"],
-        ["%"],
-        ["int", "100"],
-        ["%"]
+        TealOp(Op.int, 10),
+        TealOp(Op.int, 9),
+        TealOp(Op.mod),
+        TealOp(Op.int, 100),
+        TealOp(Op.mod)
     ]
 
 def test_mod_invalid():
@@ -129,38 +139,134 @@ def test_mod_invalid():
 
 def test_arithmetic():
     v = ((Int(2) + Int(3))/((Int(5) - Int(6)) * Int(8))) % Int(9)
-    assert v.__teal__() == \
-        [['int', '2'], ['int', '3'], ['+'], ['int', '5'], ['int', '6']] + \
-        [['-'], ['int', '8'], ['*'], ['/'], ['int', '9'], ['%']]
+    assert v.type_of() == TealType.uint64
+    assert v.__teal__() == [
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.add),
+        TealOp(Op.int, 5),
+        TealOp(Op.int, 6),
+        TealOp(Op.minus),
+        TealOp(Op.int, 8),
+        TealOp(Op.mul),
+        TealOp(Op.div),
+        TealOp(Op.int, 9),
+        TealOp(Op.mod)
+    ]
+
+def test_bitwise_and():
+    expr = BitwiseAnd(Int(1), Int(2))
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.bitwise_and)
+    ]
+
+def test_bitwise_and_overload():
+    expr = Int(1) & Int(2) & Int(4)
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.bitwise_and),
+        TealOp(Op.int, 4),
+        TealOp(Op.bitwise_and)
+    ]
+
+def test_bitwise_and_invalid():
+    with pytest.raises(TealTypeError):
+        BitwiseAnd(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BitwiseAnd(Txn.sender(), Int(2))
+
+def test_bitwise_or():
+    expr = BitwiseOr(Int(1), Int(2))
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.bitwise_or)
+    ]
+
+def test_bitwise_or_overload():
+    expr = Int(1) | Int(2) | Int(4)
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.bitwise_or),
+        TealOp(Op.int, 4),
+        TealOp(Op.bitwise_or)
+    ]
+
+def test_bitwise_or_invalid():
+    with pytest.raises(TealTypeError):
+        BitwiseOr(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BitwiseOr(Txn.sender(), Int(2))
+
+def test_bitwise_xor():
+    expr = BitwiseXor(Int(1), Int(3))
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 3),
+        TealOp(Op.bitwise_xor)
+    ]
+
+def test_bitwise_xor_overload():
+    expr = Int(1) ^ Int(3) ^ Int(5)
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 3),
+        TealOp(Op.bitwise_xor),
+        TealOp(Op.int, 5),
+        TealOp(Op.bitwise_xor)
+    ]
+
+def test_bitwise_xor_invalid():
+    with pytest.raises(TealTypeError):
+        BitwiseXor(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BitwiseXor(Txn.sender(), Int(2))
 
 def test_eq():
     expr_int = Eq(Int(2), Int(3))
+    assert expr_int.type_of() == TealType.uint64
     assert expr_int.__teal__() == [
-        ["int", "2"],
-        ["int", "3"],
-        ["=="]
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.eq)
     ]
 
     expr_bytes = Eq(Txn.receiver(), Txn.sender())
+    assert expr_bytes.type_of() == TealType.uint64
     assert expr_bytes.__teal__() == [
-        ["txn", "Receiver"],
-        ["txn", "Sender"],
-        ["=="]
+        TealOp(Op.txn, "Receiver"),
+        TealOp(Op.txn, "Sender"),
+        TealOp(Op.eq)
     ]
 
 def test_eq_overload():
     expr_int = Int(2) == Int(3)
+    assert expr_int.type_of() == TealType.uint64
     assert expr_int.__teal__() == [
-        ["int", "2"],
-        ["int", "3"],
-        ["=="]
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.eq)
     ]
 
     expr_bytes = Txn.receiver() == Txn.sender()
+    assert expr_bytes.type_of() == TealType.uint64
     assert expr_bytes.__teal__() == [
-        ["txn", "Receiver"],
-        ["txn", "Sender"],
-        ["=="]
+        TealOp(Op.txn, "Receiver"),
+        TealOp(Op.txn, "Sender"),
+        TealOp(Op.eq)
     ]
 
 def test_eq_invalid():
@@ -170,20 +276,63 @@ def test_eq_invalid():
     with pytest.raises(TealTypeError):
         Eq(Txn.sender(), Int(7))
 
+def test_neq():
+    expr_int = Neq(Int(2), Int(3))
+    assert expr_int.type_of() == TealType.uint64
+    assert expr_int.__teal__() == [
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.neq)
+    ]
+
+    expr_bytes = Neq(Txn.receiver(), Txn.sender())
+    assert expr_bytes.type_of() == TealType.uint64
+    assert expr_bytes.__teal__() == [
+        TealOp(Op.txn, "Receiver"),
+        TealOp(Op.txn, "Sender"),
+        TealOp(Op.neq)
+    ]
+
+def test_neq_overload():
+    expr_int = Int(2) != Int(3)
+    assert expr_int.type_of() == TealType.uint64
+    assert expr_int.__teal__() == [
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.neq)
+    ]
+
+    expr_bytes = Txn.receiver() != Txn.sender()
+    assert expr_bytes.type_of() == TealType.uint64
+    assert expr_bytes.__teal__() == [
+        TealOp(Op.txn, "Receiver"),
+        TealOp(Op.txn, "Sender"),
+        TealOp(Op.neq)
+    ]
+
+def test_neq_invalid():
+    with pytest.raises(TealTypeError):
+        Neq(Txn.fee(), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        Neq(Txn.sender(), Int(7))
+
 def test_lt():
     expr = Lt(Int(2), Int(3))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "2"],
-        ["int", "3"],
-        ["<"]
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.lt)
     ]
 
 def test_lt_overload():
     expr = Int(2) < Int(3)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "2"],
-        ["int", "3"],
-        ["<"]
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.lt)
     ]
 
 def test_lt_invalid():
@@ -195,18 +344,20 @@ def test_lt_invalid():
 
 def test_le():
     expr = Le(Int(1), Int(2))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "2"],
-        ["<="]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.le)
     ]
 
 def test_le_overload():
     expr = Int(1) <= Int(2)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "2"],
-        ["<="]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.le)
     ]
 
 def test_le_invalid():
@@ -218,18 +369,20 @@ def test_le_invalid():
 
 def test_gt():
     expr = Gt(Int(2), Int(3))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "2"],
-        ["int", "3"],
-        [">"]
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.gt)
     ]
 
 def test_gt_overload():
     expr = Int(2) > Int(3)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "2"],
-        ["int", "3"],
-        [">"]
+        TealOp(Op.int, 2),
+        TealOp(Op.int, 3),
+        TealOp(Op.gt)
     ]
 
 def test_gt_invalid():
@@ -241,18 +394,20 @@ def test_gt_invalid():
 
 def test_ge():
     expr = Ge(Int(1), Int(10))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "10"],
-        [">="]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 10),
+        TealOp(Op.ge)
     ]
 
 def test_ge_overload():
     expr = Int(1) >= Int(10)
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "10"],
-        [">="]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 10),
+        TealOp(Op.ge)
     ]
 
 def test_ge_invalid():

--- a/pyteal/ast/bytes.py
+++ b/pyteal/ast/bytes.py
@@ -1,41 +1,57 @@
 from ..types import TealType, valid_base16, valid_base32, valid_base64
+from ..util import escapeStr
+from ..ir import TealOp, Op
 from ..errors import TealInputError
 from .leafexpr import LeafExpr
 
 class Bytes(LeafExpr):
     """An expression that represents a byte string."""
-     
-    def __init__(self, base: str, byte_str: str) -> None:
+    
+    def __init__(self, *args: str) -> None:
         """Create a new byte string.
+        
+        Depending on the encoding, there are different arguments to pass:
 
-        Args:
-            base: The base type for this byte string. Must be one of base16, base32, or base64.
-            byte_string: The content of the byte string, encoding with the passed in base.
+        For UTF-8 strings:
+            Pass the string as the only argument. For example, Bytes("content").
+        For base16, base32, or base64 strings:
+            Pass the base as the first argument and the string as the second argument. For example,
+            Bytes("base16", "636F6E74656E74"), Bytes("base32", "ORFDPQ6ARJK"),
+            Bytes("base64", "Y29udGVudA==").
+        Special case for base16:
+            The prefix "0x" may be present in a base16 byte string. For example,
+            Bytes("base16", "0x636F6E74656E74").
         """
-        if base == "base32":
-            self.base = base
-            valid_base32(byte_str)
-            self.byte_str = byte_str
-        elif base == "base64":
-            self.base = base
-            self.byte_str = byte_str
-            valid_base64(byte_str)
-        elif base == "base16":
-            self.base = base
-            if byte_str.startswith("0x"):
-                self.byte_str = byte_str[2:]
-            else:
+        if len(args) == 1:
+            self.base = "utf8"
+            self.byte_str = escapeStr(args[0])
+        elif len(args) == 2:
+            self.base, byte_str = args
+            if self.base == "base32":
+                valid_base32(byte_str)
                 self.byte_str = byte_str
-            valid_base16(self.byte_str)
+            elif self.base == "base64":
+                self.byte_str = byte_str
+                valid_base64(byte_str)
+            elif self.base == "base16":
+                if byte_str.startswith("0x"):
+                    self.byte_str = byte_str[2:]
+                else:
+                    self.byte_str = byte_str
+                valid_base16(self.byte_str)
+            else:
+                raise TealInputError("invalid base {}, need to be base32, base64, or base16.".format(self.base))
         else:
-            raise TealInputError("invalid base {}, need to be base32, base64, or base16.".format(base))
+            raise TealInputError("Only 1 or 2 arguments are expected for Bytes constructor, you provided {}".format(len(args)))
 
     def __teal__(self):
-        if self.base == "base16":
+        if self.base == "utf8":
+            payload = self.byte_str
+        elif self.base == "base16":
             payload = "0x" + self.byte_str
         else:
             payload = "{}({})".format(self.base, self.byte_str)
-        return [["byte", payload]]
+        return [TealOp(Op.byte, payload)]
 
     def __str__(self):
         return "({} bytes: {})".format(self.base, self.byte_str)

--- a/pyteal/ast/bytes_test.py
+++ b/pyteal/ast/bytes_test.py
@@ -4,44 +4,70 @@ from .. import *
 
 def test_bytes_base32():
     expr = Bytes("base32", "7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M")
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["byte", "base32(7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M)"]
+        TealOp(Op.byte, "base32(7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M)")
     ]
 
 def test_bytes_base32_empty():
     expr = Bytes("base32", "")
     assert expr.__teal__() == [
-        ["byte", "base32()"]
+        TealOp(Op.byte, "base32()")
     ]
 
 def test_bytes_base64():
     expr = Bytes("base64", "Zm9vYmE=")
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["byte", "base64(Zm9vYmE=)"]
+        TealOp(Op.byte, "base64(Zm9vYmE=)")
     ]
 
 def test_bytes_base64_empty():
     expr = Bytes("base64", "")
     assert expr.__teal__() == [
-        ["byte", "base64()"]
+        TealOp(Op.byte, "base64()")
     ]
 
 def test_bytes_base16():
     expr = Bytes("base16", "A21212EF")
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["byte", "0xA21212EF"]
+        TealOp(Op.byte, "0xA21212EF")
     ]
 
 def test_bytes_base16_prefix():
-    b16_2 = Bytes("base16", "0xA21212EF")
-    assert b16_2.__teal__() == [
-        ["byte", "0xA21212EF"]
+    expr = Bytes("base16", "0xA21212EF")
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "0xA21212EF")
     ]
 
 def test_bytes_base16_empty():
     expr = Bytes("base16", "")
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["byte", "0x"]
+        TealOp(Op.byte, "0x")
+    ]
+
+def test_bytes_utf8():
+    expr = Bytes("hello world")
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "\"hello world\"")
+    ]
+
+def test_bytes_utf8_special_chars():
+    expr = Bytes("\t \n \r\n \\ \" \' 😀")
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "\"\\t \\n \\r\\n \\\\ \\\" \' \\xf0\\x9f\\x98\\x80\"")
+    ]
+
+def test_bytes_utf8_empty():
+    expr = Bytes("")
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "\"\"")
     ]
 
 def test_bytes_invalid():

--- a/pyteal/ast/cond.py
+++ b/pyteal/ast/cond.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from ..types import TealType, require_type
+from ..ir import TealOp, Op, TealLabel
 from ..errors import TealInputError
 from ..util import new_label
 from .expr import Expr
@@ -58,28 +59,26 @@ class Cond(Expr):
             cond = arg[0]
 
             teal += cond.__teal__()
-            teal += [["bnz", l]]
+            teal.append(TealOp(Op.bnz, l))
 
             labels.append(l)
 
         # err if no conditions are met
-        teal += [["err"]]
+        teal.append(TealOp(Op.err))
 
         # end label
         labels.append(new_label())
         
         for i, arg in enumerate(self.args):
-            label = labels[i] + ":"
+            label = TealLabel(labels[i])
             branch = arg[1]
 
-            teal += [[label]]
+            teal.append(label)
             teal += branch.__teal__()
             if i + 1 != len(self.args):
-                teal += [["int", "1"], ["bnz", labels[-1]]]
-        
-        endLabel = labels[-1] + ":"
+                teal.append(TealOp(Op.b, labels[-1]))
 
-        teal += [[endLabel]]
+        teal.append(TealLabel(labels[-1]))
 
         return teal
 

--- a/pyteal/ast/cond_test.py
+++ b/pyteal/ast/cond_test.py
@@ -3,66 +3,69 @@ import pytest
 from .. import *
 
 def test_cond_one_pred():
-    teal = Cond([Int(1), Int(2)]).__teal__()
+    expr = Cond([Int(1), Int(2)])
+    assert expr.type_of() == TealType.uint64
+    teal = expr.__teal__()
     assert len(teal) == 6
-    labels = [teal[3][0], teal[5][0]]
-    assert all(label.endswith(":") for label in labels)
+    labels = [teal[3], teal[5]]
+    assert all(isinstance(label, TealLabel) for label in labels)
     assert len(labels) == len(set(labels))
     assert teal == [
-        ["int", "1"],
-        ["bnz", labels[0][:-1]],
-        ["err"],
-        [labels[0]],
-        ["int", "2"],
-        [labels[1]]
+        TealOp(Op.int, 1),
+        TealOp(Op.bnz, labels[0].label),
+        TealOp(Op.err),
+        labels[0],
+        TealOp(Op.int, 2),
+        labels[1]
     ]
 
 def test_cond_two_pred():
-    teal = Cond([Int(1), Int(2)], [Int(0), Int(3)]).__teal__()
-    assert len(teal) == 12
-    labels = [teal[5][0], teal[9][0], teal[11][0]]
-    assert all(label.endswith(":") for label in labels)
+    expr = Cond([Int(1), Bytes("one")], [Int(0), Bytes("zero")])
+    assert expr.type_of() == TealType.bytes
+    teal = expr.__teal__()
+    assert len(teal) == 11
+    labels = [teal[5], teal[8], teal[10]]
+    assert all(isinstance(label, TealLabel) for label in labels)
     assert len(labels) == len(set(labels))
     assert teal == [
-        ["int", "1"],
-        ["bnz", labels[0][:-1]],
-        ["int", "0"],
-        ["bnz", labels[1][:-1]],
-        ["err"],
-        [labels[0]],
-        ["int", "2"],
-        ["int", "1"],
-        ["bnz", labels[2][:-1]],
-        [labels[1]],
-        ["int", "3"],
-        [labels[2]]
+        TealOp(Op.int, 1),
+        TealOp(Op.bnz, labels[0].label),
+        TealOp(Op.int, 0),
+        TealOp(Op.bnz, labels[1].label),
+        TealOp(Op.err),
+        labels[0],
+        TealOp(Op.byte, "\"one\""),
+        TealOp(Op.b, labels[2].label),
+        labels[1],
+        TealOp(Op.byte, "\"zero\""),
+        labels[2]
     ]
 
 def test_cond_three_pred():
-    teal = Cond([Int(1), Int(2)], [Int(3), Int(4)], [Int(5), Int(6)]).__teal__()
-    assert len(teal) == 18
-    labels = [teal[7][0], teal[11][0], teal[15][0], teal[17][0]]
-    assert all(label.endswith(":") for label in labels)
+    expr = Cond([Int(1), Int(2)], [Int(3), Int(4)], [Int(5), Int(6)])
+    assert expr.type_of() == TealType.uint64
+    teal = expr.__teal__()
+    assert len(teal) == 16
+    labels = [teal[7], teal[10], teal[13], teal[15]]
+    assert all(isinstance(label, TealLabel) for label in labels)
     assert len(labels) == len(set(labels))
     assert teal == [
-        ["int", "1"],
-        ["bnz", labels[0][:-1]],
-        ["int", "3"],
-        ["bnz", labels[1][:-1]],
-        ["int", "5"],
-        ["bnz", labels[2][:-1]],
-        ["err"],
-        [labels[0]],
-        ["int", "2"],
-        ["int", "1"],
-        ["bnz", labels[3][:-1]],
-        [labels[1]],
-        ["int", "4"],
-        ["int", "1"],
-        ["bnz", labels[3][:-1]],
-        [labels[2]],
-        ["int", "6"],
-        [labels[3]]
+        TealOp(Op.int, 1),
+        TealOp(Op.bnz, labels[0].label),
+        TealOp(Op.int, 3),
+        TealOp(Op.bnz, labels[1].label),
+        TealOp(Op.int, 5),
+        TealOp(Op.bnz, labels[2].label),
+        TealOp(Op.err),
+        labels[0],
+        TealOp(Op.int, 2),
+        TealOp(Op.b, labels[3].label),
+        labels[1],
+        TealOp(Op.int, 4),
+        TealOp(Op.b, labels[3].label),
+        labels[2],
+        TealOp(Op.int, 6),
+        labels[3]
     ]
 
 def test_cond_invalid():

--- a/pyteal/ast/ed25519verify.py
+++ b/pyteal/ast/ed25519verify.py
@@ -1,4 +1,5 @@
 from ..types import TealType, require_type
+from ..ir import TealOp, Op
 from .expr import Expr
 
 class Ed25519Verify(Expr):
@@ -25,7 +26,7 @@ class Ed25519Verify(Expr):
         return self.data.__teal__() + \
                self.sig.__teal__() + \
                self.key.__teal__() + \
-               [["ed25519verify"]]
+               [TealOp(Op.ed25519verify)]
 
     def __str__(self):
         return "(ed25519verify {} {} {})".format(self.data, self.sig, self.key)

--- a/pyteal/ast/ed25519verify_test.py
+++ b/pyteal/ast/ed25519verify_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+from .. import *
+
+def test_ed25519verify():
+    expr = Ed25519Verify(Bytes("data"), Bytes("sig"), Bytes("key"))
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "\"data\""),
+        TealOp(Op.byte, "\"sig\""),
+        TealOp(Op.byte, "\"key\""),
+        TealOp(Op.ed25519verify)
+    ]
+
+def test_ed25519verify_invalid():
+    with pytest.raises(TealTypeError):
+        Ed25519Verify(Int(0), Bytes("sig"), Bytes("key"))
+    
+    with pytest.raises(TealTypeError):
+        Ed25519Verify(Bytes("data"), Int(0), Bytes("key"))
+    
+    with pytest.raises(TealTypeError):
+        Ed25519Verify(Bytes("data"), Bytes("sig"), Int(0))

--- a/pyteal/ast/err.py
+++ b/pyteal/ast/err.py
@@ -1,4 +1,5 @@
 from ..types import TealType
+from ..ir import TealOp, Op
 from .leafexpr import LeafExpr
 
 class Err(LeafExpr):
@@ -8,10 +9,10 @@ class Err(LeafExpr):
         pass
 
     def __teal__(self):
-        return [["err"]]
+        return [TealOp(Op.err)]
 
     def __str__(self):
         return "(err)"
 
     def type_of(self):
-        return TealType.anytype
+        return TealType.none

--- a/pyteal/ast/err_test.py
+++ b/pyteal/ast/err_test.py
@@ -1,0 +1,10 @@
+import pytest
+
+from .. import *
+
+def test_err():
+    expr = Err()
+    assert expr.type_of() == TealType.none
+    assert expr.__teal__() == [
+        TealOp(Op.err)
+    ]

--- a/pyteal/ast/expr.py
+++ b/pyteal/ast/expr.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import List
 
 from ..types import TealType
+from ..ir import TealComponent
 
 class Expr(ABC):
     """Abstract base class for PyTeal expressions."""
@@ -18,7 +19,7 @@ class Expr(ABC):
         pass
 
     @abstractmethod
-    def __teal__(self) -> List[List[str]]:
+    def __teal__(self) -> List[TealComponent]:
         """Assemble TEAL IR for this component and its arguments."""
         pass
 
@@ -42,6 +43,10 @@ class Expr(ABC):
         from .binaryexpr import Eq
         return Eq(self, other)
 
+    def __ne__(self, other):
+        from .binaryexpr import Neq
+        return Neq(self, other)
+
     def __add__(self, other):
         from .binaryexpr import Add
         return Add(self, other)
@@ -61,7 +66,23 @@ class Expr(ABC):
     def __mod__(self, other):
         from .binaryexpr import Mod
         return Mod(self, other)
-       
+
+    def __invert__(self):
+        from .unaryexpr import BitwiseNot
+        return BitwiseNot(self)
+
+    def __and__(self, other):
+        from .binaryexpr import BitwiseAnd
+        return BitwiseAnd(self, other)
+
+    def __or__(self, other):
+        from .binaryexpr import BitwiseOr
+        return BitwiseOr(self, other)
+
+    def __xor__(self, other):
+        from .binaryexpr import BitwiseXor
+        return BitwiseXor(self, other)
+
     def And(self, other: 'Expr') -> 'Expr':
         """Take the logical And of this expression and another one.
         

--- a/pyteal/ast/global_.py
+++ b/pyteal/ast/global_.py
@@ -1,45 +1,42 @@
 from enum import Enum
 
 from ..types import TealType
+from ..ir import TealOp, Op
 from .leafexpr import LeafExpr
 
 class GlobalField(Enum):
-     min_txn_fee = 0
-     min_balance = 1
-     max_txn_life = 2
-     zero_address = 3
-     group_size = 4
+    min_txn_fee = (0, "MinTxnFee", TealType.uint64)
+    min_balance = (1, "MinBalance", TealType.uint64)
+    max_txn_life = (2, "MaxTxnLife", TealType.uint64)
+    zero_address = (3, "ZeroAddress", TealType.bytes)
+    group_size = (4, "GroupSize", TealType.uint64)
+    logic_sig_version = (5, "LogicSigVersion", TealType.uint64)
+    round = (6, "Round", TealType.uint64)
+    latest_timestamp = (7, "LatestTimestamp", TealType.uint64)
+    current_app_id = (8, "CurrentApplicationID", TealType.uint64)
 
-type_of_global_field = {
-     GlobalField.min_txn_fee: TealType.uint64,
-     GlobalField.min_balance: TealType.uint64,
-     GlobalField.max_txn_life: TealType.uint64,
-     GlobalField.zero_address: TealType.bytes,
-     GlobalField.group_size: TealType.uint64
-}
-
-str_of_global_field = {
-     GlobalField.min_txn_fee: "MinTxnFee",
-     GlobalField.min_balance: "MinBalance",
-     GlobalField.max_txn_life: "MaxTxnLife",
-     GlobalField.zero_address: "ZeroAddress",
-     GlobalField.group_size: "GroupSize"
-}   
+    def __init__(self, id: int, name: str, type: TealType) -> None:
+        self.id = id
+        self.arg_name = name
+        self.ret_type = type
+    
+    def type_of(self) -> TealType:
+        return self.ret_type
 
 class Global(LeafExpr):
     """An expression that accesses a global property."""
 
-    def __init__(self, field:GlobalField) -> None:
+    def __init__(self, field: GlobalField) -> None:
         self.field = field
 
     def __teal__(self):
-        return [["global", str_of_global_field[self.field]]]
+        return [TealOp(Op.global_, self.field.arg_name)]
          
     def __str__(self):
-        return "(Global {})".format(str_of_global_field[self.field])
+        return "(Global {})".format(self.field.arg_name)
     
     def type_of(self):
-        return type_of_global_field[self.field]
+        return self.field.type_of()
 
     @classmethod
     def min_txn_fee(cls):
@@ -68,3 +65,27 @@ class Global(LeafExpr):
         This will be at least 1.
         """
         return cls(GlobalField.group_size)
+
+    @classmethod
+    def logic_sig_version(cls):
+        """Get the maximum supported TEAL version."""
+        return cls(GlobalField.logic_sig_version)
+    
+    @classmethod
+    def round(cls):
+        """Get the current round number."""
+        return cls(GlobalField.round)
+    
+    @classmethod
+    def latest_timestamp(cls):
+        """Get the latest confirmed block UNIX timestamp.
+        
+        Fails if negative."""
+        return cls(GlobalField.latest_timestamp)
+    
+    @classmethod
+    def current_application_id(cls):
+        """Get the ID of the current application executing.
+        
+        Fails if no application is executing."""
+        return cls(GlobalField.current_app_id)

--- a/pyteal/ast/global_test.py
+++ b/pyteal/ast/global_test.py
@@ -4,30 +4,63 @@ from .. import *
 
 def test_global_min_txn_fee():
     expr = Global.min_txn_fee()
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["global", "MinTxnFee"]
+        TealOp(Op.global_, "MinTxnFee")
     ]
 
 def test_global_min_balance():
     expr = Global.min_balance()
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["global", "MinBalance"]
+        TealOp(Op.global_, "MinBalance")
     ]
 
 def test_global_max_txn_life():
     expr = Global.max_txn_life()
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["global", "MaxTxnLife"]
+        TealOp(Op.global_, "MaxTxnLife")
     ]
 
 def test_global_zero_address():
     expr = Global.zero_address()
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["global", "ZeroAddress"]
+        TealOp(Op.global_, "ZeroAddress")
     ]
 
 def test_global_group_size():
     expr = Global.group_size()
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["global", "GroupSize"]
+        TealOp(Op.global_, "GroupSize")
+    ]
+
+def test_global_logic_sig_version():
+    expr = Global.logic_sig_version()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.global_, "LogicSigVersion")
+    ]
+
+def test_global_round():
+    expr = Global.round()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.global_, "Round")
+    ]
+
+def test_global_latest_timestamp():
+    expr = Global.latest_timestamp()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.global_, "LatestTimestamp")
+    ]
+
+def test_global_current_application_id():
+    expr = Global.current_application_id()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.global_, "CurrentApplicationID")
     ]

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -1,27 +1,51 @@
 from ..types import TealType, require_type
-from ..errors import TealInputError
+from ..ir import TealOp, Op
+from ..errors import TealInputError, TealTypeError
 from ..config import MAX_GROUP_SIZE
 from .leafexpr import LeafExpr
-from .txn import TxnField, str_of_field, type_of_field
+from .txn import TxnField
+
+class Gtxna(LeafExpr):
+    """An expression that accesses a transaction array field from a transaction in the current group."""
+
+    def __init__(self, txIndex: int, field: TxnField, index: int) -> None:
+        if type(index) != int:
+            raise TealTypeError(type(index), int)
+        if index < 0 or index >= MAX_GROUP_SIZE:
+            raise TealInputError("invalid Gtxn index {}, shoud [0, {})".format(index, MAX_GROUP_SIZE))
+        self.txIndex = txIndex
+        self.field = field
+        self.index = index
+    
+    def __str__(self):
+        return "(Gxna {} {} {})".format(self.txIndex, self.field.arg_name, self.index)
+    
+    def __teal__(self):
+        return [TealOp(Op.gtxna, self.txIndex, self.field.arg_name, self.index)]
+    
+    def type_of(self):
+        return self.field.type_of()
 
 class Gtxn(LeafExpr):
     """An expression that accesses a transaction field from a transaction in the current group."""
 
     def __init__(self, index:int, field:TxnField) -> None:
-        require_type(type(index), int)
-        if index < 0 or index >= MAX_GROUP_SIZE :
-            raise TealInputError("invalid Gtxn index {}, shoud [0, {})".format(
-                 index, MAX_GROUP_SIZE))
+        if type(index) != int:
+            raise TealTypeError(type(index), int)
+        if index < 0 or index >= MAX_GROUP_SIZE:
+            raise TealInputError("invalid Gtxn index {}, shoud [0, {})".format(index, MAX_GROUP_SIZE))
         self.index = index
         self.field = field
 
     def __str__(self):
-        return "(Gtxn {} {})".format(self.index, str_of_field[self.field])
+        return "(Gtxn {} {})".format(self.index, self.field.arg_name)
 
     def __teal__(self):
-        return [["gtxn", str(self.index), str_of_field[self.field]]]
-   
-    # a series of class methods for better programmer experience
+        return [TealOp(Op.gtxn, self.index, self.field.arg_name)]
+    
+    def type_of(self):
+        return self.field.type_of()
+
     @classmethod
     def sender(cls, index):
         return cls(index, TxnField.sender)
@@ -113,6 +137,113 @@ class Gtxn(LeafExpr):
     @classmethod
     def tx_id(cls, index):
         return cls(index, TxnField.tx_id)
-   
-    def type_of(self):
-        return type_of_field[self.field]
+
+    @classmethod
+    def application_id(cls, index):
+        return cls(index, TxnField.application_id)
+
+    @classmethod
+    def on_completion(cls, index):
+        return cls(index, TxnField.on_completion)
+
+    @classmethod
+    def approval_program(cls, index):
+        return cls(index, TxnField.approval_program)
+    
+    @classmethod
+    def clear_state_program(cls, index):
+        return cls(index, TxnField.clear_state_program)
+    
+    @classmethod
+    def rekey_to(cls, index):
+        return cls(index, TxnField.rekey_to)
+    
+    @classmethod
+    def config_asset(cls, index):
+        return cls(index, TxnField.config_asset)
+    
+    @classmethod
+    def config_asset_total(cls, index):
+        return cls(index, TxnField.config_asset_total)
+
+    @classmethod
+    def config_asset_decimals(cls, index):
+        return cls(index, TxnField.config_asset_decimals)
+    
+    @classmethod
+    def config_asset_default_frozen(cls, index):
+        return cls(index, TxnField.config_asset_default_frozen)
+    
+    @classmethod
+    def config_asset_unit_name(cls, index):
+        return cls(index, TxnField.config_asset_unit_name)
+
+    @classmethod
+    def config_asset_name(cls, index):
+        return cls(index, TxnField.config_asset_name)
+    
+    @classmethod
+    def config_asset_url(cls, index):
+        return cls(index, TxnField.config_asset_url)
+    
+    @classmethod
+    def config_asset_metadata_hash(cls, index):
+        return cls(index, TxnField.config_asset_metadata_hash)
+    
+    @classmethod
+    def config_asset_manager(cls, index):
+        return cls(index, TxnField.config_asset_manager)
+    
+    @classmethod
+    def config_asset_reserve(cls, index):
+        return cls(index, TxnField.config_asset_reserve)
+    
+    @classmethod
+    def config_asset_freeze(cls, index):
+        return cls(index, TxnField.config_asset_freeze)
+    
+    @classmethod
+    def config_asset_clawback(cls, index):
+        return cls(index, TxnField.config_asset_clawback)
+    
+    @classmethod
+    def freeze_asset(cls, index):
+        return cls(index, TxnField.freeze_asset)
+    
+    @classmethod
+    def freeze_asset_account(cls, index):
+        return cls(index, TxnField.freeze_asset_account)
+    
+    @classmethod
+    def freeze_asset_frozen(cls, index):
+        return cls(index, TxnField.freeze_asset_frozen)
+    
+    class ArrayAccessor:
+
+        def __init__(self, txIndex: int, accessField: TxnField, lengthField: TxnField) -> None:
+            self.txIndex = txIndex
+            self.accessField = accessField
+            self.lengthField = lengthField
+        
+        def length(self):
+            """Get the length of this array."""
+            return Gtxn(self.txIndex, self.lengthField)
+        
+        def __getitem__(self, index: int):
+            """Get the value at an index in this array.
+            
+            Args:
+                index: Must not be negative.
+            """
+            if not isinstance(index, int) or index < 0:
+                raise TealInputError("Invalid array index: {}".format(index))
+
+            return Gtxna(self.txIndex, self.accessField, index)
+
+    @classmethod
+    def application_args(cls, index: int):
+        return cls.ArrayAccessor(index, TxnField.application_args, TxnField.num_app_args)
+
+    @classmethod
+    def accounts(cls, index: int):
+        return cls.ArrayAccessor(index, TxnField.accounts, TxnField.num_accounts)

--- a/pyteal/ast/gtxn_test.py
+++ b/pyteal/ast/gtxn_test.py
@@ -14,146 +14,378 @@ def test_gtxn_invalid():
 def test_gtxn_sender():
     for i in GTXN_RANGE:
         expr = Gtxn.sender(i)
+        assert expr.type_of() == TealType.bytes
         assert expr.__teal__() == [
-            ["gtxn", str(i), "Sender"]
+            TealOp(Op.gtxn, i, "Sender")
         ]
 
 def test_gtxn_fee():
     for i in GTXN_RANGE:
         expr = Gtxn.fee(i)
+        assert expr.type_of() == TealType.uint64
         assert expr.__teal__() == [
-            ["gtxn", str(i), "Fee"]
+            TealOp(Op.gtxn, i, "Fee")
         ]
 
 def test_gtxn_first_valid():
     for i in GTXN_RANGE:
         expr = Gtxn.first_valid(i)
+        assert expr.type_of() == TealType.uint64
         assert expr.__teal__() == [
-            ["gtxn", str(i), "FirstValid"]
+            TealOp(Op.gtxn, i, "FirstValid")
         ]
 
 def test_gtxn_last_valid():
     for i in GTXN_RANGE:
         expr = Gtxn.last_valid(i)
+        assert expr.type_of() == TealType.uint64
         assert expr.__teal__() == [
-            ["gtxn", str(i), "LastValid"]
+            TealOp(Op.gtxn, i, "LastValid")
         ]
 
 def test_gtxn_note():
     for i in GTXN_RANGE:
         expr = Gtxn.note(i)
+        assert expr.type_of() == TealType.bytes
         assert expr.__teal__() == [
-            ["gtxn", str(i), "Note"]
-        ]
-
-def test_gtxn_receiver():
-    for i in GTXN_RANGE:
-        expr = Gtxn.receiver(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "Receiver"]
-        ]
-
-def test_gtxn_amount():
-    for i in GTXN_RANGE:
-        expr = Gtxn.amount(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "Amount"]
-        ]
-
-def test_gtxn_close_remainder_to():
-    for i in GTXN_RANGE:
-        expr = Gtxn.close_remainder_to(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "CloseRemainderTo"]
-        ]
-
-def test_gtxn_vote_pk():
-    for i in GTXN_RANGE:
-        expr = Gtxn.vote_pk(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "VotePK"]
-        ]
-
-def test_gtxn_selection_pk():
-    for i in GTXN_RANGE:
-        expr = Gtxn.selection_pk(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "SelectionPK"]
-        ]
-
-def test_gtxn_vote_first():
-    for i in GTXN_RANGE:
-        expr = Gtxn.vote_first(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "VoteFirst"]
-        ]
-
-def test_gtxn_vote_last():
-    for i in GTXN_RANGE:
-        expr = Gtxn.vote_last(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "VoteLast"]
-        ]
-
-def test_gtxn_vote_key_dilution():
-    for i in GTXN_RANGE:
-        expr = Gtxn.vote_key_dilution(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "VoteKeyDilution"]
-        ]
-
-def test_gtxn_type():
-    for i in GTXN_RANGE:
-        expr = Gtxn.type(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "Type"]
-        ]
-
-def test_gtxn_type_enum():
-    for i in GTXN_RANGE:
-        expr = Gtxn.type_enum(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "TypeEnum"]
-        ]
-
-def test_gtxn_xfer_asset():
-    for i in GTXN_RANGE:
-        expr = Gtxn.xfer_asset(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "XferAsset"]
-        ]
-
-def test_gtxn_asset_amount():
-    for i in GTXN_RANGE:
-        expr = Gtxn.asset_amount(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "AssetAmount"]
-        ]
-
-def test_gtxn_asset_close_to():
-    for i in GTXN_RANGE:
-        expr = Gtxn.asset_close_to(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "AssetCloseTo"]
-        ]
-
-def test_gtxn_group_index():
-    for i in GTXN_RANGE:
-        expr = Gtxn.group_index(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "GroupIndex"]
-        ]
-
-def test_gtxn_id():
-    for i in GTXN_RANGE:
-        expr = Gtxn.tx_id(i)
-        assert expr.__teal__() == [
-            ["gtxn", str(i), "TxID"]
+            TealOp(Op.gtxn, i, "Note")
         ]
 
 def test_gtxn_lease():
     for i in GTXN_RANGE:
         expr = Gtxn.lease(i)
+        assert expr.type_of() == TealType.bytes
         assert expr.__teal__() == [
-            ["gtxn", str(i), "Lease"]
+            TealOp(Op.gtxn, i, "Lease")
         ]
+
+def test_gtxn_receiver():
+    for i in GTXN_RANGE:
+        expr = Gtxn.receiver(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "Receiver")
+        ]
+
+def test_gtxn_amount():
+    for i in GTXN_RANGE:
+        expr = Gtxn.amount(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "Amount")
+        ]
+
+def test_gtxn_close_remainder_to():
+    for i in GTXN_RANGE:
+        expr = Gtxn.close_remainder_to(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "CloseRemainderTo")
+        ]
+
+def test_gtxn_vote_pk():
+    for i in GTXN_RANGE:
+        expr = Gtxn.vote_pk(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "VotePK")
+        ]
+
+def test_gtxn_selection_pk():
+    for i in GTXN_RANGE:
+        expr = Gtxn.selection_pk(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "SelectionPK")
+        ]
+
+def test_gtxn_vote_first():
+    for i in GTXN_RANGE:
+        expr = Gtxn.vote_first(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "VoteFirst")
+        ]
+
+def test_gtxn_vote_last():
+    for i in GTXN_RANGE:
+        expr = Gtxn.vote_last(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "VoteLast")
+        ]
+
+def test_gtxn_vote_key_dilution():
+    for i in GTXN_RANGE:
+        expr = Gtxn.vote_key_dilution(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "VoteKeyDilution")
+        ]
+
+def test_gtxn_type():
+    for i in GTXN_RANGE:
+        expr = Gtxn.type(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "Type")
+        ]
+
+def test_gtxn_type_enum():
+    for i in GTXN_RANGE:
+        expr = Gtxn.type_enum(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "TypeEnum")
+        ]
+
+def test_gtxn_xfer_asset():
+    for i in GTXN_RANGE:
+        expr = Gtxn.xfer_asset(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "XferAsset")
+        ]
+
+def test_gtxn_asset_amount():
+    for i in GTXN_RANGE:
+        expr = Gtxn.asset_amount(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "AssetAmount")
+        ]
+
+def test_gtxn_asset_sender():
+    for i in GTXN_RANGE:
+        expr = Gtxn.asset_sender(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "AssetSender")
+        ]
+
+def test_gtxn_asset_receiver():
+    for i in GTXN_RANGE:
+        expr = Gtxn.asset_receiver(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "AssetReceiver")
+        ]
+
+def test_gtxn_asset_close_to():
+    for i in GTXN_RANGE:
+        expr = Gtxn.asset_close_to(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "AssetCloseTo")
+        ]
+
+def test_gtxn_group_index():
+    for i in GTXN_RANGE:
+        expr = Gtxn.group_index(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "GroupIndex")
+        ]
+
+def test_gtxn_id():
+    for i in GTXN_RANGE:
+        expr = Gtxn.tx_id(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "TxID")
+        ]
+
+def test_txn_application_id():
+    for i in GTXN_RANGE:
+        expr = Gtxn.application_id(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ApplicationID")
+        ]
+
+def test_txn_on_completion():
+    for i in GTXN_RANGE:
+        expr = Gtxn.on_completion(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "OnCompletion")
+        ]
+
+def test_txn_application_args():
+    for i in GTXN_RANGE:
+        for j in range(4):
+            expr = Gtxn.application_args(i)[j]
+            assert expr.type_of() == TealType.bytes
+            assert expr.__teal__() == [
+                TealOp(Op.gtxna, i, "ApplicationArgs", j)
+            ]
+
+def test_txn_application_args_length():
+    for i in GTXN_RANGE:
+        expr = Gtxn.application_args(i).length()
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "NumAppArgs")
+        ]
+
+def test_txn_accounts():
+    for i in GTXN_RANGE:
+        for j in range(4):
+            expr = Gtxn.accounts(i)[j]
+            assert expr.type_of() == TealType.bytes
+            assert expr.__teal__() == [
+                TealOp(Op.gtxna, i, "Accounts", j)
+            ]
+
+def test_txn_accounts_length():
+    for i in GTXN_RANGE:
+        expr = Gtxn.accounts(i).length()
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "NumAccounts")
+        ]
+
+def test_txn_approval_program():
+    for i in GTXN_RANGE:
+        expr = Gtxn.approval_program(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ApprovalProgram")
+        ]
+
+def test_txn_clear_state_program():
+    for i in GTXN_RANGE:
+        expr = Gtxn.clear_state_program(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ClearStateProgram")
+        ]
+
+def test_txn_rekey_to():
+    for i in GTXN_RANGE:
+        expr = Gtxn.rekey_to(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "RekeyTo")
+        ]
+
+def test_txn_config_asset():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAsset")
+        ]
+
+def test_txn_config_asset_total():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_total(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetTotal")
+        ]
+
+def test_txn_config_asset_decimals():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_decimals(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetDecimals")
+        ]
+
+def test_txn_config_asset_default_frozen():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_default_frozen(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetDefaultFrozen")
+        ]
+
+def test_txn_config_asset_unit_name():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_unit_name(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetUnitName")
+        ]
+
+def test_txn_config_asset_name():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_name(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetName")
+        ]
+
+def test_txn_config_asset_url():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_url(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetURL")
+        ]
+
+def test_txn_config_asset_metadata_hash():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_metadata_hash(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetMetadataHash")
+        ]
+
+def test_txn_config_asset_manager():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_manager(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetManager")
+        ]
+
+def test_txn_config_asset_reserve():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_reserve(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetReserve")
+        ]
+
+def test_txn_config_asset_freeze():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_freeze(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetFreeze")
+        ]
+
+def test_txn_config_asset_clawback():
+    for i in GTXN_RANGE:
+        expr = Gtxn.config_asset_clawback(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "ConfigAssetClawback")
+        ]
+
+def test_txn_freeze_asset():
+    for i in GTXN_RANGE:
+        expr = Gtxn.freeze_asset(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "FreezeAsset")
+        ]
+
+def test_txn_freeze_asset_account():
+    for i in GTXN_RANGE:
+        expr = Gtxn.freeze_asset_account(i)
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "FreezeAssetAccount")
+        ]
+
+def test_txn_freeze_asset_frozen():
+    for i in GTXN_RANGE:
+        expr = Gtxn.freeze_asset_frozen(i)
+        assert expr.type_of() == TealType.uint64
+        assert expr.__teal__() == [
+            TealOp(Op.gtxn, i, "FreezeAssetFrozen")
+        ]
+

--- a/pyteal/ast/if_test.py
+++ b/pyteal/ast/if_test.py
@@ -3,39 +3,39 @@ import pytest
 from .. import *
 
 def test_if_int():
-    teal = If(Int(0), Int(1), Int(2)).__teal__()
-    assert len(teal) == 9
-    labels = [teal[6][0], teal[8][0]]
-    assert all(label.endswith(":") for label in labels)
+    expr = If(Int(0), Int(1), Int(2))
+    assert expr.type_of() == TealType.uint64
+    teal = expr.__teal__()
+    assert len(teal) == 7
+    labels = [teal[4], teal[6]]
+    assert all(isinstance(label, TealLabel) for label in labels)
     assert len(labels) == len(set(labels))
     assert teal == [
-        ["int", "0"],
-        ["bnz", labels[0][:-1]],
-        ["int", "2"],
-        ["int", "1"],
-        ["bnz", labels[1][:-1]],
-        ["pop"],
-        [labels[0]],
-        ["int", "1"],
-        [labels[1]]
+        TealOp(Op.int, 0),
+        TealOp(Op.bnz, labels[0].label),
+        TealOp(Op.int, 2),
+        TealOp(Op.b, labels[1].label),
+        labels[0],
+        TealOp(Op.int, 1),
+        labels[1]
     ]
 
 def test_if_bytes():
-    teal = If(Int(0), Txn.sender(), Txn.receiver()).__teal__()
-    assert len(teal) == 9
-    labels = [teal[6][0], teal[8][0]]
-    assert all(label.endswith(":") for label in labels)
+    expr = If(Int(0), Txn.sender(), Txn.receiver())
+    assert expr.type_of() == TealType.bytes
+    teal = expr.__teal__()
+    assert len(teal) == 7
+    labels = [teal[4], teal[6]]
+    assert all(isinstance(label, TealLabel) for label in labels)
     assert len(labels) == len(set(labels))
     assert teal == [
-        ["int", "0"],
-        ["bnz", labels[0][:-1]],
-        ["txn", "Receiver"],
-        ["int", "1"],
-        ["bnz", labels[1][:-1]],
-        ["pop"],
-        [labels[0]],
-        ["txn", "Sender"],
-        [labels[1]]
+        TealOp(Op.int, 0),
+        TealOp(Op.bnz, labels[0].label),
+        TealOp(Op.txn, "Receiver"),
+        TealOp(Op.b, labels[1].label),
+        labels[0],
+        TealOp(Op.txn, "Sender"),
+        labels[1]
     ]
 
 def test_if_invalid():

--- a/pyteal/ast/int.py
+++ b/pyteal/ast/int.py
@@ -1,10 +1,13 @@
+from typing import Union
+
 from ..types import TealType
+from ..ir import TealOp, Op
 from ..errors import TealInputError
 from .leafexpr import LeafExpr
 
 class Int(LeafExpr):
     """An expression that represents a uint64."""
-     
+
     def __init__(self, value: int) -> None:
         """Create a new uint64.
 
@@ -20,10 +23,30 @@ class Int(LeafExpr):
             raise TealInputError("Int {} is out of range".format(value))
 
     def __teal__(self):
-        return [["int", str(self.value)]]
-       
+        return [TealOp(Op.int, self.value)]
+
     def __str__(self):
         return "(Int: {})".format(self.value)
+
+    def type_of(self):
+        return TealType.uint64
+
+class EnumInt(LeafExpr):
+    """An expression that represents uint64 enum values."""
+
+    def __init__(self, name: str) -> None:
+        """Create an expression to reference a uint64 enum value.
+        
+        Args:
+            name: The name of the enum value.
+        """
+        self.name = name
+
+    def __teal__(self):
+        return [TealOp(Op.int, self.name)]
+       
+    def __str__(self):
+        return "(IntEnum: {})".format(self.name)
 
     def type_of(self):
         return TealType.uint64

--- a/pyteal/ast/int_test.py
+++ b/pyteal/ast/int_test.py
@@ -7,8 +7,9 @@ def test_int():
 
     for value in values:
         expr = Int(value)
+        assert expr.type_of() == TealType.uint64
         assert expr.__teal__() == [
-            ["int", str(value)]
+            TealOp(Op.int, value)
         ]
 
 def test_int_invalid():
@@ -23,3 +24,10 @@ def test_int_invalid():
     
     with pytest.raises(TealInputError):
         Int("0")
+
+def test_enum_int():
+    expr = EnumInt("OptIn")
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, "OptIn")
+    ]

--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -1,0 +1,80 @@
+from typing import List, Union
+
+from ..types import TealType
+from ..ir import TealOp, Op
+from .expr import Expr
+from .leafexpr import LeafExpr
+from .scratch import ScratchSlot, ScratchLoad
+
+class MaybeValue(LeafExpr):
+    """Represents a get operation returning a value that may not exist."""
+
+    def __init__(self, op: Op, type: TealType, *, immediate_args: List[Union[int, str]] = None, args: List[Expr] = None):
+        """Create a new MaybeValue.
+
+        Args:
+            op: The operation that returns values.
+            type: The type of the returned value.
+            immediate_args (optional): Immediate arguments for the op. Defaults to None.
+            args (optional): Stack arguments for the op. Defaults to None.
+        """
+        self.op = op
+        self.type = type
+        if immediate_args != None:
+            self.immediate_args = immediate_args
+        else:
+            self.immediate_args = []
+        if args != None:
+            self.args = args
+        else:
+            self.args = []
+        self.slotOk = ScratchSlot()
+        self.slotValue = ScratchSlot()
+    
+    def hasValue(self) -> ScratchLoad:
+        """Check if the value exists.
+
+        This will return 1 if the value exists, otherwise 0.
+        """
+        return self.slotOk.load(TealType.uint64)
+    
+    def value(self) -> ScratchLoad:
+        """Get the value.
+
+        If the value exists, it will be returned. Otherwise, the zero value for this type will be
+        returned (i.e. either 0 or an empty byte string, depending on the type).
+        """
+        return self.slotValue.load(self.type)
+    
+    def __str__(self):
+        ret_str = "(({}".format(self.op)
+        for a in self.immediate_args:
+            ret_str += " " + a.__str__()
+
+        for a in self.args:
+            ret_str += " " + a.__str__()
+        ret_str += ") "
+
+        storeOk = self.slotOk.store()
+        storeValue = self.slotValue.store()
+
+        ret_str += storeOk.__str__() + " " + storeValue.__str__() + ")"
+
+        return ret_str
+    
+    def __teal__(self):
+        teal = []
+        for arg in self.args:
+            teal += arg.__teal__()
+        teal.append(TealOp(self.op, *self.immediate_args))
+
+        storeOk = self.slotOk.store()
+        storeValue = self.slotValue.store()
+
+        teal += storeOk.__teal__()
+        teal += storeValue.__teal__()
+
+        return teal
+
+    def type_of(self):
+        return TealType.none

--- a/pyteal/ast/maybe_test.py
+++ b/pyteal/ast/maybe_test.py
@@ -1,0 +1,30 @@
+import pytest
+
+from .. import *
+
+def test_maybe_value():
+    ops = (Op.app_global_get_ex, Op.app_local_get_ex, Op.asset_holding_get, Op.asset_params_get)
+    types = (TealType.uint64, TealType.bytes, TealType.anytype)
+    immedate_argv = ([], ["AssetFrozen"])
+    argv = ([], [Int(0)], [Int(1), Int(2)])
+    
+    for op in ops:
+        for type in types:
+            for iargs in immedate_argv:
+                for args in argv:
+                    expr = MaybeValue(op, type, immediate_args=iargs, args=args)
+
+                    assert expr.slotOk != expr.slotValue
+
+                    assert expr.hasValue().type_of() == TealType.uint64
+                    assert expr.hasValue().__teal__() == ScratchLoad(expr.slotOk).__teal__()
+                    
+                    assert expr.value().type_of() == type
+                    assert expr.value().__teal__() == ScratchLoad(expr.slotValue).__teal__()
+
+                    assert expr.type_of() == TealType.none
+                    assert expr.__teal__() == sum([arg.__teal__() for arg in args], []) + [
+                        TealOp(op, *iargs),
+                        TealOp(Op.store, expr.slotOk),
+                        TealOp(Op.store, expr.slotValue)
+                    ]

--- a/pyteal/ast/naryexpr.py
+++ b/pyteal/ast/naryexpr.py
@@ -2,6 +2,7 @@ from typing import Sequence
 
 from ..types import TealType, require_type
 from ..errors import TealInputError
+from ..ir import TealOp, Op
 from .expr import Expr
 
 class NaryExpr(Expr):
@@ -9,29 +10,28 @@ class NaryExpr(Expr):
     
     This type of expression takes an arbitrary number of arguments.
     """
-    
-    def __init__(self, op: str, inputType: TealType, outputType: TealType, args: Sequence[Expr]):
+
+    def __init__(self, op: Op, inputType: TealType, outputType: TealType, args: Sequence[Expr]):
         if len(args) < 2:
             raise TealInputError("NaryExpr requires at least two children.")
         for arg in args:
             if not isinstance(arg, Expr):
                 raise TealInputError("Argument is not a pyteal expression: {}".format(arg))
             require_type(arg.type_of(), inputType)
-
         self.op = op
         self.outputType = outputType
         self.args = args
-    
+
     def __teal__(self):
         code = []
         for i, a in enumerate(self.args):
             code += a.__teal__()
             if i != 0:
-                code.append([self.op])
+                code.append(TealOp(self.op))
         return code
 
     def __str__(self):
-        ret_str = "(" + self.op,
+        ret_str = "(" + self.op.value,
         for a in self.args:
             ret_str += " " + a.__str__()
         ret_str += ")"
@@ -44,18 +44,29 @@ def And(*args: Expr):
     """Logical and expression.
 
     Produces 1 if all arguments are nonzero. Otherwise produces 0.
-    
+
     All arguments must be PyTeal expressions that evaluate to uint64, and there must be at least two
     arguments.
     """
-    return NaryExpr("&&", TealType.uint64, TealType.uint64, args)
+    return NaryExpr(Op.logic_and, TealType.uint64, TealType.uint64, args)
 
 def Or(*args: Expr):
     """Logical or expression.
-    
+
     Produces 1 if any argument is nonzero. Otherwise produces 0.
-    
+
     All arguments must be PyTeal expressions that evaluate to uint64, and there must be at least two
     arguments.
     """
-    return NaryExpr("||", TealType.uint64, TealType.uint64, args)
+    return NaryExpr(Op.logic_or, TealType.uint64, TealType.uint64, args)
+
+def Concat(*args: Expr):
+    """Concatenate byte strings.
+    
+    Produces a new byte string consisting of the contents of each of the passed in byte strings
+    joined together.
+
+    All arguments must be PyTeal expressions that evaluate to bytes, and there must be at least two
+    arguments.
+    """
+    return NaryExpr(Op.concat, TealType.bytes, TealType.bytes, args)

--- a/pyteal/ast/naryexpr_test.py
+++ b/pyteal/ast/naryexpr_test.py
@@ -4,28 +4,31 @@ from .. import *
 
 def test_and_two():
     expr = And(Int(1), Int(2))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "2"],
-        ["&&"]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.logic_and)
     ]
 
 def test_and_three():
     expr = And(Int(1), Int(2), Int(3))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "2"],
-        ["&&"],
-        ["int", "3"],
-        ["&&"]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.logic_and),
+        TealOp(Op.int, 3),
+        TealOp(Op.logic_and)
     ]
 
 def test_and_overload():
     expr = Int(1).And(Int(2))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "2"],
-        ["&&"]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 2),
+        TealOp(Op.logic_and)
     ]
 
 def test_and_invalid():
@@ -46,28 +49,31 @@ def test_and_invalid():
 
 def test_or_two():
     expr = Or(Int(1), Int(0))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "0"],
-        ["||"]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 0),
+        TealOp(Op.logic_or)
     ]
 
 def test_or_three():
     expr = Or(Int(0), Int(1), Int(2))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "0"],
-        ["int", "1"],
-        ["||"],
-        ["int", "2"],
-        ["||"]
+        TealOp(Op.int, 0),
+        TealOp(Op.int, 1),
+        TealOp(Op.logic_or),
+        TealOp(Op.int, 2),
+        TealOp(Op.logic_or)
     ]
 
 def test_or_overload():
     expr = Int(1).Or(Int(0))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["int", "0"],
-        ["||"]
+        TealOp(Op.int, 1),
+        TealOp(Op.int, 0),
+        TealOp(Op.logic_or)
     ]
 
 def test_or_invalid():

--- a/pyteal/ast/nonce.py
+++ b/pyteal/ast/nonce.py
@@ -1,27 +1,40 @@
+from ..errors import TealInputError
 from .expr import Expr
+from ..ir import TealOp, Op
+from .seq import Seq
 from .bytes import Bytes
+from .unaryexpr import Pop
 
 class Nonce(Expr):
     """A meta expression only used to change the hash of a TEAL program."""
 
     def __init__(self, base: str, nonce: str, child: Expr) -> None:
         """Create a new Nonce.
-        
+
         The Nonce expression behaves exactly like the child expression passed into it, except it
         uses the provided nonce string to alter its structure in a way that does not affect
         execution.
-        
+
         Args:
-            base: The base of the nonce. Must be one of base16, base32, or base64.
-            nonce: An arbitrary nonce string.
+            base: The base of the nonce. Must be one of utf8, base16, base32, or base64.
+            nonce: An arbitrary nonce string that conforms to base.
             child: The expression to wrap.
         """
+        if base not in ("utf8", "base16", "base32", "base64"):
+            raise TealInputError("Invalid base: {}".format(base))
+
         self.child = child
-        self.nonce_bytes = Bytes(base, nonce)
+        if base == "utf8":
+            self.nonce_bytes = Bytes(nonce)
+        else:
+            self.nonce_bytes = Bytes(base, nonce)
 
     def __teal__(self):
-        return self.nonce_bytes.__teal__() + [["pop"]] + self.child.__teal__()
-        
+        return Seq([
+            Pop(self.nonce_bytes),
+            self.child
+        ]).__teal__()
+
     def __str__(self):
         return "(nonce: {}) {}".format(self.nonce_bytes.__str__(), self.child.__str__())
 

--- a/pyteal/ast/nonce_test.py
+++ b/pyteal/ast/nonce_test.py
@@ -4,58 +4,63 @@ from .. import *
 
 def test_nonce_base32():
     expr = Nonce("base32", "7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M", Int(1))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["byte", "base32(7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M)"],
-        ["pop"],
-        ["int", "1"]
+        TealOp(Op.byte, "base32(7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M)"),
+        TealOp(Op.pop),
+        TealOp(Op.int, 1)
     ]
 
 def test_nonce_base32_empty():
     expr = Nonce("base32", "", Int(1))
     assert expr.__teal__() == [
-        ["byte", "base32()"],
-        ["pop"],
-        ["int", "1"]
+        TealOp(Op.byte, "base32()"),
+        TealOp(Op.pop),
+        TealOp(Op.int, 1)
     ]
 
 def test_nonce_base64():
-    expr = Nonce("base64", "Zm9vYmE=", Int(1))
+    expr = Nonce("base64", "Zm9vYmE=", Txn.sender())
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["byte", "base64(Zm9vYmE=)"],
-        ["pop"],
-        ["int", "1"]
+        TealOp(Op.byte, "base64(Zm9vYmE=)"),
+        TealOp(Op.pop),
+        TealOp(Op.txn, "Sender")
     ]
 
 def test_nonce_base64_empty():
     expr = Nonce("base64", "", Int(1))
     assert expr.__teal__() == [
-        ["byte", "base64()"],
-        ["pop"],
-        ["int", "1"]
+        TealOp(Op.byte, "base64()"),
+        TealOp(Op.pop),
+        TealOp(Op.int, 1)
     ]
 
 def test_nonce_base16():
     expr = Nonce("base16", "A21212EF", Int(1))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["byte", "0xA21212EF"],
-        ["pop"],
-        ["int", "1"]
+        TealOp(Op.byte, "0xA21212EF"),
+        TealOp(Op.pop),
+        TealOp(Op.int, 1)
     ]
 
 def test_nonce_base16_prefix():
     expr = Nonce("base16", "0xA21212EF", Int(1))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["byte", "0xA21212EF"],
-        ["pop"],
-        ["int", "1"]
+        TealOp(Op.byte, "0xA21212EF"),
+        TealOp(Op.pop),
+        TealOp(Op.int, 1)
     ]
 
 def test_nonce_base16_empty():
-    expr = Nonce("base16", "", Int(1))
+    expr = Nonce("base16", "", Int(6))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["byte", "0x"],
-        ["pop"],
-        ["int", "1"]
+        TealOp(Op.byte, "0x"),
+        TealOp(Op.pop),
+        TealOp(Op.int, 6)
     ]
 
 def test_nonce_invalid():

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -1,0 +1,80 @@
+from ..types import TealType
+from .expr import Expr
+
+class ScratchSlot:
+    """Represents the allocation of a scratch space slot."""
+
+    slotId = 0
+
+    def __init__(self):
+        self.id = ScratchSlot.slotId
+        ScratchSlot.slotId += 1
+
+    def store(self):
+        """Get an expression to store a value in this slot."""
+        return ScratchStore(self)
+
+    def load(self, type: TealType = TealType.anytype):
+        """Get an expression to load a value from this slot.
+
+        Args:
+            type (optional): The type being loaded from this slot, if known. Defaults to
+            TealType.anytype.
+        """
+        return ScratchLoad(self, type)
+    
+    def __str__(self):
+        return "slot#{}".format(self.id)
+    
+    def __eq__(self, other):
+        if isinstance(other, ScratchSlot):
+            return self.id == other.id
+        return False
+    
+    def __hash__(self):
+        return hash(self.id)
+
+class ScratchLoad(Expr):
+    """Expression to load a value from scratch space."""
+
+    def __init__(self, slot: ScratchSlot, type: TealType = TealType.anytype):
+        """Create a new ScratchLoad expression.
+
+        Args:
+            slot: The slot to load the value from.
+            type (optional): The type being loaded from this slot, if known. Defaults to
+            TealType.anytype.
+        """
+        self.slot = slot
+        self.type = type
+
+    def __str__(self):
+        return "(Load {})".format(self.slot.__str__())
+
+    def __teal__(self):
+        from ..ir import TealOp, Op
+        return [TealOp(Op.load, self.slot)]
+
+    def type_of(self):
+        return self.type
+
+class ScratchStore(Expr):
+    """Expression to store a value in scratch space."""
+
+    def __init__(self, slot: ScratchSlot):
+        """Create a new ScratchStore expression.
+
+        Args:
+            slot: The slot to store the value in.
+        """
+        self.slot = slot
+
+    def __str__(self):
+        return "(Store {})".format(self.slot.__str__())
+
+    def __teal__(self):
+        from ..ir import TealOp, Op
+        return [TealOp(Op.store, self.slot)]
+
+    def type_of(self):
+        return TealType.none

--- a/pyteal/ast/scratch_test.py
+++ b/pyteal/ast/scratch_test.py
@@ -1,0 +1,40 @@
+import pytest
+
+from .. import *
+
+def test_scratch_slot():
+    slot = ScratchSlot()
+    assert slot == slot
+    assert slot.__hash__() == slot.__hash__()
+    assert slot != ScratchSlot()
+
+    assert slot.store().__teal__() == ScratchStore(slot).__teal__()
+
+    assert slot.load().type_of() == TealType.anytype
+    assert slot.load(TealType.uint64).type_of() == TealType.uint64
+    assert slot.load().__teal__() == ScratchLoad(slot).__teal__()
+
+def test_scratch_load_default():
+    slot = ScratchSlot()
+    expr = ScratchLoad(slot)
+    assert expr.type_of() == TealType.anytype
+    assert expr.__teal__() == [
+        TealOp(Op.load, slot)
+    ]
+
+def test_scratch_load_type():
+    for type in (TealType.uint64, TealType.bytes, TealType.anytype):
+        slot = ScratchSlot()
+        expr = ScratchLoad(slot, type)
+        assert expr.type_of() == type
+        assert expr.__teal__() == [
+            TealOp(Op.load, slot)
+        ]
+
+def test_scratch_store():
+    slot = ScratchSlot()
+    expr = ScratchStore(slot)
+    assert expr.type_of() == TealType.none
+    assert expr.__teal__() == [
+        TealOp(Op.store, slot)
+    ]

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -1,0 +1,43 @@
+from typing import List
+
+from ..types import TealType, require_type
+from ..errors import TealInputError
+from .expr import Expr
+
+class Seq(Expr):
+    """A control flow expression to represent a sequence of expressions."""
+    
+    def __init__(self, exprs: List[Expr]):
+        """Create a new Seq expression.
+
+        The new Seq expression will take on the return value of the final expression in the sequence.
+
+        Args:
+            exprs: The expressions to include in this sequence. All expressions that are not the
+            final one in this list must not return any values.
+        """
+        if len(exprs) == 0:
+            raise TealInputError("Seq requires children.")
+        for i, expr in enumerate(exprs):
+            if not isinstance(expr, Expr):
+                raise TealInputError("{} is not a pyteal expression.".format(expr))
+            if i + 1 < len(exprs):
+                require_type(expr.type_of(), TealType.none)
+        
+        self.args = exprs
+        
+    def __teal__(self):
+        code = []
+        for a in self.args:
+            code += a.__teal__()
+        return code
+
+    def __str__(self):
+        ret_str = "(Seq"
+        for a in self.args:
+            ret_str += " " + a.__str__()
+        ret_str += ")"
+        return ret_str
+        
+    def type_of(self):
+        return self.args[-1].type_of()

--- a/pyteal/ast/seq_test.py
+++ b/pyteal/ast/seq_test.py
@@ -1,0 +1,42 @@
+import pytest
+
+from .. import *
+
+def test_seq_one():
+    items = [Int(0)]
+    expr = Seq(items)
+    assert expr.type_of() == items[-1].type_of()
+    assert expr.__teal__() == [op for item in items for op in item.__teal__()]
+
+def test_seq_two():
+    items = [
+        App.localPut(Int(0), Bytes("key"), Int(1)),
+        Int(7)
+    ]
+    expr = Seq(items)
+    assert expr.type_of() == items[-1].type_of()
+    assert expr.__teal__() == [op for item in items for op in item.__teal__()]
+
+def test_seq_three():
+    items = [
+        App.localPut(Int(0), Bytes("key1"), Int(1)),
+        App.localPut(Int(1), Bytes("key2"), Bytes("value2")),
+        Pop(Bytes("end"))
+    ]
+    expr = Seq(items)
+    assert expr.type_of() == items[-1].type_of()
+    assert expr.__teal__() == [op for item in items for op in item.__teal__()]
+
+
+def test_seq_invalid():
+    with pytest.raises(TealInputError):
+        Seq([])
+    
+    with pytest.raises(TealTypeError):
+        Seq([Int(1), Pop(Int(2))])
+    
+    with pytest.raises(TealTypeError):
+        Seq([Int(1), Int(2)])
+    
+    with pytest.raises(TealTypeError):
+        Seq([Seq([Pop(Int(1)), Int(2)]), Int(3)])

--- a/pyteal/ast/substring.py
+++ b/pyteal/ast/substring.py
@@ -1,0 +1,37 @@
+from ..types import TealType, require_type
+from ..ir import TealOp, Op
+from .expr import Expr
+
+class Substring(Expr):
+    """Take a substring of a byte string."""
+
+    def __init__(self, string: Expr, start: Expr, end: Expr) -> None:
+        """Create a new Substring expression.
+
+        Produces a new byte string consisting of the bytes starting at start up to but not including
+        end.
+
+        Args:
+            string: The byte string.
+            start: The starting index for the substring.
+            end: The ending index for the substring.
+        """
+        require_type(string.type_of(), TealType.bytes)
+        require_type(start.type_of(), TealType.uint64)
+        require_type(end.type_of(), TealType.uint64)
+        
+        self.string = string
+        self.start = start
+        self.end = end
+
+    def __teal__(self):
+        return self.string.__teal__() + \
+               self.start.__teal__() + \
+               self.end.__teal__() + \
+               [TealOp(Op.substring3)]
+
+    def __str__(self):
+        return "(substring {} {} {})".format(self.string, self.start, self.end)
+    
+    def type_of(self):
+        return TealType.bytes

--- a/pyteal/ast/substring_test.py
+++ b/pyteal/ast/substring_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+from .. import *
+
+def test_substring():
+    expr = Substring(Bytes("my string"), Int(0), Int(2))
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.byte, "\"my string\""),
+        TealOp(Op.int, 0),
+        TealOp(Op.int, 2),
+        TealOp(Op.substring3)
+    ]
+
+def test_substring_invalid():
+    with pytest.raises(TealTypeError):
+        Substring(Int(0), Int(0), Int(2))
+    
+    with pytest.raises(TealTypeError):
+        Substring(Bytes("my string"), Txn.sender(), Int(2))
+    
+    with pytest.raises(TealTypeError):
+        Substring(Bytes("my string"), Int(0), Txn.sender())

--- a/pyteal/ast/tmpl.py
+++ b/pyteal/ast/tmpl.py
@@ -1,25 +1,26 @@
 from ..types import TealType, valid_tmpl
+from ..ir import TealOp, Op
 from ..errors import TealInternalError
 from .leafexpr import LeafExpr
 
 class Tmpl(LeafExpr):
     """Template expression for creating placeholder values."""
 
-    def __init__(self, op: str, type: TealType, name: str) -> None:
+    def __init__(self, op: Op, type: TealType, name: str) -> None:
         valid_tmpl(name)
         self.op = op
         self.type = type
         self.name = name
 
     def __str__(self):
-        return "(Tmpl {} {})".format(self.op, self.name)
+        return "(Tmpl {} {})".format(self.op.value, self.name)
 
     def __teal__(self):
-        return [[self.op, self.name]]
+        return [TealOp(self.op, self.name)]
 
     def type_of(self):
         return self.type
-    
+
     @classmethod
     def Int(cls, placeholder: str):
         """Create a new Int template.
@@ -28,8 +29,8 @@ class Tmpl(LeafExpr):
             placeholder: The name to use for this template variable. Must start with "TMPL_" and
             only consist of uppercase alphanumeric characters and underscores.
         """
-        return cls("int", TealType.uint64, placeholder)
-    
+        return cls(Op.int, TealType.uint64, placeholder)
+
     @classmethod
     def Bytes(cls, placeholder: str):
         """Create a new Bytes template.
@@ -38,14 +39,13 @@ class Tmpl(LeafExpr):
             placeholder: The name to use for this template variable. Must start with "TMPL_" and
             only consist of uppercase alphanumeric characters and underscores.
         """
-        return cls("byte", TealType.bytes, placeholder)
+        return cls(Op.byte, TealType.bytes, placeholder)
 
     @classmethod
     def Addr(cls, placeholder: str):
         """Create a new Addr template.
-        
         Args:
             placeholder: The name to use for this template variable. Must start with "TMPL_" and
             only consist of uppercase alphanumeric characters and underscores.
         """
-        return cls("addr", TealType.bytes, placeholder)
+        return cls(Op.addr, TealType.bytes, placeholder)

--- a/pyteal/ast/tmpl_test.py
+++ b/pyteal/ast/tmpl_test.py
@@ -4,8 +4,9 @@ from .. import *
 
 def test_tmpl_int():
     expr = Tmpl.Int("TMPL_AMNT")
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["int", "TMPL_AMNT"]
+        TealOp(Op.int, "TMPL_AMNT")
     ]
 
 def test_tmpl_int_invalid():
@@ -14,8 +15,9 @@ def test_tmpl_int_invalid():
 
 def test_tmpl_bytes():
     expr = Tmpl.Bytes("TMPL_NOTE")
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["byte", "TMPL_NOTE"]
+        TealOp(Op.byte, "TMPL_NOTE")
     ]
 
 def test_tmpl_bytes_invalid():
@@ -24,8 +26,9 @@ def test_tmpl_bytes_invalid():
 
 def test_tmpl_addr():
     expr = Tmpl.Addr("TMPL_RECEIVER0")
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["addr", "TMPL_RECEIVER0"]
+        TealOp(Op.addr, "TMPL_RECEIVER0")
     ]
 
 def test_tmpl_addr_invalid():

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -1,134 +1,153 @@
 from enum import Enum
 
 from ..types import TealType
+from ..errors import TealInputError
+from ..ir import TealOp, Op
 from .leafexpr import LeafExpr
+from .int import EnumInt
+
+class TxnType:
+    """Enum of all possible transaction types."""
+    Unknown = EnumInt("unknown")
+    Payment = EnumInt("pay")
+    KeyRegistration = EnumInt("keyreg")
+    AssetConfig = EnumInt("acfg")
+    AssetTransfer = EnumInt("axfer")
+    AssetFreeze = EnumInt("afrz")
+    ApplicationCall = EnumInt("appl")
 
 class TxnField(Enum):
-     sender = 0
-     fee = 1
-     first_valid = 2
-     last_valid = 3
-     note = 4
-     lease = 5
-     receiver = 6
-     amount = 7
-     close_remainder_to = 8
-     vote_pk = 9
-     selection_pk = 10
-     vote_first =11
-     vote_last = 12
-     vote_key_dilution = 13
-     type = 14
-     type_enum = 15
-     xfer_asset = 16
-     asset_amount = 17
-     asset_sender = 18
-     asset_receiver = 19
-     asset_close_to = 20
-     group_index = 21
-     tx_id = 22
+    sender = (0, "Sender", TealType.bytes)
+    fee = (1, "Fee", TealType.uint64)
+    first_valid = (2, "FirstValid", TealType.uint64)
+    first_valid_time = (3, "FirstValidTime", TealType.uint64)
+    last_valid = (4, "LastValid", TealType.uint64)
+    note = (5, "Note", TealType.bytes)
+    lease = (6, "Lease", TealType.bytes)
+    receiver = (7, "Receiver", TealType.bytes)
+    amount = (8, "Amount", TealType.uint64)
+    close_remainder_to = (9, "CloseRemainderTo", TealType.bytes)
+    vote_pk = (10, "VotePK", TealType.bytes)
+    selection_pk = (11, "SelectionPK", TealType.bytes)
+    vote_first = (12, "VoteFirst", TealType.uint64)
+    vote_last = (13, "VoteLast", TealType.uint64)
+    vote_key_dilution = (14, "VoteKeyDilution", TealType.uint64)
+    type = (15, "Type", TealType.bytes)
+    type_enum = (16, "TypeEnum", TealType.uint64)
+    xfer_asset = (17, "XferAsset", TealType.uint64)
+    asset_amount = (18, "AssetAmount", TealType.uint64)
+    asset_sender = (19, "AssetSender", TealType.bytes)
+    asset_receiver = (20, "AssetReceiver", TealType.bytes)
+    asset_close_to = (21, "AssetCloseTo", TealType.bytes)
+    group_index = (22, "GroupIndex", TealType.uint64)
+    tx_id = (23, "TxID", TealType.bytes)
+    application_id = (24, "ApplicationID", TealType.uint64)
+    on_completion = (25, "OnCompletion", TealType.uint64)
+    application_args = (26, "ApplicationArgs", TealType.bytes)
+    num_app_args = (27, "NumAppArgs", TealType.uint64)
+    accounts = (28, "Accounts", TealType.bytes)
+    num_accounts = (2, "NumAccounts", TealType.uint64)
+    approval_program = (30, "ApprovalProgram", TealType.bytes)
+    clear_state_program = (31, "ClearStateProgram", TealType.bytes)
+    rekey_to = (32, "RekeyTo", TealType.bytes)
+    config_asset = (33, "ConfigAsset", TealType.uint64)
+    config_asset_total = (34, "ConfigAssetTotal", TealType.uint64)
+    config_asset_decimals = (35, "ConfigAssetDecimals", TealType.uint64)
+    config_asset_default_frozen = (36, "ConfigAssetDefaultFrozen", TealType.uint64)
+    config_asset_unit_name = (37, "ConfigAssetUnitName", TealType.bytes)
+    config_asset_name = (38, "ConfigAssetName", TealType.bytes)
+    config_asset_url = (39, "ConfigAssetURL", TealType.bytes)
+    config_asset_metadata_hash = (40, "ConfigAssetMetadataHash", TealType.bytes)
+    config_asset_manager = (41, "ConfigAssetManager", TealType.bytes)
+    config_asset_reserve = (42, "ConfigAssetReserve", TealType.bytes)
+    config_asset_freeze = (43, "ConfigAssetFreeze", TealType.bytes)
+    config_asset_clawback = (44, "ConfigAssetClawback", TealType.bytes)
+    freeze_asset = (45, "FreezeAsset", TealType.uint64)
+    freeze_asset_account = (46, "FreezeAssetAccount", TealType.bytes)
+    freeze_asset_frozen = (47, "FreezeAssetFrozen", TealType.uint64)
 
-# data types of txn fields
-type_of_field = {
-     TxnField.sender: TealType.bytes,
-     TxnField.fee: TealType.uint64,
-     TxnField.first_valid: TealType.uint64,
-     TxnField.last_valid: TealType.uint64,
-     TxnField.note: TealType.bytes,
-     TxnField.lease: TealType.bytes,
-     TxnField.receiver: TealType.bytes,
-     TxnField.amount: TealType.uint64,
-     TxnField.close_remainder_to: TealType.bytes,
-     TxnField.vote_pk: TealType.bytes,
-     TxnField.selection_pk: TealType.bytes,
-     TxnField.vote_first: TealType.uint64,
-     TxnField.vote_last: TealType.uint64,
-     TxnField.vote_key_dilution: TealType.uint64,
-     TxnField.type: TealType.bytes,
-     TxnField.type_enum: TealType.uint64,
-     TxnField.xfer_asset: TealType.uint64,
-     TxnField.asset_amount: TealType.uint64,
-     TxnField.asset_sender: TealType.bytes,
-     TxnField.asset_receiver: TealType.bytes,
-     TxnField.asset_close_to: TealType.bytes,
-     TxnField.group_index: TealType.uint64,
-     TxnField.tx_id: TealType.bytes
-}
+    def __init__(self, id: int, name: str, type: TealType) -> None:
+        self.id = id
+        self.arg_name = name
+        self.ret_type = type
+    
+    def type_of(self) -> TealType:
+        return self.ret_type
 
-str_of_field = {
-     TxnField.sender: "Sender",
-     TxnField.fee: "Fee",
-     TxnField.first_valid: "FirstValid",
-     TxnField.last_valid: "LastValid",
-     TxnField.note: "Note",
-     TxnField.lease: "Lease",
-     TxnField.receiver: "Receiver",
-     TxnField.amount: "Amount",
-     TxnField.close_remainder_to: "CloseRemainderTo",
-     TxnField.vote_pk: "VotePK",
-     TxnField.selection_pk: "SelectionPK",
-     TxnField.vote_first: "VoteFirst",
-     TxnField.vote_last: "VoteLast",
-     TxnField.vote_key_dilution: "VoteKeyDilution",
-     TxnField.type: "Type",
-     TxnField.type_enum: "TypeEnum",
-     TxnField.xfer_asset: "XferAsset",
-     TxnField.asset_amount: "AssetAmount",
-     TxnField.asset_sender: "AssetSender",
-     TxnField.asset_receiver: "AssetReceiver",
-     TxnField.asset_close_to: "AssetCloseTo",
-     TxnField.group_index: "GroupIndex",
-     TxnField.tx_id: "TxID"
-}
+class Txna(LeafExpr):
+    """An expression that accesses a transaction array field from the current transaction."""
 
-# get a field from the current txn
+    def __init__(self, field: TxnField, index: int) -> None:
+        self.field = field
+        self.index = index
+    
+    def __str__(self):
+        return "(Txna {} {})".format(self.field.arg_name, self.index)
+    
+    def __teal__(self):
+        return [TealOp(Op.txna, self.field.arg_name, self.index)]
+    
+    def type_of(self):
+        return self.field.type_of()
+
 class Txn(LeafExpr):
+    """An expression that accesses a transaction field from the current transaction."""
 
-    # default constructor
-    def __init__(self, field:TxnField) -> None:
+    def __init__(self, field: TxnField) -> None:
         self.field = field
 
     def __str__(self):
-        return "(Txn {})".format(str_of_field[self.field])
+        return "(Txn {})".format(self.field.arg_name)
 
     def __teal__(self):
-        return [["txn", str_of_field[self.field]]]
-   
-    # a series of class methods for better programmer experience
+        return [TealOp(Op.txn, self.field.arg_name)]
+    
+    def type_of(self):
+        return self.field.type_of()
+
     @classmethod
     def sender(cls):
+        """Get the 32 byte address of the sender."""
         return cls(TxnField.sender)
-   
+
     @classmethod
     def fee(cls):
+        """Get the transaction fee in micro Algos."""
         return cls(TxnField.fee)
 
     @classmethod
     def first_valid(cls):
+        """Get the first valid round number."""
         return cls(TxnField.first_valid)
    
     @classmethod
     def last_valid(cls):
+        """Get the last valid round number."""
         return cls(TxnField.last_valid)
 
     @classmethod
     def note(cls):
+        """Get the transaction note."""
         return cls(TxnField.note)
 
     @classmethod
     def lease(cls):
+        """Get the transaction lease."""
         return cls(TxnField.lease)
    
     @classmethod
     def receiver(cls):
+        """Get the 32 byte address of the receiver."""
         return cls(TxnField.receiver)
 
     @classmethod
     def amount(cls):
+        """Get the amount of the transaction in micro Algos."""
         return cls(TxnField.amount)
 
     @classmethod
     def close_remainder_to(cls):
+        """Get the 32 byte address of the CloseRemainderTo field."""
         return cls(TxnField.close_remainder_to)
 
     @classmethod
@@ -157,18 +176,29 @@ class Txn(LeafExpr):
 
     @classmethod
     def type_enum(cls):
+        """Get the type of this transaction.
+        
+        See the TxnType enum for possible values.
+        """
         return cls(TxnField.type_enum)
 
     @classmethod
     def xfer_asset(cls):
+        """The ID of the asset being transferred."""
         return cls(TxnField.xfer_asset)
 
     @classmethod
     def asset_amount(cls):
+        """The the amount of the asset being transferred, measured in the asset's units."""
         return cls(TxnField.asset_amount)
 
     @classmethod
     def asset_sender(cls):
+        """Get the 32 byte address of the subject of clawback.
+        
+        The transaction will clawback of all of an asset from this address if the transaction sender
+        is the clawback address of the asset.
+        """
         return cls(TxnField.asset_sender)
 
     @classmethod
@@ -181,11 +211,140 @@ class Txn(LeafExpr):
 
     @classmethod
     def group_index(cls):
+        """Get the position of the current transaction within the atomic transaction group.
+        
+        A stand-alone transaction is implictly element 0 in a group of 1.
+        """
         return cls(TxnField.group_index)
 
     @classmethod
     def tx_id(cls):
+        """Get the 32 byte computed ID for the current transaction."""
         return cls(TxnField.tx_id)
-   
-    def type_of(self):
-        return type_of_field[self.field]
+    
+    @classmethod
+    def application_id(cls):
+        """Get the application ID from the ApplicationCall portion of the current transaction."""
+        return cls(TxnField.application_id)
+
+    @classmethod
+    def on_completion(cls):
+        """Get the on completion action from the ApplicationCall portion of the current transaction."""
+        return cls(TxnField.on_completion)
+
+    @classmethod
+    def approval_program(cls):
+        """Get the approval program."""
+        return cls(TxnField.approval_program)
+    
+    @classmethod
+    def clear_state_program(cls):
+        """Get the clear state program."""
+        return cls(TxnField.clear_state_program)
+    
+    @classmethod
+    def rekey_to(cls):
+        """Get the sender's new 32 byte AuthAddr"""
+        return cls(TxnField.rekey_to)
+    
+    @classmethod
+    def config_asset(cls):
+        """Get the asset ID in asset config transaction."""
+        return cls(TxnField.config_asset)
+    
+    @classmethod
+    def config_asset_total(cls):
+        """Get the total number of units of this asset created."""
+        return cls(TxnField.config_asset_total)
+
+    @classmethod
+    def config_asset_decimals(cls):
+        """Get the number of digits to display after the decimal place when displaying the asset."""
+        return cls(TxnField.config_asset_decimals)
+    
+    @classmethod
+    def config_asset_default_frozen(cls):
+        """Check if the asset's slots are frozen by default or not."""
+        return cls(TxnField.config_asset_default_frozen)
+    
+    @classmethod
+    def config_asset_unit_name(cls):
+        """Get the unit name of the asset."""
+        return cls(TxnField.config_asset_unit_name)
+
+    @classmethod
+    def config_asset_name(cls):
+        """Get the asset name."""
+        return cls(TxnField.config_asset_name)
+    
+    @classmethod
+    def config_asset_url(cls):
+        """Get the asset URL."""
+        return cls(TxnField.config_asset_url)
+    
+    @classmethod
+    def config_asset_metadata_hash(cls):
+        """Get the 32 byte commitment to some unspecified asset metdata."""
+        return cls(TxnField.config_asset_metadata_hash)
+    
+    @classmethod
+    def config_asset_manager(cls):
+        """Get the 32 byte asset manager address."""
+        return cls(TxnField.config_asset_manager)
+    
+    @classmethod
+    def config_asset_reserve(cls):
+        """Get the 32 byte asset reserve address."""
+        return cls(TxnField.config_asset_reserve)
+    
+    @classmethod
+    def config_asset_freeze(cls):
+        """Get the 32 byte asset freeze address."""
+        return cls(TxnField.config_asset_freeze)
+    
+    @classmethod
+    def config_asset_clawback(cls):
+        """Get the 32 byte asset clawback address."""
+        return cls(TxnField.config_asset_clawback)
+    
+    @classmethod
+    def freeze_asset(cls):
+        """Get the asset ID being frozen or un-frozen."""
+        return cls(TxnField.freeze_asset)
+    
+    @classmethod
+    def freeze_asset_account(cls):
+        """Get the 32 byte address of the account whose asset slot is being frozen or un-frozen."""
+        return cls(TxnField.freeze_asset_account)
+    
+    @classmethod
+    def freeze_asset_frozen(cls):
+        """Get the new frozen value for the asset."""
+        return cls(TxnField.freeze_asset_frozen)
+    
+    class ArrayAccessor:
+
+        def __init__(self, accessField: TxnField, lengthField: TxnField) -> None:
+            self.accessField = accessField
+            self.lengthField = lengthField
+        
+        def length(self):
+            """Get the length of this array."""
+            return Txn(self.lengthField)
+        
+        def __getitem__(self, index: int):
+            """Get the value at an index in this array.
+            
+            Args:
+                index: Must not be negative.
+            """
+            if not isinstance(index, int) or index < 0:
+                raise TealInputError("Invalid array index: {}".format(index))
+
+            return Txna(self.accessField, index)
+    
+    """Application args array"""
+    application_args = ArrayAccessor(TxnField.application_args, TxnField.num_app_args)
+
+    """Accounts array"""
+    accounts = ArrayAccessor(TxnField.accounts, TxnField.num_accounts)

--- a/pyteal/ast/txn_test.py
+++ b/pyteal/ast/txn_test.py
@@ -4,126 +4,331 @@ from .. import *
 
 def test_txn_sender():
     expr = Txn.sender()
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["txn", "Sender"]
+        TealOp(Op.txn, "Sender")
     ]
 
 def test_txn_fee():
     expr = Txn.fee()
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["txn", "Fee"]
+        TealOp(Op.txn, "Fee")
     ]
 
 def test_txn_first_valid():
     expr = Txn.first_valid()
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["txn", "FirstValid"]
+        TealOp(Op.txn, "FirstValid")
     ]
 
 def test_txn_last_valid():
     expr = Txn.last_valid()
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["txn", "LastValid"]
+        TealOp(Op.txn, "LastValid")
     ]
 
 def test_txn_note():
     expr = Txn.note()
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["txn", "Note"]
-    ]
-
-def test_txn_receiver():
-    expr = Txn.receiver()
-    assert expr.__teal__() == [
-        ["txn", "Receiver"]
-    ]
-
-def test_txn_amount():
-    expr = Txn.amount()
-    assert expr.__teal__() == [
-        ["txn", "Amount"]
-    ]
-
-def test_txn_close_remainder_to():
-    expr = Txn.close_remainder_to()
-    assert expr.__teal__() == [
-        ["txn", "CloseRemainderTo"]
-    ]
-
-def test_txn_vote_pk():
-    expr = Txn.vote_pk()
-    assert expr.__teal__() == [
-        ["txn", "VotePK"]
-    ]
-
-def test_txn_selection_pk():
-    expr = Txn.selection_pk()
-    assert expr.__teal__() == [
-        ["txn", "SelectionPK"]
-    ]
-
-def test_txn_vote_first():
-    expr = Txn.vote_first()
-    assert expr.__teal__() == [
-        ["txn", "VoteFirst"]
-    ]
-
-def test_txn_vote_last():
-    expr = Txn.vote_last()
-    assert expr.__teal__() == [
-        ["txn", "VoteLast"]
-    ]
-
-def test_txn_vote_key_dilution():
-    expr = Txn.vote_key_dilution()
-    assert expr.__teal__() == [
-        ["txn", "VoteKeyDilution"]
-    ]
-
-def test_txn_type():
-    expr = Txn.type()
-    assert expr.__teal__() == [
-        ["txn", "Type"]
-    ]
-
-def test_txn_type_enum():
-    expr = Txn.type_enum()
-    assert expr.__teal__() == [
-        ["txn", "TypeEnum"]
-    ]
-
-def test_txn_xfer_asset():
-    expr = Txn.xfer_asset()
-    assert expr.__teal__() == [
-        ["txn", "XferAsset"]
-    ]
-
-def test_txn_asset_amount():
-    expr = Txn.asset_amount()
-    assert expr.__teal__() == [
-        ["txn", "AssetAmount"]
-    ]
-
-def test_txn_asset_close_to():
-    expr = Txn.asset_close_to()
-    assert expr.__teal__() == [
-        ["txn", "AssetCloseTo"]
-    ]
-
-def test_txn_group_index():
-    expr = Txn.group_index()
-    assert expr.__teal__() == [
-        ["txn", "GroupIndex"]
-    ]
-
-def test_txn_id():
-    expr = Txn.tx_id()
-    assert expr.__teal__() == [
-        ["txn", "TxID"]
+        TealOp(Op.txn, "Note")
     ]
 
 def test_txn_lease():
     expr = Txn.lease()
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["txn", "Lease"]
+        TealOp(Op.txn, "Lease")
+    ]
+
+def test_txn_receiver():
+    expr = Txn.receiver()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "Receiver")
+    ]
+
+def test_txn_amount():
+    expr = Txn.amount()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "Amount")
+    ]
+
+def test_txn_close_remainder_to():
+    expr = Txn.close_remainder_to()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "CloseRemainderTo")
+    ]
+
+def test_txn_vote_pk():
+    expr = Txn.vote_pk()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "VotePK")
+    ]
+
+def test_txn_selection_pk():
+    expr = Txn.selection_pk()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "SelectionPK")
+    ]
+
+def test_txn_vote_first():
+    expr = Txn.vote_first()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "VoteFirst")
+    ]
+
+def test_txn_vote_last():
+    expr = Txn.vote_last()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "VoteLast")
+    ]
+
+def test_txn_vote_key_dilution():
+    expr = Txn.vote_key_dilution()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "VoteKeyDilution")
+    ]
+
+def test_txn_type():
+    expr = Txn.type()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "Type")
+    ]
+
+def test_txn_type_enum():
+    expr = Txn.type_enum()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "TypeEnum")
+    ]
+
+def test_txn_xfer_asset():
+    expr = Txn.xfer_asset()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "XferAsset")
+    ]
+
+def test_txn_asset_amount():
+    expr = Txn.asset_amount()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "AssetAmount")
+    ]
+
+def test_txn_asset_sender():
+    expr = Txn.asset_sender()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "AssetSender")
+    ]
+
+def test_txn_asset_receiver():
+    expr = Txn.asset_receiver()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "AssetReceiver")
+    ]
+
+def test_txn_asset_close_to():
+    expr = Txn.asset_close_to()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "AssetCloseTo")
+    ]
+
+def test_txn_group_index():
+    expr = Txn.group_index()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "GroupIndex")
+    ]
+
+def test_txn_id():
+    expr = Txn.tx_id()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "TxID")
+    ]
+
+def test_txn_application_id():
+    expr = Txn.application_id()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ApplicationID")
+    ]
+
+def test_txn_on_completion():
+    expr = Txn.on_completion()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "OnCompletion")
+    ]
+
+def test_txn_application_args():
+    for i in range(4):
+        expr = Txn.application_args[i]
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.txna, "ApplicationArgs", i)
+        ]
+
+def test_txn_application_args_length():
+    expr = Txn.application_args.length()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "NumAppArgs")
+    ]
+
+def test_txn_accounts():
+    for i in range(4):
+        expr = Txn.accounts[i]
+        assert expr.type_of() == TealType.bytes
+        assert expr.__teal__() == [
+            TealOp(Op.txna, "Accounts", i)
+        ]
+
+def test_txn_accounts_length():
+    expr = Txn.accounts.length()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "NumAccounts")
+    ]
+
+def test_txn_approval_program():
+    expr = Txn.approval_program()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ApprovalProgram")
+    ]
+
+def test_txn_clear_state_program():
+    expr = Txn.clear_state_program()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ClearStateProgram")
+    ]
+
+def test_txn_rekey_to():
+    expr = Txn.rekey_to()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "RekeyTo")
+    ]
+
+def test_txn_config_asset():
+    expr = Txn.config_asset()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAsset")
+    ]
+
+def test_txn_config_asset_total():
+    expr = Txn.config_asset_total()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetTotal")
+    ]
+
+def test_txn_config_asset_decimals():
+    expr = Txn.config_asset_decimals()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetDecimals")
+    ]
+
+def test_txn_config_asset_default_frozen():
+    expr = Txn.config_asset_default_frozen()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetDefaultFrozen")
+    ]
+
+def test_txn_config_asset_unit_name():
+    expr = Txn.config_asset_unit_name()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetUnitName")
+    ]
+
+def test_txn_config_asset_name():
+    expr = Txn.config_asset_name()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetName")
+    ]
+
+def test_txn_config_asset_url():
+    expr = Txn.config_asset_url()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetURL")
+    ]
+
+def test_txn_config_asset_metadata_hash():
+    expr = Txn.config_asset_metadata_hash()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetMetadataHash")
+    ]
+
+def test_txn_config_asset_manager():
+    expr = Txn.config_asset_manager()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetManager")
+    ]
+
+def test_txn_config_asset_reserve():
+    expr = Txn.config_asset_reserve()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetReserve")
+    ]
+
+def test_txn_config_asset_freeze():
+    expr = Txn.config_asset_freeze()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetFreeze")
+    ]
+
+def test_txn_config_asset_clawback():
+    expr = Txn.config_asset_clawback()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "ConfigAssetClawback")
+    ]
+
+def test_txn_freeze_asset():
+    expr = Txn.freeze_asset()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "FreezeAsset")
+    ]
+
+def test_txn_freeze_asset_account():
+    expr = Txn.freeze_asset_account()
+    assert expr.type_of() == TealType.bytes
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "FreezeAssetAccount")
+    ]
+
+def test_txn_freeze_asset_frozen():
+    expr = Txn.freeze_asset_frozen()
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.txn, "FreezeAssetFrozen")
     ]

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -1,10 +1,11 @@
 from ..types import TealType, require_type
+from ..ir import TealOp, Op
 from .expr import Expr
 
 class UnaryExpr(Expr):
     """An expression with a single argument."""
 
-    def __init__(self, op: str, inputType: TealType, outputType: TealType, arg: Expr) -> None:
+    def __init__(self, op: Op, inputType: TealType, outputType: TealType, arg: Expr) -> None:
         require_type(arg.type_of(), inputType)
         self.op = op
         self.outputType = outputType
@@ -12,39 +13,64 @@ class UnaryExpr(Expr):
 
     def __teal__(self):
         teal = self.arg.__teal__()
-        teal.append([self.op])
+        teal.append(TealOp(self.op))
         return teal
 
     def __str__(self):
-        return "({} {})".format(self.op, self.arg)
+        return "({} {})".format(self.op.value, self.arg)
 
     def type_of(self):
         return self.outputType
 
 def Btoi(arg: Expr):
     """Convert a byte string to a uint64."""
-    return UnaryExpr("btoi", TealType.bytes, TealType.uint64, arg)
+    return UnaryExpr(Op.btoi, TealType.bytes, TealType.uint64, arg)
 
 def Itob(arg: Expr):
     """Convert a uint64 string to a byte string."""
-    return UnaryExpr("itob", TealType.uint64, TealType.bytes, arg)
+    return UnaryExpr(Op.itob, TealType.uint64, TealType.bytes, arg)
 
 def Len(arg: Expr):
     """Get the length of a byte string."""
-    return UnaryExpr("len", TealType.bytes, TealType.uint64, arg)
+    return UnaryExpr(Op.len, TealType.bytes, TealType.uint64, arg)
 
 def Sha256(arg: Expr):
     """Get the SHA-256 hash of a byte string."""
-    return UnaryExpr("sha256", TealType.bytes, TealType.bytes, arg)
+    return UnaryExpr(Op.sha256, TealType.bytes, TealType.bytes, arg)
 
 def Sha512_256(arg: Expr):
     """Get the SHA-512/256 hash of a byte string."""
-    return UnaryExpr("sha512_256", TealType.bytes, TealType.bytes, arg)
+    return UnaryExpr(Op.sha512_256, TealType.bytes, TealType.bytes, arg)
 
 def Keccak256(arg: Expr):
     """Get the KECCAK-256 hash of a byte string."""
-    return UnaryExpr("keccak256", TealType.bytes, TealType.bytes, arg)
+    return UnaryExpr(Op.keccak256, TealType.bytes, TealType.bytes, arg)
+
+def Not(arg: Expr):
+    """Get the logical inverse of a uint64.
+
+    If the argument is 0, then this will produce 1. Otherwise this will produce 0.
+    """
+    return UnaryExpr(Op.logic_not, TealType.uint64, TealType.uint64, arg)
+
+def BitwiseNot(arg: Expr):
+    """Get the bitwise inverse of a uint64."""
+    return UnaryExpr(Op.bitwise_not, TealType.uint64, TealType.uint64, arg)
 
 def Pop(arg: Expr):
     """Pop a value from the stack."""
-    return UnaryExpr("pop", TealType.anytype, TealType.none, arg)
+    return UnaryExpr(Op.pop, TealType.anytype, TealType.none, arg)
+
+def Return(arg: Expr):
+    """Immediately exit the program using the last value on stack as the success value."""
+    return UnaryExpr(Op.return_, TealType.uint64, TealType.none, arg)
+
+def Balance(arg: Expr):
+    """Get the balance of a user in micro Algos.
+
+    Argument must be an index into Txn.Accounts that corresponds to the account to read from. It
+    must evaluate to uint64.
+
+    This operation is only permitted in application mode.
+    """
+    return UnaryExpr(Op.balance, TealType.uint64, TealType.uint64, arg)

--- a/pyteal/ast/unaryexpr_test.py
+++ b/pyteal/ast/unaryexpr_test.py
@@ -4,9 +4,10 @@ from .. import *
 
 def test_btoi():
     expr = Btoi(Arg(1))
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["arg", "1"],
-        ["btoi"]
+        TealOp(Op.arg, 1),
+        TealOp(Op.btoi)
     ]
 
 def test_btoi_invalid():
@@ -15,9 +16,10 @@ def test_btoi_invalid():
 
 def test_itob():
     expr = Itob(Int(1))
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["int", "1"],
-        ["itob"]
+        TealOp(Op.int, 1),
+        TealOp(Op.itob)
     ]
 
 def test_itob_invalid():
@@ -26,9 +28,10 @@ def test_itob_invalid():
 
 def test_len():
     expr = Len(Txn.receiver())
+    assert expr.type_of() == TealType.uint64
     assert expr.__teal__() == [
-        ["txn", "Receiver"],
-        ["len"]
+        TealOp(Op.txn, "Receiver"),
+        TealOp(Op.len)
     ]
 
 def test_len_invalid():
@@ -37,9 +40,10 @@ def test_len_invalid():
 
 def test_sha256():
     expr = Sha256(Arg(0))
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["arg", "0"],
-        ["sha256"]
+        TealOp(Op.arg, 0),
+        TealOp(Op.sha256)
     ]
 
 def test_sha256_invalid():
@@ -48,9 +52,10 @@ def test_sha256_invalid():
 
 def test_sha512_256():
     expr = Sha512_256(Arg(0))
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["arg", "0"],
-        ["sha512_256"]
+        TealOp(Op.arg, 0),
+        TealOp(Op.sha512_256)
     ]
 
 def test_sha512_256_invalid():
@@ -59,11 +64,88 @@ def test_sha512_256_invalid():
 
 def test_keccak256():
     expr = Keccak256(Arg(0))
+    assert expr.type_of() == TealType.bytes
     assert expr.__teal__() == [
-        ["arg", "0"],
-        ["keccak256"]
+        TealOp(Op.arg, 0),
+        TealOp(Op.keccak256)
     ]
 
 def test_keccak256_invalid():
     with pytest.raises(TealTypeError):
         Keccak256(Int(1))
+
+def test_not():
+    expr = Not(Int(1))
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.logic_not)
+    ]
+
+def test_not_invalid():
+    with pytest.raises(TealTypeError):
+        Not(Txn.receiver())
+
+def test_bitwise_not():
+    expr = BitwiseNot(Int(2))
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 2),
+        TealOp(Op.bitwise_not)
+    ]
+
+def test_bitwise_not_overload():
+    expr = ~Int(10)
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 10),
+        TealOp(Op.bitwise_not)
+    ]
+
+def test_bitwise_not_invalid():
+    with pytest.raises(TealTypeError):
+        BitwiseNot(Txn.receiver())
+
+def test_pop():
+    expr_int = Pop(Int(3))
+    assert expr_int.type_of() == TealType.none
+    assert expr_int.__teal__() == [
+        TealOp(Op.int, 3),
+        TealOp(Op.pop)
+    ]
+
+    expr_bytes = Pop(Txn.receiver())
+    assert expr_bytes.type_of() == TealType.none
+    assert expr_bytes.__teal__() == [
+        TealOp(Op.txn, "Receiver"),
+        TealOp(Op.pop)
+    ]
+
+def test_pop_invalid():
+    expr = Pop(Int(0))
+    with pytest.raises(TealTypeError):
+        Pop(expr)
+
+def test_return():
+    expr = Return(Int(1))
+    assert expr.type_of() == TealType.none
+    assert expr.__teal__() == [
+        TealOp(Op.int, 1),
+        TealOp(Op.return_)
+    ]
+
+def test_return_invalid():
+    with pytest.raises(TealTypeError):
+        Return(Txn.receiver())
+
+def test_balance():
+    expr = Balance(Int(0))
+    assert expr.type_of() == TealType.uint64
+    assert expr.__teal__() == [
+        TealOp(Op.int, 0),
+        TealOp(Op.balance)
+    ]
+
+def test_balance_invalid():
+    with pytest.raises(TealTypeError):
+        Balance(Txn.receiver())

--- a/pyteal/compiler.py
+++ b/pyteal/compiler.py
@@ -1,6 +1,19 @@
-from .ast import Expr
+from typing import List
 
-def compileTeal(ast: Expr) -> str:
+from .ast import Expr
+from .ir import Mode, TealComponent, TealOp
+from .errors import TealInputError, TealInternalError
+
+NUM_SLOTS = 256
+
+def verifyOpsForMode(teal: List[TealComponent], mode: Mode):
+    for stmt in teal:
+        if isinstance(stmt, TealOp):
+            op = stmt.getOp()
+            if not op.mode & mode:
+                raise TealInputError("Op not supported in {} mode: {}".format(mode.name, op.value))
+
+def compileTeal(ast: Expr, mode: Mode) -> str:
     """Compile a PyTeal expression into TEAL assembly.
 
     Args:
@@ -11,6 +24,24 @@ def compileTeal(ast: Expr) -> str:
     """
     teal = ast.__teal__()
 
-    lines = ["#pragma version 1"]
-    lines += [" ".join(i) for i in teal]
+    verifyOpsForMode(teal, mode)
+
+    slots = set()
+    for stmt in teal:
+        for slot in stmt.getSlots():
+            slots.add(slot)
+    
+    if len(slots) > NUM_SLOTS:
+        # TODO: identify which slots can be reused
+        raise TealInternalError("Not yet implemented")
+    
+    location = 0
+    while len(slots) > 0:
+        slot = slots.pop()
+        for stmt in teal:
+            stmt.assignSlot(slot, location)
+        location += 1
+
+    lines = ["#pragma version 2"]
+    lines += [i.assemble() for i in teal]
     return "\n".join(lines)

--- a/pyteal/ir/__init__.py
+++ b/pyteal/ir/__init__.py
@@ -1,0 +1,5 @@
+from .ops import Op, Mode
+
+from .tealcomponent import TealComponent
+from .tealop import TealOp
+from .teallabel import TealLabel

--- a/pyteal/ir/ops.py
+++ b/pyteal/ir/ops.py
@@ -1,0 +1,76 @@
+from enum import Enum, Flag, auto
+
+class Mode(Flag):
+    Signature = auto()
+    Application = auto()
+
+class Op(Enum):
+    err = "err", Mode.Signature | Mode.Application
+    sha256 = "sha256", Mode.Signature | Mode.Application
+    keccak256 = "keccak256", Mode.Signature | Mode.Application
+    sha512_256 = "sha512_256", Mode.Signature | Mode.Application
+    ed25519verify = "ed25519verify", Mode.Signature
+    add = "+", Mode.Signature | Mode.Application
+    minus = "-", Mode.Signature | Mode.Application
+    div = "/", Mode.Signature | Mode.Application
+    mul = "*", Mode.Signature | Mode.Application
+    lt = "<", Mode.Signature | Mode.Application
+    gt = ">", Mode.Signature | Mode.Application
+    le = "<=", Mode.Signature | Mode.Application
+    ge = ">=", Mode.Signature | Mode.Application
+    logic_and = "&&", Mode.Signature | Mode.Application
+    logic_or = "||", Mode.Signature | Mode.Application
+    eq = "==", Mode.Signature | Mode.Application
+    neq = "!=", Mode.Signature | Mode.Application
+    logic_not = "!", Mode.Signature | Mode.Application
+    len = "len", Mode.Signature | Mode.Application
+    itob = "itob", Mode.Signature | Mode.Application
+    btoi = "btoi", Mode.Signature | Mode.Application
+    mod = "%", Mode.Signature | Mode.Application
+    bitwise_or = "|", Mode.Signature | Mode.Application
+    bitwise_and = "&", Mode.Signature | Mode.Application
+    bitwise_xor = "^", Mode.Signature | Mode.Application
+    bitwise_not = "~", Mode.Signature | Mode.Application
+    mulw = "mulw", Mode.Signature | Mode.Application
+    addw = "addw", Mode.Signature | Mode.Application
+    int = "int", Mode.Signature | Mode.Application
+    byte = "byte", Mode.Signature | Mode.Application
+    addr = "addr", Mode.Signature | Mode.Application
+    arg = "arg", Mode.Signature
+    txn = "txn", Mode.Signature | Mode.Application
+    global_ = "global", Mode.Signature | Mode.Application
+    gtxn = "gtxn", Mode.Signature | Mode.Application
+    load = "load", Mode.Signature | Mode.Application
+    store = "store", Mode.Signature | Mode.Application
+    txna = "txna", Mode.Signature | Mode.Application
+    gtxna = "gtxna", Mode.Signature | Mode.Application
+    bnz = "bnz", Mode.Signature | Mode.Application
+    bz = "bz", Mode.Signature | Mode.Application
+    b = "b", Mode.Signature | Mode.Application
+    return_ = "return", Mode.Signature | Mode.Application
+    pop = "pop", Mode.Signature | Mode.Application
+    dup = "dup", Mode.Signature | Mode.Application
+    dup2 = "dup2", Mode.Signature | Mode.Application
+    concat = "concat", Mode.Signature | Mode.Application
+    substring = "substring", Mode.Signature | Mode.Application
+    substring3 = "substring3", Mode.Signature | Mode.Application
+    balance = "balance", Mode.Application
+    app_opted_in = "app_opted_in", Mode.Application
+    app_local_get = "app_local_get", Mode.Application
+    app_local_get_ex = "app_local_get_ex", Mode.Application
+    app_global_get = "app_global_get", Mode.Application
+    app_global_get_ex = "app_global_get_ex", Mode.Application
+    app_local_put = "app_local_put", Mode.Application
+    app_global_put = "app_global_put", Mode.Application
+    app_local_del = "app_local_del", Mode.Application
+    app_global_del = "app_global_del", Mode.Application
+    asset_holding_get = "asset_holding_get", Mode.Application
+    asset_params_get = "asset_params_get", Mode.Application
+
+    def __new__(cls, value: str, mode: Mode):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        return obj
+
+    def __init__(self, value: str, mode: Mode):
+        self.mode = mode

--- a/pyteal/ir/tealcomponent.py
+++ b/pyteal/ir/tealcomponent.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..ast import ScratchSlot
+
+class TealComponent(ABC):
+
+    def getSlots(self) -> List['ScratchSlot']:
+        return []
+    
+    def assignSlot(self, slot: 'ScratchSlot', location: int):
+        pass
+    
+    @abstractmethod
+    def assemble(self) -> str:
+        pass
+
+    @abstractmethod
+    def __repr__(self) -> str:
+        pass
+
+    @abstractmethod
+    def __hash__(self) -> int:
+        pass
+
+    @abstractmethod
+    def __eq__(self, other: object) -> bool:
+        pass

--- a/pyteal/ir/teallabel.py
+++ b/pyteal/ir/teallabel.py
@@ -1,0 +1,20 @@
+from .tealcomponent import TealComponent
+
+class TealLabel(TealComponent):
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+    
+    def assemble(self) -> str:
+        return self.label + ":"
+    
+    def __repr__(self) -> str:
+        return "TealLabel({})".format(self.label.__repr__())
+    
+    def __hash__(self) -> int:
+        return self.label.__hash__()
+    
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TealLabel):
+            return False
+        return self.label == other.label

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -1,0 +1,54 @@
+from typing import cast, Union, List, TYPE_CHECKING
+
+from .tealcomponent import TealComponent
+from .ops import Op
+from ..errors import TealInternalError
+if TYPE_CHECKING:
+    from ..ast import ScratchSlot
+
+class TealOp(TealComponent):
+    
+    def __init__(self, op: Op, *args: Union[int, str, 'ScratchSlot']) -> None:
+        self.op = op
+        self.args = list(args)
+    
+    def getOp(self) -> Op:
+        return self.op
+    
+    def getSlots(self) -> List['ScratchSlot']:
+        from ..ast import ScratchSlot
+        return [arg for arg in self.args if isinstance(arg, ScratchSlot)]
+    
+    def assignSlot(self, slot: 'ScratchSlot', location: int):
+        for i, arg in enumerate(self.args):
+            if slot == arg:
+                self.args[i] = location
+
+    def assemble(self) -> str:
+        from ..ast import ScratchSlot
+        parts = [self.op.value]
+        for arg in self.args:
+            if isinstance(arg, ScratchSlot):
+                raise TealInternalError("Slot not assigned: {}".format(arg))
+            
+            if isinstance(arg, int):
+                parts.append(str(arg))
+            else:
+                parts.append(arg)
+
+        return " ".join(parts)
+    
+    def __repr__(self) -> str:
+        args = [self.op.__str__()]
+        for a in self.args:
+            args.append(a.__repr__())
+
+        return "TealOp({})".format(", ".join(args))
+    
+    def __hash__(self) -> int:
+        return (self.op, *self.args).__hash__()
+    
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TealOp):
+            return False
+        return self.op == other.op and self.args == other.args

--- a/pyteal/types.py
+++ b/pyteal/types.py
@@ -4,13 +4,17 @@ from enum import Enum
 from .errors import TealTypeError, TealInputError
 
 class TealType(Enum):
+    """Unsigned 64 bit integer type."""
     uint64 = 0
+    """Byte string type."""
     bytes = 1
+    """Any type that is not none."""
     anytype = 2
+    """Represents no value."""
     none = 3
 
 def require_type(actual, expected):
-    if actual != expected and (expected == TealType.none or (actual != TealType.anytype and expected != TealType.anytype)):
+    if actual != expected and (expected == TealType.none or actual == TealType.none or (actual != TealType.anytype and expected != TealType.anytype)):
         raise TealTypeError(actual, expected)
 
 def types_match(type1: TealType, type2: TealType) -> bool:

--- a/pyteal/util.py
+++ b/pyteal/util.py
@@ -30,7 +30,32 @@ def execute(args):
     return (stdout.decode("utf-8"), stderr.decode("utf-8"))
 
 def escapeStr(s: str) -> str:
+    """Escape a UTF-8 string for use in TEAL assembly.
+
+    Args:
+        s: A UTF-8 string to escape.
+
+    Returns:
+        An escaped version of the input string. This version will be surrounded in double quotes,
+        all special characters (such as \\n) will be escaped with additional backslashes, and all
+        Unicode characters beyond the latin-1 encoding will be encoded in hex escapes (e.g. \\xf0).
+    """
+    # The point of this conversion is to escape all special characters and turn all Unicode
+    # characters into hex-escaped characters in the input string.
+    #
+    # The first step breaks up large Unicode characters into multiple UTF-8 hex characters:
+    #     s_1 = s.encode("utf-8").decode("latin-1"), e.g. "\n 😀" => "\n ð\x9f\x98\x80"
+    #
+    # The next step escapes all special characters:
+    #     s_1.encode("unicode-escape").decode("latin-1"), e.g. "\n ð\x9f\x98\x80" => "\\n \\xf0\\x9f\\x98\\x80"
+    #
+    # If we skipped the first step we would end up with Unicode codepoints instead of hex escaped
+    # characters, which TEAL assembly cannot process:
+    #     s.encode("unicode-escape").decode("latin-1"), e.g. "\n 😀" => "\\n \\U0001f600'"
     s = s.encode("utf-8").decode("latin-1").encode("unicode-escape").decode("latin-1")
+
+    # Escape double quote characters (not covered by unicode-escape) but leave in single quotes
     s = s.replace("\"", "\\\"")
     
+    # Surround string in double quotes
     return "\"" + s + "\""

--- a/pyteal/util.py
+++ b/pyteal/util.py
@@ -28,3 +28,9 @@ def execute(args):
     stdout, stderr = process.communicate()
     
     return (stdout.decode("utf-8"), stderr.decode("utf-8"))
+
+def escapeStr(s: str) -> str:
+    s = s.encode("utf-8").decode("latin-1").encode("unicode-escape").decode("latin-1")
+    s = s.replace("\"", "\\\"")
+    
+    return "\"" + s + "\""

--- a/tests/compile_test.py
+++ b/tests/compile_test.py
@@ -20,7 +20,7 @@ def test_atomic_swap():
 
     atomic_swap = fee_cond.And(type_cond).And(recv_cond.Or(esc_cond))
 
-    a_teal = """#pragma version 1
+    a_teal = """#pragma version 2
 txn Fee
 int 1000
 <
@@ -53,7 +53,7 @@ int 3000
 ||
 &&"""
     reset_label_count()
-    assert compileTeal(atomic_swap) == a_teal
+    assert compileTeal(atomic_swap, Mode.Signature) == a_teal
 
 
 def test_periodic_payment():
@@ -82,7 +82,7 @@ def test_periodic_payment():
 
     periodic_pay_escrow = periodic_pay_core.And(periodic_pay_transfer.Or(periodic_pay_close))
 
-    p_teal = """#pragma version 1
+    p_teal = """#pragma version 2
 txn TypeEnum
 int 1
 ==
@@ -135,7 +135,7 @@ int 0
 ||
 &&"""
     reset_label_count()
-    assert compileTeal(periodic_pay_escrow) == p_teal
+    assert compileTeal(periodic_pay_escrow, Mode.Signature) == p_teal
 
 
 def test_split():
@@ -169,7 +169,7 @@ def test_split():
                    split_transfer,
                    split_close))
 
-    target = """#pragma version 1
+    target = """#pragma version 2
 txn TypeEnum
 int 1
 ==
@@ -196,9 +196,7 @@ txn FirstValid
 int 30000
 >
 &&
-int 1
-bnz l1
-pop
+b l1
 l0:
 gtxn 0 Sender
 gtxn 1 Sender
@@ -232,7 +230,7 @@ int 5000000
 l1:
 &&"""
     reset_label_count()
-    assert compileTeal(split) == target
+    assert compileTeal(split, Mode.Signature) == target
 
 
 def test_cond():
@@ -242,4 +240,4 @@ def test_cond():
 	core = Cond([Global.group_size()==Int(2), cond1],
 				[Global.group_size()==Int(3), cond2],
 				[Global.group_size()==Int(4), cond3])
-	compileTeal(core)
+	compileTeal(core, Mode.Signature)


### PR DESCRIPTION
This PR adds support for LogicSig v2 opcodes and features, including stateful TEAL applications. In addition to supporting new v2 opcodes, this PR also adds the following:
* `TxnType` enum
* `Pop` expression
* `Not` expression
* `BitwiseNot` expression
* `BitwiseAnd` expression
* `BitwiseOr` expression
* `BitwiseXor` expression
* `Neq` (not equal) expression
* `Assert` expression
* `ScratchSlot`, `ScratchLoad`, and `ScratchStore` objects/expressions for manipulating scratch space
* Testing `.type_of()` for all expressions
* More structured IR that consists of `List[TealComponent]`

Closes #5, closes #10.