### PR TITLE
Add ScratchVar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.idea

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ PyTeal **hasn't been security audited**. Use it at your own risk.
    byte_expression
    accessing_transaction_field
    crypto
+   scratch
    control_structures
    state
 

--- a/docs/scratch.rst
+++ b/docs/scratch.rst
@@ -1,19 +1,28 @@
 .. _scratch:
 
-Scratch Operations
+Scratch Space
 ========================
 
-Algorand Smart Contracts provides a Scratch Space as a way of temporarily storing values for later use in your code.
-You can store up 32 separate values in Scratch Space, each value is stored in separate place called slot.
+`Scratch space <https://developer.algorand.org/docs/reference/teal/specification/#scratch-space>`_
+is a temporary place to store values for later use in your program. It is temporary because any
+changes to scratch space do not persist beyond the current tranasaction. Scratch space can be used
+in both Application and Signature mode.
+
+Scratch space consists of 256 scratch slots, each capable of storing one integer or byte slice. When
+using the :any:`ScratchVar` class to work with scratch space, a slot is automatically assigned to
+each variable.
 
 Writing and Reading
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To write to Scratch Space, use the :any:`ScratchVar` class. Object of that class represents single slot in the Scratch Space.
+To write to scratch space, first create a :any:`ScratchVar` object and pass in the :any:`TealType`
+of the values that you will store there. It is possible to create a :any:`ScratchVar` that can store
+both integers and byte slices by passing no arguments to the :any:`ScratchVar` constructor, but note
+that no type checking takes places in this situation.
 
-To write or read from it you need to use corresponding :any:`ScratchVar.store` or :any:`ScratchVar.load` methods.
+To write or read values, use the corresponding :any:`ScratchVar.store` or :any:`ScratchVar.load` methods.
 
-Example:
+For example:
 
 .. code-block:: python
 

--- a/docs/scratch.rst
+++ b/docs/scratch.rst
@@ -1,0 +1,24 @@
+.. _scratch:
+
+Scratch Operations
+========================
+
+Algorand Smart Contracts provides a Scratch Space as a way of temporarily storing values for later use in your code.
+You can store up 32 separate values in Scratch Space, each value is stored in separate place called slot.
+
+Writing and Reading
+~~~~~~~~~~~~~~~~~~~~~~
+
+To write to Scratch Space, use the :any:`ScratchVar` class. Object of that class represents single slot in the Scratch Space.
+
+To write or read from it you need to use corresponding :any:`ScratchVar.store` or :any:`ScratchVar.load` methods.
+
+Example:
+
+.. code-block:: python
+
+    myvar = ScratchVar(TealType.uint64)
+    program = Seq([
+        myvar.store(Int(5)),
+        Assert(myvar.load() == Int(5))
+    ])

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -39,7 +39,7 @@ from .seq import Seq
 from .assert_ import Assert
 
 # misc
-from .scratch import ScratchSlot, ScratchLoad, ScratchStore
+from .scratch import ScratchSlot, ScratchLoad, ScratchStore, ScratchStackStore
 from .scratchvar import ScratchVar
 from .maybe import MaybeValue
 
@@ -113,6 +113,7 @@ __all__ = [
     "ScratchSlot",
     "ScratchLoad",
     "ScratchStore",
+    "ScratchStackStore",
     "ScratchVar",
     "MaybeValue",
 ]

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -40,6 +40,7 @@ from .assert_ import Assert
 
 # misc
 from .scratch import ScratchSlot, ScratchLoad, ScratchStore
+from .scratchvar import ScratchVar
 from .maybe import MaybeValue
 
 __all__ = [
@@ -112,5 +113,6 @@ __all__ = [
     "ScratchSlot",
     "ScratchLoad",
     "ScratchStore",
+    "ScratchVar",
     "MaybeValue",
 ]

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -72,11 +72,7 @@ class ScratchLoad(Expr):
 ScratchLoad.__module__ = "pyteal"
 
 class ScratchStore(Expr):
-    """Expression to store a value in scratch space.
-    
-    NOTE: This expression breaks the typical semantics of PyTeal, only use if you know what you're
-    doing.
-    """
+    """Expression to store a value in scratch space."""
 
     def __init__(self, slot: ScratchSlot, value: Expr):
         """Create a new ScratchStore expression.
@@ -102,7 +98,11 @@ class ScratchStore(Expr):
 ScratchStore.__module__ = "pyteal"
 
 class ScratchStackStore(Expr):
-    """Expression to store a value from the stack in scratch space."""
+    """Expression to store a value from the stack in scratch space.
+    
+    NOTE: This expression breaks the typical semantics of PyTeal, only use if you know what you're
+    doing.
+    """
 
     def __init__(self, slot: ScratchSlot):
         """Create a new ScratchStackStore expression.

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -10,11 +10,19 @@ class ScratchSlot:
         self.id = ScratchSlot.slotId
         ScratchSlot.slotId += 1
 
-    def store(self):
-        """Get an expression to store a value in this slot."""
-        return ScratchStore(self)
+    def store(self, value: Expr = None) -> Expr:
+        """Get an expression to store a value in this slot.
+        
+        Args:
+            value (optional): The value to store in this slot. If not included, the last value on
+            the stack will be stored. NOTE: storing the last value on the stack breaks the typical
+            semantics of PyTeal, only use if you know what you're doing.
+        """
+        if value is not None:
+            return ScratchStore(self, value)
+        return ScratchStackStore(self)
 
-    def load(self, type: TealType = TealType.anytype):
+    def load(self, type: TealType = TealType.anytype) -> 'ScratchLoad':
         """Get an expression to load a value from this slot.
 
         Args:
@@ -64,10 +72,40 @@ class ScratchLoad(Expr):
 ScratchLoad.__module__ = "pyteal"
 
 class ScratchStore(Expr):
-    """Expression to store a value in scratch space."""
+    """Expression to store a value in scratch space.
+    
+    NOTE: This expression breaks the typical semantics of PyTeal, only use if you know what you're
+    doing.
+    """
+
+    def __init__(self, slot: ScratchSlot, value: Expr):
+        """Create a new ScratchStore expression.
+
+        Args:
+            slot: The slot to store the value in.
+            value: The value to store.
+        """
+        self.slot = slot
+        self.value = value
+
+    def __str__(self):
+        return "(Store {} {})".format(str(self.slot), str(self.value))
+
+    def __teal__(self):
+        from ..ir import TealOp, Op, TealBlock
+        op = TealOp(Op.store, self.slot)
+        return TealBlock.FromOp(op, self.value)
+
+    def type_of(self):
+        return TealType.none
+
+ScratchStore.__module__ = "pyteal"
+
+class ScratchStackStore(Expr):
+    """Expression to store a value from the stack in scratch space."""
 
     def __init__(self, slot: ScratchSlot):
-        """Create a new ScratchStore expression.
+        """Create a new ScratchStackStore expression.
 
         Args:
             slot: The slot to store the value in.
@@ -75,7 +113,7 @@ class ScratchStore(Expr):
         self.slot = slot
 
     def __str__(self):
-        return "(Store {})".format(self.slot.__str__())
+        return "(StackStore {})".format(str(self.slot))
 
     def __teal__(self):
         from ..ir import TealOp, Op, TealBlock
@@ -85,4 +123,4 @@ class ScratchStore(Expr):
     def type_of(self):
         return TealType.none
 
-ScratchStore.__module__ = "pyteal"
+ScratchStackStore.__module__ = "pyteal"

--- a/pyteal/ast/scratch_test.py
+++ b/pyteal/ast/scratch_test.py
@@ -8,7 +8,8 @@ def test_scratch_slot():
     assert slot.__hash__() == slot.__hash__()
     assert slot != ScratchSlot()
 
-    assert slot.store().__teal__()[0] == ScratchStore(slot).__teal__()[0]
+    assert slot.store().__teal__()[0] == ScratchStackStore(slot).__teal__()[0]
+    assert slot.store(Int(1)).__teal__()[0] == ScratchStore(slot, Int(1)).__teal__()[0]
 
     assert slot.load().type_of() == TealType.anytype
     assert slot.load(TealType.uint64).type_of() == TealType.uint64
@@ -42,8 +43,24 @@ def test_scratch_load_type():
         assert actual == expected
 
 def test_scratch_store():
+    for value in (Int(1), Bytes("test"), App.globalGet(Bytes("key")), If(Int(1), Int(2), Int(3))):
+        slot = ScratchSlot()
+        expr = ScratchStore(slot, value)
+        assert expr.type_of() == TealType.none
+        
+        expected, valueEnd = value.__teal__()
+        storeBlock = TealSimpleBlock([
+            TealOp(Op.store, slot)
+        ])
+        valueEnd.setNextBlock(storeBlock)
+
+        actual, _ = expr.__teal__()
+
+        assert actual == expected
+
+def test_scratch_stack_store():
     slot = ScratchSlot()
-    expr = ScratchStore(slot)
+    expr = ScratchStackStore(slot)
     assert expr.type_of() == TealType.none
     
     expected = TealSimpleBlock([

--- a/pyteal/ast/scratchvar.py
+++ b/pyteal/ast/scratchvar.py
@@ -1,0 +1,60 @@
+from ..types import TealType, require_type
+from ..ir import TealOp, Op, TealBlock
+from .leafexpr import LeafExpr
+from .expr import Expr
+from .scratch import ScratchSlot
+
+
+class ScratchVar:
+    """
+    Interface around Scratch space, similiar to get/put local/global state
+    >>> myvar = ScratchVar()
+    >>> Seq([myvar.store(Int(5)), Assert(myvar.load() == Int(5))])
+    """
+    def __init__(self):
+        self.slot = ScratchSlot()
+
+    def store(self, value: Expr) -> 'ScratchVarStore':
+        """Store value in Scratch Space"""
+        return ScratchVarStore(self.slot, value)
+
+    def load(self) -> 'ScrachVarLoad':
+        """Load value from Scratch Space"""
+        return ScrachVarLoad(self.slot)
+
+    def __eq__(self, other):
+        return self.__eq__(other)
+
+
+class ScratchVarStore(LeafExpr):
+    """
+    Expression to store value in Scratch Space
+    """
+    def __init__(self, slot: ScratchSlot, value: Expr):
+        require_type(value.type_of(), TealType.anytype)
+        self.slot = slot
+        self.value = value
+
+    def __teal__(self):
+        return TealBlock.FromOp(TealOp(Op.store, self.slot), self.value)
+
+    def type_of(self) -> TealType:
+        return TealType.none
+
+    def __str__(self):
+        return "(ScratchVarStore {} {})".format(self.slot, self.value)
+
+
+class ScrachVarLoad(LeafExpr):
+    """Expression to load value from Scratch Space"""
+    def __init__(self, slot: ScratchSlot):
+        self.slot = slot
+
+    def __teal__(self):
+        return TealBlock.FromOp(TealOp(Op.load, self.slot))
+
+    def type_of(self) -> TealType:
+        return TealType.anytype
+
+    def __str__(self):
+        return "(ScrachVarLoad {})".format(self.slot)

--- a/pyteal/ast/scratchvar_test.py
+++ b/pyteal/ast/scratchvar_test.py
@@ -1,0 +1,35 @@
+from .. import *
+
+
+def test_scratchvar():
+    myvar = ScratchVar()
+    assert myvar.store(Bytes("value")).type_of() == TealType.none
+
+    expected = TealSimpleBlock([
+        TealOp(Op.byte, "\"value\""),
+        TealOp(Op.store, myvar.slot),
+    ])
+
+    expr = myvar.store(Bytes("value"))
+    actual, _ = expr.__teal__()
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    assert actual == expected
+
+
+def test_scratchvar_load():
+    myvar = ScratchVar()
+
+    assert myvar.load().type_of() == TealType.anytype
+
+    expected = TealSimpleBlock([
+        TealOp(Op.load, myvar.slot),
+    ])
+
+    expr = myvar.load()
+    actual, _ = expr.__teal__()
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    assert actual == expected

--- a/pyteal/ast/scratchvar_test.py
+++ b/pyteal/ast/scratchvar_test.py
@@ -1,33 +1,62 @@
+import pytest
+
 from .. import *
 
 
-def test_scratchvar():
-    myvar = ScratchVar()
-    assert myvar.store(Bytes("value")).type_of() == TealType.none
+def test_scratchvar_type():
+    myvar_default = ScratchVar()
+    assert myvar_default.storage_type() == TealType.anytype
+    assert myvar_default.store(Bytes("value")).type_of() == TealType.none
+    assert myvar_default.load().type_of() == TealType.anytype
+
+    with pytest.raises(TealTypeError):
+        myvar_default.store(Pop(Int(1)))
+
+    myvar_int = ScratchVar(TealType.uint64)
+    assert myvar_int.storage_type() == TealType.uint64
+    assert myvar_int.store(Int(1)).type_of() == TealType.none
+    assert myvar_int.load().type_of() == TealType.uint64
+
+    with pytest.raises(TealTypeError):
+        myvar_int.store(Bytes("value"))
+
+    with pytest.raises(TealTypeError):
+        myvar_int.store(Pop(Int(1)))
+
+    myvar_bytes = ScratchVar(TealType.bytes)
+    assert myvar_bytes.storage_type() == TealType.bytes
+    assert myvar_bytes.store(Bytes("value")).type_of() == TealType.none
+    assert myvar_bytes.load().type_of() == TealType.bytes
+
+    with pytest.raises(TealTypeError):
+        myvar_bytes.store(Int(0))
+    
+    with pytest.raises(TealTypeError):
+        myvar_bytes.store(Pop(Int(1)))
+
+def test_scratchvar_store():
+    myvar = ScratchVar(TealType.bytes)
+    expr = myvar.store(Bytes("value"))
 
     expected = TealSimpleBlock([
         TealOp(Op.byte, "\"value\""),
         TealOp(Op.store, myvar.slot),
     ])
 
-    expr = myvar.store(Bytes("value"))
     actual, _ = expr.__teal__()
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
     assert actual == expected
 
-
 def test_scratchvar_load():
     myvar = ScratchVar()
-
-    assert myvar.load().type_of() == TealType.anytype
+    expr = myvar.load()
 
     expected = TealSimpleBlock([
-        TealOp(Op.load, myvar.slot),
+        TealOp(Op.load, myvar.slot)
     ])
 
-    expr = myvar.load()
     actual, _ = expr.__teal__()
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)


### PR DESCRIPTION
Add `ScratchVar`, an interface for programs to store and load values from scratch space.

Example:
```python
myvar = ScratchVar(TealType.uint64)
program = Seq([
     myvar.store(Int(5)),
     Assert(myvar.load() == Int(5))
])
```

Fixes #32