### PR TITLE
Fix docs and examples that reference Txn.accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added `ScratchVar`, an inteface for storing and loading values from scratch space ([#33](https://github.com/algorand/pyteal/pull/33)).
 
 ## Fixed
+* Corrected documentation and examples that incorrectly used the `Txn.accounts` array ([#42](https://github.com/algorand/pyteal/pull/42)).
 * Fixed improper base32 validation and allow the use of padding ([#34](https://github.com/algorand/pyteal/pull/34)
 and [#37](https://github.com/algorand/pyteal/pull/37)).
 

--- a/docs/accessing_transaction_field.rst
+++ b/docs/accessing_transaction_field.rst
@@ -58,9 +58,12 @@ Operator                                  Type                     Notes
 :code:`Txn.freeze_asset()`                :code:`TealType.uint64`
 :code:`Txn.freeze_asset_account()`        :code:`TealType.bytes`   32 byte address
 :code:`Txn.freeze_asset_frozen()`         :code:`TealType.uint64`
-:code:`Txn.application_args()`            :code:`TealType.bytes[]`
-:code:`Txn.accounts()`                    :code:`TealType.bytes[]`
+:code:`Txn.application_args`              :code:`TealType.bytes[]` Array of application arguments
+:code:`Txn.accounts`                      :code:`TealType.bytes[]` Array of additional application accounts
 ========================================= ======================== =======================================================================
+
+Transaction Type
+~~~~~~~~~~~~~~~~
 
 The :code:`Txn.type_enum()` values can be checked using the :any:`TxnType` enum:
 
@@ -76,8 +79,32 @@ Value                          Numerical Value Type String  Description
 :any:`TxnType.ApplicationCall` :code:`6`       appl         application call
 ============================== =============== ============ =========================
 
-Atomic Tranfers
-~~~~~~~~~~~~~~~
+Tranasction Array Fields
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some of the exposed transaction fields are arrays with the type :code:`TealType.bytes[]`. These
+fields are :code:`Txn.application_args` and :code:`Txn.accounts`.
+
+The length of these array fields can be found using the :code:`.length()` method, and individual
+items can be accesses using bracket notation. For example:
+
+.. code-block:: python
+
+  Txn.application_args.length() # get the number of application arguments in the transaction
+  Txn.application_args[0] # get the first application argument
+  Txn.application_args[1] # get the second application argument
+
+Special case: :code:`Txn.accounts`
+""""""""""""""""""""""""""""""""""
+
+The :code:`Txn.accounts` is a special case array. Normal arrays in PyTeal are :code:`0`-indexed, but
+this one is :code:`1`-indexed with a special value at index :code:`0`, the sender's address. That
+means if :code:`Txn.accounts.length()` is 2, then indexes :code:`0`, :code:`1`, and :code:`2` will
+be present. In fact, :code:`Txn.accounts[0]` will always evaluate to the sender's address, even when
+:code:`Txn.accounts.length()` is :code:`0`.
+
+Atomic Tranfer Groups
+---------------------
 
 `Atomic Transfers <https://developer.algorand.org/docs/features/atomic_transfers/>`_ are irreducible
 batch transactions that allow groups of transactions to be submitted at one time. If any of the
@@ -91,7 +118,12 @@ available on the elements of :code:`Gtxn`. For example:
   Gtxn[0].sender() # get the sender of the first transaction in the atomic transfer group
   Gtxn[1].receiver() # get the receiver of the second transaction in the atomic transfer group
 
-:code:`Gtxn` is zero-indexed and the maximum size of an atomic transfer group is 16.
+:code:`Gtxn` is zero-indexed and the maximum size of an atomic transfer group is 16. The size of the
+current transaction group is available as :any:`Global.group_size()`. A standalone transaction will
+have a group size of :code:`1`.
+
+To find the current transaction's index in the transfer group, use :code:`Txn.group_index()`. If the
+current transaction is standalone, it's group index will be :code:`0`.
 
 Global Parameters
 -----------------
@@ -106,7 +138,7 @@ Operator                                Type                    Notes
 :any:`Global.min_balance()`             :code:`TealType.uint64` in mircoAlgos
 :any:`Global.max_txn_life()`            :code:`TealType.uint64` number of rounds
 :any:`Global.zero_address()`            :code:`TealType.bytes`  32 byte address of all zero bytes
-:any:`Global.group_size()`              :code:`TealType.uint64` number of txns in this atomic transaction group, At least 1
+:any:`Global.group_size()`              :code:`TealType.uint64` number of txns in this atomic transaction group, at least 1
 :any:`Global.logic_sig_version()`       :code:`TealType.uint64` the maximum supported TEAL version
 :any:`Global.round()`                   :code:`TealType.uint64` the current round number
 :any:`Global.latest_timestamp()`        :code:`TealType.uint64` the latest confirmed block UNIX timestamp

--- a/docs/byte_expression.rst
+++ b/docs/byte_expression.rst
@@ -3,10 +3,20 @@
 Byte Operators
 ====================
 
-TEAL byte slices are similar to strings and can be manipulated in much the same way.
+TEAL byte slices are similar to strings and can be manipulated in the same way.
 
-Concat
---------------------
+Length
+------
+
+The length of a byte slice can be obtained using the :any:`Len` expression. For example:
+
+.. code-block:: python
+
+    Len(Bytes("")) # will produce 0
+    Len(Bytes("algorand")) # will produce 8
+
+Concatenation
+-------------
 
 Byte slices can be combined using the :any:`Concat` expression. This expression takes at least
 two arguments and produces a new byte slice consisting of each argument, one after another. For
@@ -14,9 +24,9 @@ example:
 
 .. code-block:: python
 
-    Concat(Bytes("a"), Bytes("b"), Bytes("c")) # equivalent to Bytes("abc")
+    Concat(Bytes("a"), Bytes("b"), Bytes("c")) # will produce "abc"
 
-Substring
+Substring Extraction
 --------------------
 
 Byte slices can be extracted from other byte slices using the :any:`Substring` expression. This
@@ -24,4 +34,4 @@ expression can extract part of a byte slicing given start and end indices. For e
 
 .. code-block:: python
 
-    Substring(Bytes("algorand"), Int(0), Int(4)) # equivalent to Bytes("algo")
+    Substring(Bytes("algorand"), Int(0), Int(4)) # will produce "algo"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,11 @@ author = 'Algorand'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 # extensions = ['m2r']
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autosectionlabel'
+]
 source_suffix = ['.rst', '.md']
 master_doc = 'index'
 

--- a/docs/data_type.rst
+++ b/docs/data_type.rst
@@ -80,3 +80,8 @@ Converting a value to its corresponding value in the other data type is supporte
 
  * :code:`Itob(n)`: generate a :code:`TealType.bytes` value from a :code:`TealType.uint64` value :code:`n`
  * :code:`Btoi(b)`: generate a :code:`TealType.uint64` value from a :code:`TealType.bytes` value :code:`b`
+
+**Note:** These operations are **not** meant to convert between human-readable strings and numbers.
+:code:`Itob` produces a big-endian 8-byte encoding of an unsigned integers, not a human readable
+string. For example, :code:`Itob(Int(1))` will produce the string :code:`"\x00\x00\x00\x00\x00\x00\x00\x01"`
+not the string :code:`"1"`.

--- a/examples/application/asset.py
+++ b/examples/application/asset.py
@@ -27,7 +27,7 @@ def approval_program():
         Return(Int(1))
     ])
 
-    # configure the admin status of the account Txn.accounts[0]
+    # configure the admin status of the account Txn.accounts[1]
     # sender must be admin
     new_admin_status = Btoi(Txn.application_args[1])
     set_admin = Seq([
@@ -42,11 +42,11 @@ def approval_program():
     #     Return(is_admin)
     # ])
     # It would be vulnerable to the following attack: a sender passes in their own address as
-    # Txn.accounts[0], so then the line App.localPut(Int(1), Bytes("admin"), new_admin_status)
+    # Txn.accounts[1], so then the line App.localPut(Int(1), Bytes("admin"), new_admin_status)
     # changes the sender's admin status, meaning the final Return(is_admin) can return anything the
     # sender wants. This allows anyone to become an admin!
 
-    # move assets from the reserve to Txn.accounts[0]
+    # move assets from the reserve to Txn.accounts[1]
     # sender must be admin
     mint_amount = Btoi(Txn.application_args[1])
     mint = Seq([
@@ -57,7 +57,7 @@ def approval_program():
         Return(is_admin)
     ])
 
-    # transfer assets from the sender to Txn.accounts[0]
+    # transfer assets from the sender to Txn.accounts[1]
     transfer_amount = Btoi(Txn.application_args[1])
     transfer = Seq([
         Assert(Txn.application_args.length() == Int(2)),

--- a/examples/application/security_token.py
+++ b/examples/application/security_token.py
@@ -45,7 +45,7 @@ def approval_program():
         Return(is_any_admin)
     ])
 
-    # configure the admin status of the account Txn.accounts[0]
+    # configure the admin status of the account Txn.accounts[1]
     # sender must be contract admin
     new_admin_type = Txn.application_args[1]
     new_admin_status = Btoi(Txn.application_args[2])
@@ -70,11 +70,11 @@ def approval_program():
     #     Return(is_contract_admin)
     # ])
     # It would be vulnerable to the following attack: a sender passes in their own address as
-    # Txn.accounts[0], so then the line App.localPut(Int(1), new_admin_type, new_admin_status)
+    # Txn.accounts[1], so then the line App.localPut(Int(1), new_admin_type, new_admin_status)
     # changes the sender's admin status, meaning the final Return(is_contract_admin) can return
     # anything the sender wants. This allows anyone to become an admin!
 
-    # freeze Txn.accounts[0]
+    # freeze Txn.accounts[1]
     # sender must be any admin
     new_freeze_value = Btoi(Txn.application_args[1])
     freeze = Seq([
@@ -86,7 +86,7 @@ def approval_program():
         Return(is_any_admin)
     ])
 
-    # modify the max balance of Txn.accounts[0]
+    # modify the max balance of Txn.accounts[1]
     # if max_balance_value is 0, will delete the existing max balance limitation on the account
     # sender must be transfer admin
     max_balance_value = Btoi(Txn.application_args[1])
@@ -102,7 +102,7 @@ def approval_program():
         Return(is_transfer_admin)
     ])
 
-    # lock Txn.accounts[0] until a UNIX timestamp
+    # lock Txn.accounts[1] until a UNIX timestamp
     # sender must be transfer admin
     lock_until_value = Btoi(Txn.application_args[1])
     lock_until = Seq([
@@ -148,7 +148,7 @@ def approval_program():
         Return(is_transfer_admin)
     ])
 
-    # move assets from the reserve to Txn.accounts[0]
+    # move assets from the reserve to Txn.accounts[1]
     # sender must be contract admin
     mint_amount = Btoi(Txn.application_args[1])
     mint = Seq([
@@ -162,7 +162,7 @@ def approval_program():
         Return(is_contract_admin)
     ])
 
-    # move assets from Txn.accounts[0] to the reserve
+    # move assets from Txn.accounts[1] to the reserve
     # sender must be contract admin
     burn_amount = Btoi(Txn.application_args[1])
     burn = Seq([
@@ -176,7 +176,7 @@ def approval_program():
         Return(is_contract_admin)
     ])
 
-    # transfer assets from the sender to Txn.accounts[0]
+    # transfer assets from the sender to Txn.accounts[1]
     transfer_amount = Btoi(Txn.application_args[1])
     receiver_max_balance = App.localGetEx(Int(1), App.id(), Bytes("max balance"))
     transfer = Seq([


### PR DESCRIPTION
Fix documentation and examples that incorrectly reference the `Txn.accounts` array. I also added a dedicated section to the transaction field docs page that explains how `Txn.accounts` works. I included some unrelated small docs improvements as well.

Fixes #40.