### PR TITLE
Add missing Txn field

### DIFF
--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -142,6 +142,12 @@ class TxnObject:
     def first_valid(self) -> TxnExpr:
         """Get the first valid round number."""
         return self.txnType(TxnField.first_valid)
+    
+    def first_valid_time(self) -> TxnExpr:
+        """Causes the program to fail.
+        
+        Reserved for future use."""
+        return self.txnType(TxnField.first_valid_time)
    
     def last_valid(self) -> TxnExpr:
         """Get the last valid round number."""


### PR DESCRIPTION
`Txn.first_valid_time` somehow got removed when updating to TEAL v2