### PR TITLE
Remove travis token from build status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyTeal: Algorand Smart Contracts in Python
 
-[![Build Status](https://travis-ci.com/algorand/pyteal.svg?token=B9eSse5TZikdgKBemvq3&branch=master)](https://travis-ci.com/algorand/pyteal)
+[![Build Status](https://travis-ci.com/algorand/pyteal.svg?branch=master)](https://travis-ci.com/algorand/pyteal)
 [![PyPI version](https://badge.fury.io/py/pyteal.svg)](https://badge.fury.io/py/pyteal)
 [![Documentation Status](https://readthedocs.org/projects/pyteal/badge/?version=latest)](https://pyteal.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
This token is only necessary for private repositories and could potentially leak private repository (i.e. not this repository) information.