### PR TITLE
Teal v2 docs code changes

### DIFF
--- a/examples/atomic_swap.py
+++ b/examples/atomic_swap.py
@@ -2,30 +2,40 @@
 
 from pyteal import *
 
-""" Atomic Swap
-"""
+"""Atomic Swap"""
+
 alice = Addr("6ZHGHH5Z5CTPCF5WCESXMGRSVK7QJETR63M3NY5FJCUYDHO57VTCMJOBGY")
 bob = Addr("7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M")
 secret = Bytes("base32", "23232323232323")
 timeout = 3000
 
 def htlc(tmpl_seller=alice,
-		 tmpl_buyer=bob,
-		 tmpl_fee=1000,
-		 tmpl_secret=secret,
-		 tmpl_hash_fn=Sha256,
-		 tmpl_timeout=timeout):
-	fee_cond = Txn.fee() < Int(tmpl_fee)
-	type_cond = Txn.type_enum() == Int(1)
-	recv_cond = And(Txn.close_remainder_to() == Global.zero_address(),
-					Txn.receiver() == tmpl_seller,
-					tmpl_hash_fn(Arg(0)) == tmpl_secret)
-	esc_cond = And(Txn.close_remainder_to()  == Global.zero_address(),
-				   Txn.receiver() == tmpl_buyer,
-				   Txn.first_valid() > Int(tmpl_timeout))
+         tmpl_buyer=bob,
+         tmpl_fee=1000,
+         tmpl_secret=secret,
+         tmpl_hash_fn=Sha256,
+         tmpl_timeout=timeout):
+    
+    fee_cond = Txn.fee() < Int(tmpl_fee)
+    type_cond = Txn.type_enum() == TxnType.Payment
 
-	return And(fee_cond,
-			   type_cond,
-			   Or(recv_cond, esc_cond))
+    recv_cond = And(
+        Txn.close_remainder_to() == Global.zero_address(),
+        Txn.receiver() == tmpl_seller,
+        tmpl_hash_fn(Arg(0)) == tmpl_secret
+    )
+    
+    esc_cond = And(
+        Txn.close_remainder_to() == Global.zero_address(),
+        Txn.receiver() == tmpl_buyer,
+        Txn.first_valid() > Int(tmpl_timeout)
+    )
 
-print(compileTeal(htlc(), Mode.Signature))
+    return And(
+        fee_cond,
+        type_cond,
+        Or(recv_cond, esc_cond)
+    )
+
+if __name__ == "__main__":
+    print(compileTeal(htlc(), Mode.Signature))

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,32 @@
+# This example is provided for informational purposes only and has not been audited for security.
+
+from pyteal import *
+
+"""Basic Bank"""
+
+def bank_for_account(receiver):
+    """Only allow receiver to withdraw funds from this contract account.
+    
+    Args:
+        receiver (str): Base 32 Algorand address of the receiver.
+    """
+
+    is_payment = Txn.type_enum() == TxnType.Payment
+    is_single_tx = Global.group_size() == Int(1)
+    is_correct_receiver = Txn.receiver() == Addr(receiver)
+    no_close_out_addr = Txn.close_remainder_to() == Global.zero_address()
+    no_rekey_addr = Txn.rekey_to() == Global.zero_address()
+    acceptable_fee = Txn.fee() <= Int(1000)
+
+    return And(
+        is_payment,
+        is_single_tx,
+        is_correct_receiver,
+        no_close_out_addr,
+        no_rekey_addr,
+        acceptable_fee
+    )
+
+if __name__ == "__main__":
+    program = bank_for_account("ZZAF5ARA4MEC5PVDOP64JM5O5MQST63Q2KOY2FLYFLXXD3PFSNJJBYAFZM")
+    print(compileTeal(program, Mode.Signature))

--- a/examples/basic.teal
+++ b/examples/basic.teal
@@ -1,0 +1,24 @@
+#pragma version 2
+txn TypeEnum
+int pay
+==
+global GroupSize
+int 1
+==
+&&
+txn Receiver
+addr ZZAF5ARA4MEC5PVDOP64JM5O5MQST63Q2KOY2FLYFLXXD3PFSNJJBYAFZM
+==
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn Fee
+int 1000
+<=
+&&

--- a/examples/periodic_payment.py
+++ b/examples/periodic_payment.py
@@ -2,31 +2,48 @@
 
 from pyteal import *
 
-#template variables
+"""Periodic Payment"""
+
 tmpl_fee = Int(1000)
-tmpl_period = Int(1000)
-tmpl_dur = Int(1000)
-tmpl_lease = Bytes("base64", "y9OJ5MRLCHQj8GqbikAUKMBI7hom+SOj8dlopNdNHXI=")
-tmpl_amt = Int(200000)
-tmpl_rcv = Addr("ZZAF5ARA4MEC5PVDOP64JM5O5MQST63Q2KOY2FLYFLXXD3PFSNJJBYAFZM")
+tmpl_period = Int(50)
+tmpl_dur = Int(5000)
+tmpl_lease = Bytes("base64", "023sdDE2")
+tmpl_amt = Int(2000)
+tmpl_rcv = Addr("6ZHGHH5Z5CTPCF5WCESXMGRSVK7QJETR63M3NY5FJCUYDHO57VTCMJOBGY")
+tmpl_timeout = Int(30000)
 
 def periodic_payment(tmpl_fee=tmpl_fee,
                      tmpl_period=tmpl_period,
                      tmpl_dur=tmpl_dur,
                      tmpl_lease=tmpl_lease,
                      tmpl_amt=tmpl_amt,
-                     tmpl_rcv=tmpl_rcv):
+                     tmpl_rcv=tmpl_rcv,
+                     tmpl_timeout=tmpl_timeout):
 
-    periodic_pay_core = And(Txn.type_enum() == Int(1),
-                            Txn.fee() <= tmpl_fee)
-    
-    periodic_pay_transfer = And(Txn.close_remainder_to() ==  Global.zero_address(),
-                                Txn.receiver() == tmpl_rcv,
-                                Txn.amount() == tmpl_amt,
-                                Txn.first_valid() % tmpl_period == Int(0),
-                                Txn.last_valid() == tmpl_dur + Txn.first_valid(),
-                                Txn.lease() == tmpl_lease)
+    periodic_pay_core = And(
+        Txn.type_enum() == TxnType.Payment,
+        Txn.fee() < tmpl_fee,
+        Txn.first_valid() % tmpl_period == Int(0),
+        Txn.last_valid() == tmpl_dur + Txn.first_valid(),
+        Txn.lease() == tmpl_lease
+    )
 
-    return And(periodic_pay_core, periodic_pay_transfer)
+    periodic_pay_transfer = And(
+        Txn.close_remainder_to() == Global.zero_address(),
+        Txn.receiver() == tmpl_rcv,
+        Txn.amount() == tmpl_amt
+    )
 
-# print(compileTeal(periodic_payment(), Mode.Signature))
+    periodic_pay_close = And(
+        Txn.close_remainder_to() == tmpl_rcv,
+        Txn.receiver() == Global.zero_address(),
+        Txn.first_valid() == tmpl_timeout,
+        Txn.amount() == Int(0)
+    )
+
+    periodic_pay_escrow = periodic_pay_core.And(periodic_pay_transfer.Or(periodic_pay_close))
+
+    return periodic_pay_escrow
+
+if __name__ == "__main__":
+    print(compileTeal(periodic_payment(), Mode.Signature))

--- a/examples/periodic_payment_deploy.py
+++ b/examples/periodic_payment_deploy.py
@@ -7,7 +7,7 @@ from periodic_payment import periodic_payment, tmpl_amt
 
 #--------- compile & send transaction using Goal and Python SDK ----------
 
-teal_source = compileTeal(periodic_payment())
+teal_source = compileTeal(periodic_payment(), Mode.Signature)
 
 # compile teal
 teal_file = str(uuid.uuid4()) + ".teal"

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -10,13 +10,14 @@ from .int import Int, EnumInt
 
 # properties
 from .arg import Arg
-from .txn import TxnType, TxnField, TxnExpr, TxnaExpr, Txn
-from .gtxn import GtxnExpr, GtxnaExpr, Gtxn
+from .txn import TxnType, TxnField, TxnExpr, TxnaExpr, TxnArray, TxnObject, Txn
+from .gtxn import GtxnExpr, GtxnaExpr, TxnGroup, Gtxn
 from .global_ import Global, GlobalField
 from .app import App, AppField, OnComplete
 from .asset import AssetHolding, AssetParam
 
 # meta
+from .array import Array
 from .tmpl import Tmpl
 from .nonce import Nonce
 

--- a/pyteal/ast/addr.py
+++ b/pyteal/ast/addr.py
@@ -22,3 +22,5 @@ class Addr(LeafExpr):
 
     def type_of(self):
         return TealType.bytes
+
+Addr.__module__ = "pyteal"

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -9,7 +9,7 @@ from .int import EnumInt
 from .global_ import Global
 
 class OnComplete:
-    """An enum of values that Txn.on_completion() may return."""
+    """An enum of values that :any:`TxnObject.on_completion()` may return."""
     NoOp = EnumInt("NoOp")
     OptIn = EnumInt("OptIn")
     CloseOut = EnumInt("CloseOut")
@@ -17,7 +17,10 @@ class OnComplete:
     UpdateApplication = EnumInt("UpdateApplication")
     DeleteApplication = EnumInt("DeleteApplication")
 
+OnComplete.__module__ = "pyteal"
+
 class AppField(Enum):
+    """Enum of app fields used to create :any:`App` objects."""
     optedIn = (Op.app_opted_in, TealType.uint64)
     localGet = (Op.app_local_get, TealType.anytype)
     localGetEx = (Op.app_local_get_ex, TealType.none)
@@ -37,6 +40,8 @@ class AppField(Enum):
     
     def type_of(self) -> TealType:
         return self.ret_type
+
+AppField.__module__ = "pyteal"
 
 class App(LeafExpr):
     """An expression related to applications."""
@@ -63,20 +68,20 @@ class App(LeafExpr):
         return self.field.type_of()
 
     @classmethod
-    def id(cls):
+    def id(cls) -> Global:
         """Get the ID of the current running application.
         
-        This is the same as Global.current_application_id().
+        This is the same as :any:`Global.current_application_id()`.
         """
         return Global.current_application_id()
 
     @classmethod
-    def optedIn(cls, account: Expr, app: Expr):
+    def optedIn(cls, account: Expr, app: Expr) -> 'App':
         """Check if an account has opted in for an application.
 
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
             app: The ID of the application being checked. Must evaluate to uint64.
         """
         require_type(account.type_of(), TealType.uint64)
@@ -84,12 +89,12 @@ class App(LeafExpr):
         return cls(AppField.optedIn, [account, app])
     
     @classmethod
-    def localGet(cls, account: Expr, key: Expr):
+    def localGet(cls, account: Expr, key: Expr) -> 'App':
         """Read from an account's local state for the current application.
 
         Args:
             account: An index into Txn.Accounts that corresponds to the account to read from. Must
-            evaluate to uint64.
+                evaluate to uint64.
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
         require_type(account.type_of(), TealType.uint64)
@@ -97,12 +102,12 @@ class App(LeafExpr):
         return cls(AppField.localGet, [account, key])
     
     @classmethod
-    def localGetEx(cls, account: Expr, app: Expr, key: Expr):
+    def localGetEx(cls, account: Expr, app: Expr, key: Expr) -> MaybeValue:
         """Read from an account's local state for an application.
 
         Args:
             account: An index into Txn.Accounts that corresponds to the account to read from. Must
-            evaluate to uint64.
+                evaluate to uint64.
             app: The ID of the application being checked. Must evaluate to uint64.
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
@@ -112,7 +117,7 @@ class App(LeafExpr):
         return MaybeValue(AppField.localGetEx.get_op(), TealType.anytype, args=[account, app, key])
 
     @classmethod
-    def globalGet(cls, key: Expr):
+    def globalGet(cls, key: Expr) -> 'App':
         """Read from the global state of the current application.
 
         Args:
@@ -122,12 +127,12 @@ class App(LeafExpr):
         return cls(AppField.globalGet, [key])
     
     @classmethod
-    def globalGetEx(cls, app: Expr, key: Expr):
+    def globalGetEx(cls, app: Expr, key: Expr) -> MaybeValue:
         """Read from the global state of an application.
 
         Args:
             app: An index into Txn.ForeignApps that corresponds to the application to read from.
-            Must evaluate to uint64.
+                Must evaluate to uint64.
             key: The key to read from the global application state. Must evaluate to bytes.
         """
         require_type(app.type_of(), TealType.uint64)
@@ -135,12 +140,12 @@ class App(LeafExpr):
         return MaybeValue(AppField.globalGetEx.get_op(), TealType.anytype, args=[app, key])
 
     @classmethod
-    def localPut(cls, account: Expr, key: Expr, value: Expr):
+    def localPut(cls, account: Expr, key: Expr, value: Expr) -> 'App':
         """Write to an account's local state for the current application.
 
         Args:
             account: An index into Txn.Accounts that corresponds to the account to write to. Must
-            evaluate to uint64.
+                evaluate to uint64.
             key: The key to write in the account's local state. Must evaluate to bytes.
             value: The value to write in the account's local state. Can evaluate to any type.
         """
@@ -150,7 +155,7 @@ class App(LeafExpr):
         return cls(AppField.localPut, [account, key, value])
     
     @classmethod
-    def globalPut(cls, key: Expr, value: Expr):
+    def globalPut(cls, key: Expr, value: Expr) -> 'App':
         """Write to the global state of the current application.
 
         Args:
@@ -162,12 +167,12 @@ class App(LeafExpr):
         return cls(AppField.globalPut, [key, value])
 
     @classmethod
-    def localDel(cls, account: Expr, key: Expr):
+    def localDel(cls, account: Expr, key: Expr) -> 'App':
         """Delete a key from an account's local state for the current application.
 
         Args:
             account: An index into Txn.Accounts that corresponds to the account from which the key
-            should be deleted. Must evaluate to uint64.
+                should be deleted. Must evaluate to uint64.
             key: The key to delete from the account's local state. Must evaluate to bytes.
         """
         require_type(account.type_of(), TealType.uint64)
@@ -175,7 +180,7 @@ class App(LeafExpr):
         return cls(AppField.localDel, [account, key])
     
     @classmethod
-    def globalDel(cls, key: Expr):
+    def globalDel(cls, key: Expr) -> 'App':
         """Delete a key from the global state of the current application.
 
         Args:
@@ -183,3 +188,5 @@ class App(LeafExpr):
         """
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.globalDel, [key])
+
+App.__module__ = "pyteal"

--- a/pyteal/ast/arg.py
+++ b/pyteal/ast/arg.py
@@ -10,7 +10,7 @@ class Arg(LeafExpr):
         """Get an argument for this program.
         
         Should only be used in signature verification mode. For application mode arguments, see
-        Txn.application_args.
+        :any:`TxnObject.application_args`.
 
         Args:
             index: The integer index of the argument to get. Must be between 0 and 255 inclusive.
@@ -31,3 +31,5 @@ class Arg(LeafExpr):
 
     def type_of(self):
         return TealType.bytes
+
+Arg.__module__ = "pyteal"

--- a/pyteal/ast/array.py
+++ b/pyteal/ast/array.py
@@ -14,3 +14,5 @@ class Array(ABC):
     def __getitem__(self, index: int):
         """Get the value at a given index in this array."""
         pass
+
+Array.__module__ = "pyteal"

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -29,3 +29,5 @@ class Assert(Expr):
 
     def type_of(self):
         return TealType.none
+
+Assert.__module__ = "pyteal"

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -9,12 +9,12 @@ from .maybe import MaybeValue
 class AssetHolding:
     
     @classmethod
-    def balance(cls, account: Expr, asset: Expr):
+    def balance(cls, account: Expr, asset: Expr) -> MaybeValue:
         """Get the amount of an asset held by an account.
 
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
             asset: The ID of the asset to get. Must evaluate to uint64.
         """
         require_type(account.type_of(), TealType.uint64)
@@ -22,137 +22,141 @@ class AssetHolding:
         return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetBalance"], args=[account, asset])
     
     @classmethod
-    def frozen(cls, account: Expr, asset: Expr):
+    def frozen(cls, account: Expr, asset: Expr) -> MaybeValue:
         """Check if an asset is frozen for an account.
 
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
             asset: The ID of the asset to check. Must evaluate to uint64.
         """
         require_type(account.type_of(), TealType.uint64)
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetFrozen"], args=[account, asset])
 
+AssetHolding.__module__ = "pyteal"
+
 class AssetParam:
 
     @classmethod
-    def total(cls, asset: Expr):
+    def total(cls, asset: Expr) -> MaybeValue:
         """Get the total number of units of an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetTotal"], args=[asset])
     
     @classmethod
-    def decimals(cls, asset: Expr):
+    def decimals(cls, asset: Expr) -> MaybeValue:
         """Get the number of decimals for an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDecimals"], args=[asset])
     
     @classmethod
-    def defaultFrozen(cls, asset: Expr):
+    def defaultFrozen(cls, asset: Expr) -> MaybeValue:
         """Check if an asset is frozen by default.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDefaultFrozen"], args=[asset])
     
     @classmethod
-    def unitName(cls, asset: Expr):
+    def unitName(cls, asset: Expr) -> MaybeValue:
         """Get the unit name of an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetUnitName"], args=[asset])
     
     @classmethod
-    def name(cls, asset: Expr):
+    def name(cls, asset: Expr) -> MaybeValue:
         """Get the name of an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetName"], args=[asset])
     
     @classmethod
-    def url(cls, asset: Expr):
+    def url(cls, asset: Expr) -> MaybeValue:
         """Get the URL of an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetURL"], args=[asset])
     
     @classmethod
-    def metadataHash(cls, asset: Expr):
+    def metadataHash(cls, asset: Expr) -> MaybeValue:
         """Get the arbitrary commitment for an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetMetadataHash"], args=[asset])
     
     @classmethod
-    def manager(cls, asset: Expr):
+    def manager(cls, asset: Expr) -> MaybeValue:
         """Get the manager commitment for an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetManager"], args=[asset])
     
     @classmethod
-    def reserve(cls, asset: Expr):
+    def reserve(cls, asset: Expr) -> MaybeValue:
         """Get the reserve address for an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetReserve"], args=[asset])
     
     @classmethod
-    def freeze(cls, asset: Expr):
+    def freeze(cls, asset: Expr) -> MaybeValue:
         """Get the freeze address for an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetFreeze"], args=[asset])
     
     @classmethod
-    def clawback(cls, asset: Expr):
+    def clawback(cls, asset: Expr) -> MaybeValue:
         """Get the clawback address for an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-            evaluate to uint64.
+                evaluate to uint64.
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetClawback"], args=[asset])
+
+AssetParam.__module__ = "pyteal"

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -24,7 +24,9 @@ class BinaryExpr(Expr):
     def type_of(self):
         return self.outputType
 
-def Add(left: Expr, right: Expr):
+BinaryExpr.__module__ = "pyteal"
+
+def Add(left: Expr, right: Expr) -> BinaryExpr:
     """Add two numbers.
     
     Produces left + right.
@@ -35,7 +37,7 @@ def Add(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.add, TealType.uint64, TealType.uint64, left, right)
 
-def Minus(left: Expr, right: Expr):
+def Minus(left: Expr, right: Expr) -> BinaryExpr:
     """Subtract two numbers.
     
     Produces left - right.
@@ -46,7 +48,7 @@ def Minus(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.minus, TealType.uint64, TealType.uint64, left, right)
 
-def Mul(left: Expr, right: Expr):
+def Mul(left: Expr, right: Expr) -> BinaryExpr:
     """Multiply two numbers.
     
     Produces left * right.
@@ -57,7 +59,7 @@ def Mul(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.mul, TealType.uint64, TealType.uint64, left, right)
 
-def Div(left: Expr, right: Expr):
+def Div(left: Expr, right: Expr) -> BinaryExpr:
     """Divide two numbers.
     
     Produces left / right.
@@ -68,7 +70,7 @@ def Div(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.div, TealType.uint64, TealType.uint64, left, right)
 
-def Mod(left: Expr, right: Expr):
+def Mod(left: Expr, right: Expr) -> BinaryExpr:
     """Modulo expression.
     
     Produces left % right.
@@ -79,8 +81,10 @@ def Mod(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.mod, TealType.uint64, TealType.uint64, left, right)
 
-def BitwiseAnd(left: Expr, right: Expr):
+def BitwiseAnd(left: Expr, right: Expr) -> BinaryExpr:
     """Bitwise and expression.
+
+    Produces left & right.
 
     Args:
         left: Must evaluate to uint64.
@@ -88,8 +92,10 @@ def BitwiseAnd(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.bitwise_and, TealType.uint64, TealType.uint64, left, right)
 
-def BitwiseOr(left: Expr, right: Expr):
+def BitwiseOr(left: Expr, right: Expr) -> BinaryExpr:
     """Bitwise or expression.
+
+    Produces left | right.
 
     Args:
         left: Must evaluate to uint64.
@@ -97,8 +103,10 @@ def BitwiseOr(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.bitwise_or, TealType.uint64, TealType.uint64, left, right)
 
-def BitwiseXor(left: Expr, right: Expr):
+def BitwiseXor(left: Expr, right: Expr) -> BinaryExpr:
     """Bitwise xor expression.
+
+    Produces left ^ right.
 
     Args:
         left: Must evaluate to uint64.
@@ -106,7 +114,7 @@ def BitwiseXor(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.bitwise_xor, TealType.uint64, TealType.uint64, left, right)
 
-def Eq(left: Expr, right: Expr):
+def Eq(left: Expr, right: Expr) -> BinaryExpr:
     """Equality expression.
     
     Checks if left == right.
@@ -117,7 +125,7 @@ def Eq(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.eq, right.type_of(), TealType.uint64, left, right)
 
-def Neq(left: Expr, right: Expr):
+def Neq(left: Expr, right: Expr) -> BinaryExpr:
     """Difference expression.
     
     Checks if left != right.
@@ -128,7 +136,7 @@ def Neq(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.neq, right.type_of(), TealType.uint64, left, right)
 
-def Lt(left: Expr, right: Expr):
+def Lt(left: Expr, right: Expr) -> BinaryExpr:
     """Less than expression.
     
     Checks if left < right.
@@ -139,7 +147,7 @@ def Lt(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.lt, TealType.uint64, TealType.uint64, left, right)
 
-def Le(left: Expr, right: Expr):
+def Le(left: Expr, right: Expr) -> BinaryExpr:
     """Less than or equal to expression.
     
     Checks if left <= right.
@@ -150,7 +158,7 @@ def Le(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.le, TealType.uint64, TealType.uint64, left, right)
 
-def Gt(left: Expr, right: Expr):
+def Gt(left: Expr, right: Expr) -> BinaryExpr:
     """Greater than expression.
     
     Checks if left > right.
@@ -161,7 +169,7 @@ def Gt(left: Expr, right: Expr):
     """
     return BinaryExpr(Op.gt, TealType.uint64, TealType.uint64, left, right)
 
-def Ge(left: Expr, right: Expr):
+def Ge(left: Expr, right: Expr) -> BinaryExpr:
     """Greater than or equal to expression.
     
     Checks if left >= right.

--- a/pyteal/ast/bytes.py
+++ b/pyteal/ast/bytes.py
@@ -13,14 +13,14 @@ class Bytes(LeafExpr):
         Depending on the encoding, there are different arguments to pass:
 
         For UTF-8 strings:
-            Pass the string as the only argument. For example, Bytes("content").
+            Pass the string as the only argument. For example, ``Bytes("content")``.
         For base16, base32, or base64 strings:
             Pass the base as the first argument and the string as the second argument. For example,
-            Bytes("base16", "636F6E74656E74"), Bytes("base32", "ORFDPQ6ARJK"),
-            Bytes("base64", "Y29udGVudA==").
+            ``Bytes("base16", "636F6E74656E74")``, ``Bytes("base32", "ORFDPQ6ARJK")``,
+            ``Bytes("base64", "Y29udGVudA==")``.
         Special case for base16:
             The prefix "0x" may be present in a base16 byte string. For example,
-            Bytes("base16", "0x636F6E74656E74").
+            ``Bytes("base16", "0x636F6E74656E74")``.
         """
         if len(args) == 1:
             self.base = "utf8"
@@ -58,3 +58,5 @@ class Bytes(LeafExpr):
 
     def type_of(self):
         return TealType.bytes
+
+Bytes.__module__ = "pyteal"

--- a/pyteal/ast/cond.py
+++ b/pyteal/ast/cond.py
@@ -22,10 +22,12 @@ class Cond(Expr):
         the value for this Cond expression. If no condition evalutes to a true value, the Cond
         expression produces an error and the TEAL program terminates.
         
-        For example:
-            Cond([Global.group_size() == Int(5), bid],
-                [Global.group_size() == Int(4), redeem],
-                [Global.group_size() == Int(1), wrapup])
+        Example:
+            .. code-block:: python
+
+                Cond([Global.group_size() == Int(5), bid],
+                    [Global.group_size() == Int(4), redeem],
+                    [Global.group_size() == Int(1), wrapup])
         """
 
         if len(argv) < 1:
@@ -91,3 +93,5 @@ class Cond(Expr):
         
     def type_of(self):
         return self.value_type
+
+Cond.__module__ = "pyteal"

--- a/pyteal/ast/ed25519verify.py
+++ b/pyteal/ast/ed25519verify.py
@@ -11,7 +11,7 @@ class Ed25519Verify(Expr):
         Args:
             data: The data signed by the public. Must evalutes to bytes.
             sig: The proposed 64 byte signature of ("ProgData" || program_hash || data). Must
-            evalute to bytes.
+                evalute to bytes.
             key: The 32 byte public key that produced the signature. Must evaluate to bytes.
         """
         require_type(data.type_of(), TealType.bytes)
@@ -33,3 +33,5 @@ class Ed25519Verify(Expr):
 
     def type_of(self):
         return TealType.uint64
+
+Ed25519Verify.__module__ = "pyteal"

--- a/pyteal/ast/err.py
+++ b/pyteal/ast/err.py
@@ -16,3 +16,5 @@ class Err(LeafExpr):
 
     def type_of(self):
         return TealType.none
+
+Err.__module__ = "pyteal"

--- a/pyteal/ast/expr.py
+++ b/pyteal/ast/expr.py
@@ -87,6 +87,8 @@ class Expr(ABC):
         """Take the logical And of this expression and another one.
         
         This expression must evaluate to uint64.
+
+        This is the same as using :func:`And()` with two arguments.
         """
         from .naryexpr import And
         return And(self, other)
@@ -95,6 +97,10 @@ class Expr(ABC):
         """Take the logical Or of this expression and another one.
         
         This expression must evaluate to uint64.
+
+        This is the same as using :func:`Or()` with two arguments.
         """
         from .naryexpr import Or
         return Or(self, other)
+
+Expr.__module__ = "pyteal"

--- a/pyteal/ast/global_.py
+++ b/pyteal/ast/global_.py
@@ -23,6 +23,8 @@ class GlobalField(Enum):
     def type_of(self) -> TealType:
         return self.ret_type
 
+GlobalField.__module__ = "pyteal"
+
 class Global(LeafExpr):
     """An expression that accesses a global property."""
 
@@ -39,27 +41,27 @@ class Global(LeafExpr):
         return self.field.type_of()
 
     @classmethod
-    def min_txn_fee(cls):
+    def min_txn_fee(cls) -> 'Global':
         """Get the minumum transaction fee in micro Algos."""
         return cls(GlobalField.min_txn_fee)
 
     @classmethod
-    def min_balance(cls):
+    def min_balance(cls) -> 'Global':
         """Get the minumum balance in micro Algos."""
         return cls(GlobalField.min_balance)
 
     @classmethod
-    def max_txn_life(cls):
+    def max_txn_life(cls) -> 'Global':
         """Get the maximum number of rounds a transaction can have."""
         return cls(GlobalField.max_txn_life)
 
     @classmethod
-    def zero_address(cls):
+    def zero_address(cls) -> 'Global':
         """Get the 32 byte zero address."""
         return cls(GlobalField.zero_address)
 
     @classmethod
-    def group_size(cls):
+    def group_size(cls) -> 'Global':
         """Get the number of transactions in this atomic transaction group.
         
         This will be at least 1.
@@ -67,25 +69,27 @@ class Global(LeafExpr):
         return cls(GlobalField.group_size)
 
     @classmethod
-    def logic_sig_version(cls):
+    def logic_sig_version(cls) -> 'Global':
         """Get the maximum supported TEAL version."""
         return cls(GlobalField.logic_sig_version)
     
     @classmethod
-    def round(cls):
+    def round(cls) -> 'Global':
         """Get the current round number."""
         return cls(GlobalField.round)
     
     @classmethod
-    def latest_timestamp(cls):
+    def latest_timestamp(cls) -> 'Global':
         """Get the latest confirmed block UNIX timestamp.
         
         Fails if negative."""
         return cls(GlobalField.latest_timestamp)
     
     @classmethod
-    def current_application_id(cls):
+    def current_application_id(cls) -> 'Global':
         """Get the ID of the current application executing.
         
         Fails if no application is executing."""
         return cls(GlobalField.current_app_id)
+
+Global.__module__ = "pyteal"

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -20,6 +20,8 @@ class GtxnExpr(TxnExpr):
     def __teal__(self):
         return [TealOp(Op.gtxn, self.txnIndex, self.field.arg_name)]
 
+GtxnExpr.__module__ = "pyteal"
+
 class GtxnaExpr(TxnaExpr):
     """An expression that accesses a transaction array field from a transaction in the current group."""
 
@@ -33,6 +35,8 @@ class GtxnaExpr(TxnaExpr):
     def __teal__(self):
         return [TealOp(Op.gtxna, self.txnIndex, self.field.arg_name, self.index)]
 
+GtxnaExpr.__module__ = "pyteal"
+
 class TxnGroup:
     """Represents a group of transactions."""
 
@@ -41,4 +45,8 @@ class TxnGroup:
             raise TealInputError("Invalid Gtxn index {}, shoud be in [0, {})".format(txnIndex, MAX_GROUP_SIZE))
         return TxnObject(lambda field: GtxnExpr(txnIndex, field), lambda field, index: GtxnaExpr(txnIndex, field, index))
 
+TxnGroup.__module__ = "pyteal"
+
 Gtxn: TxnGroup = TxnGroup()
+
+Gtxn.__module__ = "pyteal"

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -17,7 +17,7 @@ class If(Expr):
             cond: The condition to check. Must evaluate to uint64.
             thenBranch: Expression to evaluate if the condition is true.
             elseBranch (optional): Expression to evaluate if the condition is false. Must evaluate
-            to the same type as thenBranch, if provided. Defaults to None.
+                to the same type as thenBranch, if provided. Defaults to None.
         """
         require_type(cond.type_of(), TealType.uint64)
 
@@ -61,3 +61,5 @@ class If(Expr):
 
     def type_of(self):
         return self.thenBranch.type_of()
+
+If.__module__ = "pyteal"

--- a/pyteal/ast/int.py
+++ b/pyteal/ast/int.py
@@ -13,7 +13,7 @@ class Int(LeafExpr):
 
         Args:
             value: The integer value this uint64 will represent. Must be a positive value less than
-            2**64.
+                2**64.
         """
         if type(value) is not int:
             raise TealInputError("invalid input type {} to Int".format(type(value))) 
@@ -30,6 +30,8 @@ class Int(LeafExpr):
 
     def type_of(self):
         return TealType.uint64
+
+Int.__module__ = "pyteal"
 
 class EnumInt(LeafExpr):
     """An expression that represents uint64 enum values."""
@@ -50,3 +52,5 @@ class EnumInt(LeafExpr):
 
     def type_of(self):
         return TealType.uint64
+
+EnumInt.__module__ = "pyteal"

--- a/pyteal/ast/leafexpr.py
+++ b/pyteal/ast/leafexpr.py
@@ -3,3 +3,5 @@ from .expr import Expr
 class LeafExpr(Expr):
     """Leaf expression base class."""
     pass
+
+LeafExpr.__module__ = "pyteal"

--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -78,3 +78,5 @@ class MaybeValue(LeafExpr):
 
     def type_of(self):
         return TealType.none
+
+MaybeValue.__module__ = "pyteal"

--- a/pyteal/ast/naryexpr.py
+++ b/pyteal/ast/naryexpr.py
@@ -40,17 +40,22 @@ class NaryExpr(Expr):
     def type_of(self):
         return self.outputType
 
-def And(*args: Expr):
+NaryExpr.__module__ = "pyteal"
+
+def And(*args: Expr) -> NaryExpr:
     """Logical and expression.
 
     Produces 1 if all arguments are nonzero. Otherwise produces 0.
 
     All arguments must be PyTeal expressions that evaluate to uint64, and there must be at least two
     arguments.
+
+    Example:
+        ``And(Txn.amount() == Int(500), Txn.fee() <= Int(10))``
     """
     return NaryExpr(Op.logic_and, TealType.uint64, TealType.uint64, args)
 
-def Or(*args: Expr):
+def Or(*args: Expr) -> NaryExpr:
     """Logical or expression.
 
     Produces 1 if any argument is nonzero. Otherwise produces 0.
@@ -60,7 +65,7 @@ def Or(*args: Expr):
     """
     return NaryExpr(Op.logic_or, TealType.uint64, TealType.uint64, args)
 
-def Concat(*args: Expr):
+def Concat(*args: Expr) -> NaryExpr:
     """Concatenate byte strings.
     
     Produces a new byte string consisting of the contents of each of the passed in byte strings
@@ -68,5 +73,8 @@ def Concat(*args: Expr):
 
     All arguments must be PyTeal expressions that evaluate to bytes, and there must be at least two
     arguments.
+
+    Example:
+        ``Concat(Bytes("hello"), Bytes(" "), Bytes("world"))``
     """
     return NaryExpr(Op.concat, TealType.bytes, TealType.bytes, args)

--- a/pyteal/ast/nonce.py
+++ b/pyteal/ast/nonce.py
@@ -40,3 +40,5 @@ class Nonce(Expr):
 
     def type_of(self):
         return self.child.type_of()
+
+Nonce.__module__ = "pyteal"

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -19,7 +19,7 @@ class ScratchSlot:
 
         Args:
             type (optional): The type being loaded from this slot, if known. Defaults to
-            TealType.anytype.
+                TealType.anytype.
         """
         return ScratchLoad(self, type)
     
@@ -34,6 +34,8 @@ class ScratchSlot:
     def __hash__(self):
         return hash(self.id)
 
+ScratchSlot.__module__ = "pyteal"
+
 class ScratchLoad(Expr):
     """Expression to load a value from scratch space."""
 
@@ -43,7 +45,7 @@ class ScratchLoad(Expr):
         Args:
             slot: The slot to load the value from.
             type (optional): The type being loaded from this slot, if known. Defaults to
-            TealType.anytype.
+                TealType.anytype.
         """
         self.slot = slot
         self.type = type
@@ -57,6 +59,8 @@ class ScratchLoad(Expr):
 
     def type_of(self):
         return self.type
+
+ScratchLoad.__module__ = "pyteal"
 
 class ScratchStore(Expr):
     """Expression to store a value in scratch space."""
@@ -78,3 +82,5 @@ class ScratchStore(Expr):
 
     def type_of(self):
         return TealType.none
+
+ScratchStore.__module__ = "pyteal"

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -14,7 +14,15 @@ class Seq(Expr):
 
         Args:
             exprs: The expressions to include in this sequence. All expressions that are not the
-            final one in this list must not return any values.
+                final one in this list must not return any values.
+        
+        Example:
+            .. code-block:: python
+            
+                Seq([
+                    App.localPut(Bytes("key"), Bytes("value")),
+                    Int(1)
+                ])
         """
         if len(exprs) == 0:
             raise TealInputError("Seq requires children.")
@@ -41,3 +49,5 @@ class Seq(Expr):
         
     def type_of(self):
         return self.args[-1].type_of()
+
+Seq.__module__ = "pyteal"

--- a/pyteal/ast/substring.py
+++ b/pyteal/ast/substring.py
@@ -35,3 +35,5 @@ class Substring(Expr):
     
     def type_of(self):
         return TealType.bytes
+
+Substring.__module__ = "pyteal"

--- a/pyteal/ast/tmpl.py
+++ b/pyteal/ast/tmpl.py
@@ -26,8 +26,8 @@ class Tmpl(LeafExpr):
         """Create a new Int template.
 
         Args:
-            placeholder: The name to use for this template variable. Must start with "TMPL_" and
-            only consist of uppercase alphanumeric characters and underscores.
+            placeholder: The name to use for this template variable. Must start with `TMPL_` and
+                only consist of uppercase alphanumeric characters and underscores.
         """
         return cls(Op.int, TealType.uint64, placeholder)
 
@@ -36,16 +36,19 @@ class Tmpl(LeafExpr):
         """Create a new Bytes template.
 
         Args:
-            placeholder: The name to use for this template variable. Must start with "TMPL_" and
-            only consist of uppercase alphanumeric characters and underscores.
+            placeholder: The name to use for this template variable. Must start with `TMPL_` and
+                only consist of uppercase alphanumeric characters and underscores.
         """
         return cls(Op.byte, TealType.bytes, placeholder)
 
     @classmethod
     def Addr(cls, placeholder: str):
         """Create a new Addr template.
+        
         Args:
-            placeholder: The name to use for this template variable. Must start with "TMPL_" and
-            only consist of uppercase alphanumeric characters and underscores.
+            placeholder: The name to use for this template variable. Must start with `TMPL_` and
+                only consist of uppercase alphanumeric characters and underscores.
         """
         return cls(Op.addr, TealType.bytes, placeholder)
+
+Tmpl.__module__ = "pyteal"

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -18,6 +18,8 @@ class TxnType:
     AssetFreeze = EnumInt("afrz")
     ApplicationCall = EnumInt("appl")
 
+TxnType.__module__ = "pyteal"
+
 class TxnField(Enum):
     sender = (0, "Sender", TealType.bytes)
     fee = (1, "Fee", TealType.uint64)
@@ -76,6 +78,8 @@ class TxnField(Enum):
     def type_of(self) -> TealType:
         return self.ret_type
 
+TxnField.__module__ = "pyteal"
+
 class TxnExpr(LeafExpr):
     """An expression that accesses a transaction field from the current transaction."""
 
@@ -90,6 +94,8 @@ class TxnExpr(LeafExpr):
     
     def type_of(self):
         return self.field.type_of()
+
+TxnExpr.__module__ = "pyteal"
 
 class TxnaExpr(LeafExpr):
     """An expression that accesses a transaction array field from the current transaction."""
@@ -106,6 +112,8 @@ class TxnaExpr(LeafExpr):
     
     def type_of(self):
         return self.field.type_of()
+
+TxnaExpr.__module__ = "pyteal"
 
 class TxnArray(Array):
     """Represents a transaction array field."""
@@ -124,6 +132,8 @@ class TxnArray(Array):
 
         return self.txnObject.txnaType(self.accessField, index)
 
+TxnArray.__module__ = "pyteal"
+
 class TxnObject:
     """Represents a transaction and its fields."""
 
@@ -132,92 +142,186 @@ class TxnObject:
         self.txnaType = txnaType
 
     def sender(self) -> TxnExpr:
-        """Get the 32 byte address of the sender."""
+        """Get the 32 byte address of the sender.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#sender
+        """
         return self.txnType(TxnField.sender)
    
     def fee(self) -> TxnExpr:
-        """Get the transaction fee in micro Algos."""
+        """Get the transaction fee in micro Algos.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#fee
+        """
         return self.txnType(TxnField.fee)
 
     def first_valid(self) -> TxnExpr:
-        """Get the first valid round number."""
+        """Get the first valid round number.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#firstvalid
+        """
         return self.txnType(TxnField.first_valid)
    
     def last_valid(self) -> TxnExpr:
-        """Get the last valid round number."""
+        """Get the last valid round number.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#lastvalid
+        """
         return self.txnType(TxnField.last_valid)
 
     def note(self) -> TxnExpr:
-        """Get the transaction note."""
+        """Get the transaction note.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#note
+        """
         return self.txnType(TxnField.note)
 
     def lease(self) -> TxnExpr:
-        """Get the transaction lease."""
+        """Get the transaction lease.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#lease
+        """
         return self.txnType(TxnField.lease)
 
     def receiver(self) -> TxnExpr:
-        """Get the 32 byte address of the receiver."""
+        """Get the 32 byte address of the receiver.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.Payment`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#receiver
+        """
         return self.txnType(TxnField.receiver)
 
     def amount(self) -> TxnExpr:
-        """Get the amount of the transaction in micro Algos."""
+        """Get the amount of the transaction in micro Algos.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.Payment`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#amount
+        """
         return self.txnType(TxnField.amount)
 
     def close_remainder_to(self) -> TxnExpr:
-        """Get the 32 byte address of the CloseRemainderTo field."""
+        """Get the 32 byte address of the CloseRemainderTo field.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.Payment`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#closeremainderto
+        """
         return self.txnType(TxnField.close_remainder_to)
 
     def vote_pk(self) -> TxnExpr:
+        """Get the root participation public key.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.KeyRegistration`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#votepk
+        """
         return self.txnType(TxnField.vote_pk)
 
     def selection_pk(self) -> TxnExpr:
+        """Get the VRF public key.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.KeyRegistration`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#selectionpk
+        """
         return self.txnType(TxnField.selection_pk)
 
     def vote_first(self) -> TxnExpr:
+        """Get the first round that the participation key is valid.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.KeyRegistration`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#votefirst
+        """
         return self.txnType(TxnField.vote_first)
 
     def vote_last(self) -> TxnExpr:
+        """Get the last round that the participation key is valid.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.KeyRegistration`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#votelast
+        """
         return self.txnType(TxnField.vote_last)
 
     def vote_key_dilution(self) -> TxnExpr:
+        """Get the dilution for the 2-level participation key.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.KeyRegistration`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#votekeydilution
+        """
         return self.txnType(TxnField.vote_key_dilution)
 
     def type(self) -> TxnExpr:
+        """Get the type of this transaction as a byte string.
+        
+        In most cases it is preferable to use :any:`type_enum()` instead.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#type
+        """
         return self.txnType(TxnField.type)
 
     def type_enum(self) -> TxnExpr:
         """Get the type of this transaction.
         
-        See the TxnType enum for possible values.
+        See :any:`TxnType` for possible values.
         """
         return self.txnType(TxnField.type_enum)
 
     def xfer_asset(self) -> TxnExpr:
-        """The ID of the asset being transferred."""
+        """Get the ID of the asset being transferred.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetTransfer`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#xferasset
+        """
         return self.txnType(TxnField.xfer_asset)
 
     def asset_amount(self) -> TxnExpr:
-        """The the amount of the asset being transferred, measured in the asset's units."""
+        """Get the amount of the asset being transferred, measured in the asset's units.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetTransfer`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#assetamount
+        """
         return self.txnType(TxnField.asset_amount)
 
     def asset_sender(self) -> TxnExpr:
         """Get the 32 byte address of the subject of clawback.
         
-        The transaction will clawback of all of an asset from this address if the transaction sender
-        is the clawback address of the asset.
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetTransfer`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#assetsender
         """
         return self.txnType(TxnField.asset_sender)
 
     def asset_receiver(self) -> TxnExpr:
+        """Get the recipient of the asset transfer.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetTransfer`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#assetreceiver
+        """
         return self.txnType(TxnField.asset_receiver)
 
     def asset_close_to(self) -> TxnExpr:
+        """Get the closeout address of the asset transfer.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetTransfer`.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#assetcloseto
+        """
         return self.txnType(TxnField.asset_close_to)
 
     def group_index(self) -> TxnExpr:
         """Get the position of the transaction within the atomic transaction group.
         
         A stand-alone transaction is implictly element 0 in a group of 1.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#group
         """
         return self.txnType(TxnField.group_index)
 
@@ -226,93 +330,181 @@ class TxnObject:
         return self.txnType(TxnField.tx_id)
 
     def application_id(self) -> TxnExpr:
-        """Get the application ID from the ApplicationCall portion of the transaction."""
+        """Get the application ID from the ApplicationCall portion of the current transaction.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall`.
+        """
         return self.txnType(TxnField.application_id)
 
     def on_completion(self) -> TxnExpr:
-        """Get the on completion action from the ApplicationCall portion of the transaction."""
+        """Get the on completion action from the ApplicationCall portion of the transaction.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall`.
+        """
         return self.txnType(TxnField.on_completion)
 
     def approval_program(self) -> TxnExpr:
-        """Get the approval program."""
+        """Get the approval program.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall`.
+        """
         return self.txnType(TxnField.approval_program)
 
     def clear_state_program(self) -> TxnExpr:
-        """Get the clear state program."""
+        """Get the clear state program.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall`.
+        """
         return self.txnType(TxnField.clear_state_program)
 
     def rekey_to(self) -> TxnExpr:
-        """Get the sender's new 32 byte AuthAddr"""
+        """Get the sender's new 32 byte AuthAddr.
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#rekeyto
+        """
         return self.txnType(TxnField.rekey_to)
 
     def config_asset(self) -> TxnExpr:
-        """Get the asset ID in asset config transaction."""
+        """Get the asset ID in asset config transaction.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#configasset
+        """
         return self.txnType(TxnField.config_asset)
 
     def config_asset_total(self) -> TxnExpr:
-        """Get the total number of units of this asset created."""
+        """Get the total number of units of this asset created.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#total"""
         return self.txnType(TxnField.config_asset_total)
 
     def config_asset_decimals(self) -> TxnExpr:
-        """Get the number of digits to display after the decimal place when displaying the asset."""
+        """Get the number of digits to display after the decimal place when displaying the asset.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#decimals
+        """
         return self.txnType(TxnField.config_asset_decimals)
 
     def config_asset_default_frozen(self) -> TxnExpr:
-        """Check if the asset's slots are frozen by default or not."""
+        """Check if the asset's slots are frozen by default or not.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#defaultfrozen"""
         return self.txnType(TxnField.config_asset_default_frozen)
 
     def config_asset_unit_name(self) -> TxnExpr:
-        """Get the unit name of the asset."""
+        """Get the unit name of the asset.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#unitname"""
         return self.txnType(TxnField.config_asset_unit_name)
 
     def config_asset_name(self) -> TxnExpr:
-        """Get the asset name."""
+        """Get the asset name.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#assetname"""
         return self.txnType(TxnField.config_asset_name)
 
     def config_asset_url(self) -> TxnExpr:
-        """Get the asset URL."""
+        """Get the asset URL.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#url"""
         return self.txnType(TxnField.config_asset_url)
 
     def config_asset_metadata_hash(self) -> TxnExpr:
-        """Get the 32 byte commitment to some unspecified asset metdata."""
+        """Get the 32 byte commitment to some unspecified asset metdata.
+
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#metadatahash
+        """
         return self.txnType(TxnField.config_asset_metadata_hash)
 
     def config_asset_manager(self) -> TxnExpr:
-        """Get the 32 byte asset manager address."""
+        """Get the 32 byte asset manager address.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#manageraddr"""
         return self.txnType(TxnField.config_asset_manager)
 
     def config_asset_reserve(self) -> TxnExpr:
-        """Get the 32 byte asset reserve address."""
+        """Get the 32 byte asset reserve address.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#reserveaddr"""
         return self.txnType(TxnField.config_asset_reserve)
 
     def config_asset_freeze(self) -> TxnExpr:
-        """Get the 32 byte asset freeze address."""
+        """Get the 32 byte asset freeze address.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#freezeaddr"""
         return self.txnType(TxnField.config_asset_freeze)
 
     def config_asset_clawback(self) -> TxnExpr:
-        """Get the 32 byte asset clawback address."""
+        """Get the 32 byte asset clawback address.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetConfig`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#clawbackaddr"""
         return self.txnType(TxnField.config_asset_clawback)
 
     def freeze_asset(self) -> TxnExpr:
-        """Get the asset ID being frozen or un-frozen."""
+        """Get the asset ID being frozen or un-frozen.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetFreeze`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#freezeasset"""
         return self.txnType(TxnField.freeze_asset)
 
     def freeze_asset_account(self) -> TxnExpr:
-        """Get the 32 byte address of the account whose asset slot is being frozen or un-frozen."""
+        """Get the 32 byte address of the account whose asset slot is being frozen or un-frozen.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetFreeze`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#freezeaccount"""
         return self.txnType(TxnField.freeze_asset_account)
 
     def freeze_asset_frozen(self) -> TxnExpr:
-        """Get the new frozen value for the asset."""
+        """Get the new frozen value for the asset.
+        
+        Only set when :any:`type_enum()` is :any:`TxnType.AssetFreeze`.
+
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#assetfrozen"""
         return self.txnType(TxnField.freeze_asset_frozen)
 
     @property
     def application_args(self) -> TxnArray:
-        """Application arguments array."""
+        """Application call arguments array.
+        
+        :type: TxnArray
+        """
         return TxnArray(self, TxnField.application_args, TxnField.num_app_args)
 
     @property
     def accounts(self) -> TxnArray:
-        """Accounts array."""
+        """Application call accounts array.
+        
+        :type: TxnArray
+        """
         return TxnArray(self, TxnField.accounts, TxnField.num_accounts)
 
+TxnObject.__module__ = "pyteal"
+
 Txn: TxnObject = TxnObject(TxnExpr, TxnaExpr)
+
+Txn.__module__ = "pyteal"

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -22,50 +22,55 @@ class UnaryExpr(Expr):
     def type_of(self):
         return self.outputType
 
-def Btoi(arg: Expr):
+UnaryExpr.__module__ = "pyteal"
+
+def Btoi(arg: Expr) -> UnaryExpr:
     """Convert a byte string to a uint64."""
     return UnaryExpr(Op.btoi, TealType.bytes, TealType.uint64, arg)
 
-def Itob(arg: Expr):
+def Itob(arg: Expr) -> UnaryExpr:
     """Convert a uint64 string to a byte string."""
     return UnaryExpr(Op.itob, TealType.uint64, TealType.bytes, arg)
 
-def Len(arg: Expr):
+def Len(arg: Expr) -> UnaryExpr:
     """Get the length of a byte string."""
     return UnaryExpr(Op.len, TealType.bytes, TealType.uint64, arg)
 
-def Sha256(arg: Expr):
+def Sha256(arg: Expr) -> UnaryExpr:
     """Get the SHA-256 hash of a byte string."""
     return UnaryExpr(Op.sha256, TealType.bytes, TealType.bytes, arg)
 
-def Sha512_256(arg: Expr):
+def Sha512_256(arg: Expr) -> UnaryExpr:
     """Get the SHA-512/256 hash of a byte string."""
     return UnaryExpr(Op.sha512_256, TealType.bytes, TealType.bytes, arg)
 
-def Keccak256(arg: Expr):
+def Keccak256(arg: Expr) -> UnaryExpr:
     """Get the KECCAK-256 hash of a byte string."""
     return UnaryExpr(Op.keccak256, TealType.bytes, TealType.bytes, arg)
 
-def Not(arg: Expr):
+def Not(arg: Expr) -> UnaryExpr:
     """Get the logical inverse of a uint64.
 
     If the argument is 0, then this will produce 1. Otherwise this will produce 0.
     """
     return UnaryExpr(Op.logic_not, TealType.uint64, TealType.uint64, arg)
 
-def BitwiseNot(arg: Expr):
-    """Get the bitwise inverse of a uint64."""
+def BitwiseNot(arg: Expr) -> UnaryExpr:
+    """Get the bitwise inverse of a uint64.
+    
+    Produces ~arg.
+    """
     return UnaryExpr(Op.bitwise_not, TealType.uint64, TealType.uint64, arg)
 
-def Pop(arg: Expr):
+def Pop(arg: Expr) -> UnaryExpr:
     """Pop a value from the stack."""
     return UnaryExpr(Op.pop, TealType.anytype, TealType.none, arg)
 
-def Return(arg: Expr):
-    """Immediately exit the program using the last value on stack as the success value."""
+def Return(arg: Expr) -> UnaryExpr:
+    """Immediately exit the program with the given success value."""
     return UnaryExpr(Op.return_, TealType.uint64, TealType.none, arg)
 
-def Balance(arg: Expr):
+def Balance(arg: Expr) -> UnaryExpr:
     """Get the balance of a user in micro Algos.
 
     Argument must be an index into Txn.Accounts that corresponds to the account to read from. It

--- a/pyteal/errors.py
+++ b/pyteal/errors.py
@@ -7,6 +7,8 @@ class TealInternalError(Exception):
     def __str__(self):
         return self.message
 
+TealInternalError.__module__ = "pyteal"
+
 class TealTypeError(Exception):
 
     def __init__(self, actual, expected):
@@ -15,6 +17,8 @@ class TealTypeError(Exception):
     def __str__(self):
         return self.message
 
+TealTypeError.__module__ = "pyteal"
+
 class TealInputError(Exception):
 
     def __init__(self, msg):
@@ -22,3 +26,5 @@ class TealInputError(Exception):
 
     def __str__(self):
         return self.message
+
+TealInputError.__module__ = "pyteal"

--- a/pyteal/ir/ops.py
+++ b/pyteal/ir/ops.py
@@ -1,10 +1,16 @@
 from enum import Enum, Flag, auto
 
 class Mode(Flag):
+    """Enum of program running modes."""
+    
     Signature = auto()
     Application = auto()
 
+Mode.__module__ = "pyteal"
+
 class Op(Enum):
+    """Enum of program opcodes."""
+
     err = "err", Mode.Signature | Mode.Application
     sha256 = "sha256", Mode.Signature | Mode.Application
     keccak256 = "keccak256", Mode.Signature | Mode.Application
@@ -74,3 +80,5 @@ class Op(Enum):
 
     def __init__(self, value: str, mode: Mode):
         self.mode = mode
+
+Op.__module__ = "pyteal"

--- a/pyteal/ir/tealcomponent.py
+++ b/pyteal/ir/tealcomponent.py
@@ -27,3 +27,5 @@ class TealComponent(ABC):
     @abstractmethod
     def __eq__(self, other: object) -> bool:
         pass
+
+TealComponent.__module__ = "pyteal"

--- a/pyteal/ir/teallabel.py
+++ b/pyteal/ir/teallabel.py
@@ -18,3 +18,5 @@ class TealLabel(TealComponent):
         if not isinstance(other, TealLabel):
             return False
         return self.label == other.label
+
+TealLabel.__module__ = "pyteal"

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -52,3 +52,5 @@ class TealOp(TealComponent):
         if not isinstance(other, TealOp):
             return False
         return self.op == other.op and self.args == other.args
+
+TealOp.__module__ = "pyteal"

--- a/pyteal/types.py
+++ b/pyteal/types.py
@@ -4,14 +4,21 @@ from enum import Enum
 from .errors import TealTypeError, TealInputError
 
 class TealType(Enum):
+    """Teal type enum."""
+
     """Unsigned 64 bit integer type."""
     uint64 = 0
+
     """Byte string type."""
     bytes = 1
+    
     """Any type that is not none."""
     anytype = 2
+    
     """Represents no value."""
     none = 3
+
+TealType.__module__ = "pyteal"
 
 def require_type(actual, expected):
     if actual != expected and (expected == TealType.none or actual == TealType.none or (actual != TealType.anytype and expected != TealType.anytype)):


### PR DESCRIPTION
Changes to code for the new TEAL v2 documentation.

Note: I set all external types `.__module__` property to `"pyteal"` so that Sphinx shows `pyteal` as the parent package, giving us names like `pyteal.Assert` instead of `pyteal.ast.assert.Assert`. In addition to this Sphinx shows all the types in a single list, instead of breaking up our documentation based on submodules. I believe this change is benign, but if it looks suspicious I can look into conditionally including this code only when the documentation is being generated.