### PR TITLE
Documentation additions for TEAL 3

### DIFF
--- a/docs/accessing_transaction_field.rst
+++ b/docs/accessing_transaction_field.rst
@@ -12,60 +12,66 @@ Transaction Fields
 Information about the current transaction being evaluated can be obtained using the :any:`Txn`
 object. Below are the PyTeal expressions that refer to transaction fields:
 
-========================================= ======================== =======================================================================
-Operator                                  Type                     Notes
-========================================= ======================== =======================================================================
-:code:`Txn.sender()`                      :code:`TealType.bytes`   32 byte address
-:code:`Txn.fee()`                         :code:`TealType.uint64`  in microAlgos
-:code:`Txn.first_valid()`                 :code:`TealType.uint64`  round number 
-:code:`Txn.last_valid()`                  :code:`TealType.uint64`  round number
-:code:`Txn.note()`                        :code:`TealType.bytes`   transaction note in bytes
-:code:`Txn.lease()`                       :code:`TealType.bytes`   transaction lease in bytes
-:code:`Txn.receiver()`                    :code:`TealType.bytes`   32 byte address
-:code:`Txn.amount()`                      :code:`TealType.uint64`  in microAlgos
-:code:`Txn.close_remainder_to()`          :code:`TealType.bytes`   32 byte address
-:code:`Txn.vote_pk()`                     :code:`TealType.bytes`   32 byte address
-:code:`Txn.selection_pk()`                :code:`TealType.bytes`   32 byte address
-:code:`Txn.vote_first()`                  :code:`TealType.uint64`
-:code:`Txn.vote_last()`                   :code:`TealType.uint64`
-:code:`Txn.vote_key_dilution()`           :code:`TealType.uint64`
-:code:`Txn.type()`                        :code:`TealType.bytes`
-:code:`Txn.type_enum()`                   :code:`TealType.uint64`  see table below
-:code:`Txn.xfer_asset()`                  :code:`TealType.uint64`  asset ID
-:code:`Txn.asset_amount()`                :code:`TealType.uint64`  value in Asset's units
-:code:`Txn.asset_sender()`                :code:`TealType.bytes`   32 byte address, causes clawback of all value if sender is the Clawback
-:code:`Txn.asset_receiver()`              :code:`TealType.bytes`   32 byte address
-:code:`Txn.asset_close_to()`              :code:`TealType.bytes`   32 byte address
-:code:`Txn.group_index()`                 :code:`TealType.uint64`  position of this transaction within a transaction group
-:code:`Txn.tx_id()`                       :code:`TealType.bytes`   the computed ID for this transaction, 32 bytes
-:code:`Txn.application_id()`              :code:`TealType.uint64`
-:code:`Txn.on_completion()`               :code:`TealType.uint64`
-:code:`Txn.approval_program()`            :code:`TealType.bytes`
-:code:`Txn.clear_state_program()`         :code:`TealType.bytes`
-:code:`Txn.rekey_to()`                    :code:`TealType.bytes`   32 byte address
-:code:`Txn.config_asset()`                :code:`TealType.uint64`
-:code:`Txn.config_asset_total()`          :code:`TealType.uint64`
-:code:`Txn.config_asset_decimals()`       :code:`TealType.uint64`
-:code:`Txn.config_asset_default_frozen()` :code:`TealType.uint64`
-:code:`Txn.config_asset_unit_name()`      :code:`TealType.bytes`
-:code:`Txn.config_asset_name()`           :code:`TealType.bytes`
-:code:`Txn.config_asset_url()`            :code:`TealType.bytes`
-:code:`Txn.config_asset_metadata_hash()`  :code:`TealType.bytes`
-:code:`Txn.config_asset_manager()`        :code:`TealType.bytes`   32 byte address
-:code:`Txn.config_asset_reserve()`        :code:`TealType.bytes`   32 byte address
-:code:`Txn.config_asset_freeze()`         :code:`TealType.bytes`   32 byte address
-:code:`Txn.config_asset_clawback()`       :code:`TealType.bytes`   32 byte address
-:code:`Txn.freeze_asset()`                :code:`TealType.uint64`
-:code:`Txn.freeze_asset_account()`        :code:`TealType.bytes`   32 byte address
-:code:`Txn.freeze_asset_frozen()`         :code:`TealType.uint64`
-:code:`Txn.application_args`              :code:`TealType.bytes[]` Array of application arguments
-:code:`Txn.accounts`                      :code:`TealType.bytes[]` Array of additional application accounts
-========================================= ======================== =======================================================================
+================================================================================ ========================= =======================================================================
+Operator                                  Type                      Notes
+================================================================================ ========================= =======================================================================
+:any:`Txn.sender() <TxnObject.sender>`                                           :code:`TealType.bytes`    32 byte address
+:any:`Txn.fee() <TxnObject.fee>`                                                 :code:`TealType.uint64`   in microAlgos
+:any:`Txn.first_valid() <TxnObject.first_valid>`                                 :code:`TealType.uint64`   round number 
+:any:`Txn.last_valid() <TxnObject.last_valid>`                                   :code:`TealType.uint64`   round number
+:any:`Txn.note() <TxnObject.note>`                                               :code:`TealType.bytes`    transaction note in bytes
+:any:`Txn.lease() <TxnObject.lease>`                                             :code:`TealType.bytes`    transaction lease in bytes
+:any:`Txn.receiver() <TxnObject.receiver>`                                       :code:`TealType.bytes`    32 byte address
+:any:`Txn.amount() <TxnObject.amount>`                                           :code:`TealType.uint64`   in microAlgos
+:any:`Txn.close_remainder_to() <TxnObject.close_remainder_to>`                   :code:`TealType.bytes`    32 byte address
+:any:`Txn.vote_pk() <TxnObject.vote_pk>`                                         :code:`TealType.bytes`    32 byte address
+:any:`Txn.selection_pk() <TxnObject.selection_pk>`                               :code:`TealType.bytes`    32 byte address
+:any:`Txn.vote_first() <TxnObject.vote_first>`                                   :code:`TealType.uint64`
+:any:`Txn.vote_last() <TxnObject.vote_last>`                                     :code:`TealType.uint64`
+:any:`Txn.vote_key_dilution() <TxnObject.vote_key_dilution>`                     :code:`TealType.uint64`
+:any:`Txn.type() <TxnObject.type>`                                               :code:`TealType.bytes`
+:any:`Txn.type_enum() <TxnObject.type_enum>`                                     :code:`TealType.uint64`   see table below
+:any:`Txn.xfer_asset() <TxnObject.xfer_asset>`                                   :code:`TealType.uint64`   ID of asset being transferred
+:any:`Txn.asset_amount() <TxnObject.asset_amount>`                               :code:`TealType.uint64`   value in Asset's units
+:any:`Txn.asset_sender() <TxnObject.asset_sender>`                               :code:`TealType.bytes`    32 byte address, causes clawback of all value if sender is the clawback
+:any:`Txn.asset_receiver() <TxnObject.asset_receiver>`                           :code:`TealType.bytes`    32 byte address
+:any:`Txn.asset_close_to() <TxnObject.asset_close_to>`                           :code:`TealType.bytes`    32 byte address
+:any:`Txn.group_index() <TxnObject.group_index>`                                 :code:`TealType.uint64`   position of this transaction within a transaction group, starting at 0
+:any:`Txn.tx_id() <TxnObject.tx_id>`                                             :code:`TealType.bytes`    the computed ID for this transaction, 32 bytes
+:any:`Txn.application_id() <TxnObject.application_id>`                           :code:`TealType.uint64`
+:any:`Txn.on_completion() <TxnObject.on_completion>`                             :code:`TealType.uint64`
+:any:`Txn.approval_program() <TxnObject.approval_program>`                       :code:`TealType.bytes`
+:any:`Txn.clear_state_program() <TxnObject.clear_state_program>`                 :code:`TealType.bytes`
+:any:`Txn.rekey_to() <TxnObject.rekey_to>`                                       :code:`TealType.bytes`    32 byte address
+:any:`Txn.config_asset() <TxnObject.config_asset>`                               :code:`TealType.uint64`   ID of asset being configured
+:any:`Txn.config_asset_total() <TxnObject.config_asset_total>`                   :code:`TealType.uint64`
+:any:`Txn.config_asset_decimals() <TxnObject.config_asset_decimals>`             :code:`TealType.uint64`
+:any:`Txn.config_asset_default_frozen() <TxnObject.config_asset_default_frozen>` :code:`TealType.uint64`
+:any:`Txn.config_asset_unit_name() <TxnObject.config_asset_unit_name>`           :code:`TealType.bytes`
+:any:`Txn.config_asset_name() <TxnObject.config_asset_name>`                     :code:`TealType.bytes`
+:any:`Txn.config_asset_url() <TxnObject.config_asset_url>`                       :code:`TealType.bytes`
+:any:`Txn.config_asset_metadata_hash() <TxnObject.config_asset_metadata_hash>`   :code:`TealType.bytes`
+:any:`Txn.config_asset_manager() <TxnObject.config_asset_manager>`               :code:`TealType.bytes`    32 byte address
+:any:`Txn.config_asset_reserve() <TxnObject.config_asset_reserve>`               :code:`TealType.bytes`    32 byte address
+:any:`Txn.config_asset_freeze() <TxnObject.config_asset_freeze>`                 :code:`TealType.bytes`    32 byte address
+:any:`Txn.config_asset_clawback() <TxnObject.config_asset_clawback>`             :code:`TealType.bytes`    32 byte address
+:any:`Txn.freeze_asset() <TxnObject.freeze_asset>`                               :code:`TealType.uint64`
+:any:`Txn.freeze_asset_account() <TxnObject.freeze_asset_account>`               :code:`TealType.bytes`    32 byte address
+:any:`Txn.freeze_asset_frozen() <TxnObject.freeze_asset_frozen>`                 :code:`TealType.uint64`
+:any:`Txn.global_num_uints() <TxnObject.global_num_uints>`                       :code:`TealType.uint64`   Maximum global integers in app schema
+:any:`Txn.global_num_byte_slices() <TxnObject.global_num_byte_slices>`           :code:`TealType.uint64`   Maximum global byte strings in app schema
+:any:`Txn.local_num_uints() <TxnObject.local_num_uints>`                         :code:`TealType.uint64`   Maximum local integers in app schema
+:any:`Txn.local_num_byte_slices() <TxnObject.local_num_byte_slices>`             :code:`TealType.uint64`   Maximum local byte strings in app schema
+:any:`Txn.application_args <TxnObject.application_args>`                         :code:`TealType.bytes[]`  Array of application arguments
+:any:`Txn.accounts <TxnObject.accounts>`                                         :code:`TealType.bytes[]`  Array of application accounts
+:any:`Txn.assets <TxnObject.assets>`                                             :code:`TealType.uint64[]` Array of application assets
+:any:`Txn.applications <TxnObject.applications>`                                 :code:`TealType.uint64[]` Array of applications
+================================================================================ ========================= =======================================================================
 
 Transaction Type
 ~~~~~~~~~~~~~~~~
 
-The :code:`Txn.type_enum()` values can be checked using the :any:`TxnType` enum:
+The :any:`Txn.type_enum() <TxnObject.type_enum>` values can be checked using the :any:`TxnType` enum:
 
 ============================== =============== ============ ========================= 
 Value                          Numerical Value Type String  Description
@@ -79,11 +85,11 @@ Value                          Numerical Value Type String  Description
 :any:`TxnType.ApplicationCall` :code:`6`       appl         application call
 ============================== =============== ============ =========================
 
-Tranasction Array Fields
+Transaction Array Fields
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some of the exposed transaction fields are arrays with the type :code:`TealType.bytes[]`. These
-fields are :code:`Txn.application_args` and :code:`Txn.accounts`.
+Some of the exposed transaction fields are arrays with the type :code:`TealType.uint64[]` or :code:`TealType.bytes[]`.
+These fields are :code:`Txn.application_args`, :code:`Txn.assets`, :code:`Txn.accounts`, and :code:`Txn.applications`.
 
 The length of these array fields can be found using the :code:`.length()` method, and individual
 items can be accesses using bracket notation. For example:
@@ -94,17 +100,25 @@ items can be accesses using bracket notation. For example:
   Txn.application_args[0] # get the first application argument
   Txn.application_args[1] # get the second application argument
 
-Special case: :code:`Txn.accounts`
-""""""""""""""""""""""""""""""""""
+.. _txn_special_case_arrays:
 
-The :code:`Txn.accounts` is a special case array. Normal arrays in PyTeal are :code:`0`-indexed, but
-this one is :code:`1`-indexed with a special value at index :code:`0`, the sender's address. That
-means if :code:`Txn.accounts.length()` is 2, then indexes :code:`0`, :code:`1`, and :code:`2` will
-be present. In fact, :code:`Txn.accounts[0]` will always evaluate to the sender's address, even when
-:code:`Txn.accounts.length()` is :code:`0`.
+Special case: :code:`Txn.accounts` and :code:`Txn.applications`
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Atomic Tranfer Groups
----------------------
+The :code:`Txn.accounts` and :code:`Txn.applications` arrays are special cases. Normal arrays in
+PyTeal are :code:`0`-indexed, but these are :code:`1`-indexed with special values at index :code:`0`.
+
+For the accounts array, :code:`Txn.accounts[0]` is always equivalent to :code:`Txn.sender()`.
+
+For the applications array, :code:`Txn.applications[0]` is always equivalent to :code:`Txn.application_id()`.
+
+**IMPORTANT:** Since these arrays are :code:`1`-indexed, their lengths are handled differently.
+For example, if :code:`Txn.accounts.length()` or :code:`Txn.applications.length()` is 2, then
+indexes :code:`0`, :code:`1`, and :code:`2` will be present. In fact, the index :code:`0` will
+always evaluate to the special values above, even when :code:`length()` is :code:`0`.
+
+Atomic Transfer Groups
+----------------------
 
 `Atomic Transfers <https://developer.algorand.org/docs/features/atomic_transfers/>`_ are irreducible
 batch transactions that allow groups of transactions to be submitted at one time. If any of the
@@ -122,7 +136,7 @@ available on the elements of :code:`Gtxn`. For example:
 current transaction group is available as :any:`Global.group_size()`. A standalone transaction will
 have a group size of :code:`1`.
 
-To find the current transaction's index in the transfer group, use :code:`Txn.group_index()`. If the
+To find the current transaction's index in the transfer group, use :any:`Txn.group_index() <TxnObject.group_index>`. If the
 current transaction is standalone, it's group index will be :code:`0`.
 
 Global Parameters

--- a/docs/arithmetic_expression.rst
+++ b/docs/arithmetic_expression.rst
@@ -1,47 +1,127 @@
 .. _arithmetic_expressions:
 
-Arithmetic Operators
-====================
+Arithmetic Operations
+=====================
 
 An arithmetic expression is an expression that results in a :code:`TealType.uint64` value.
-In PyTeal, arithmetic expressions include integer arithmetics operators and boolean operators.
-We overloaded all integer arithmetics operator in Python.
+In PyTeal, arithmetic expressions include integer and boolean operators (booleans are the integers
+`0` or `1`). The table below summarized all arithmetic expressions in PyTeal.
 
-======================== =========== ================================================= ===========================
-Operator                 Overloaded  Semantics                                         Example
-======================== =========== ================================================= ===========================
-:code:`Lt(a, b)`         :code:`<`   `1` if `a` is less than `b`, `0` otherwise            :code:`Int(1) < Int(5)`
-:code:`Gt(a, b)`         :code:`>`   `1` if `a` is greater than `b`, `0` otherwise         :code:`Int(1) > Int(5)`
-:code:`Le(a, b)`         :code:`<=`  `1` if `a` is no greater than `b`, `0` otherwise      :code:`Int(1) <= Int(5)`
-:code:`Ge(a, b)`         :code:`>=`  `1` if `a` is no less than `b`, `0` otherwise         :code:`Int(1) >= Int(5)`
-:code:`Add(a, b)`        :code:`+`   `a + b`, error (panic) if overflow                :code:`Int(1) + Int(5)`
-:code:`Minus(a, b)`      :code:`-`   `a - b`, error if underflow                       :code:`Int(5) - Int(1)`
-:code:`Mul(a, b)`        :code:`*`   `a * b`, error if overflow                        :code:`Int(2) * Int(3)`
-:code:`Div(a, b)`        :code:`/`   `a / b`, error if devided by zero                 :code:`Int(3) / Int(2)`
-:code:`Mod(a, b)`        :code:`%`   `a % b`, modulo operation                         :code:`Int(7) % Int(3)`
-:code:`Eq(a, b)`         :code:`==`  `1` if `a` equals `b`, `0` otherwise                  :code:`Int(7) == Int(7)`
-:code:`Neq(a, b)`        :code:`!=`  `0` if `a` equals `b`, `1` otherwise                  :code:`Int(7) != Int(7)`
-:code:`And(a, b)`                    `1` if `a > 0 && b > 0`, `0` otherwise            :code:`And(Int(1), Int(1))`
-:code:`Or(a, b)`                     `1` if `a > 0 || b > 0`, `0` otherwise            :code:`Or(Int(1), Int(0))`
-:code:`Not(a)`                       `1` if `a` equals `0`, `0` otherwise                  :code:`Not(Int(0))`
-:code:`BitwiseAnd(a,b)`  :code:`&`   `a & b`, bitwise and operation                    :code:`Int(1) & Int(3)`
-:code:`BitwiseOr(a,b)`   :code:`|`   `a | b`, bitwise or operation                     :code:`Int(2) | Int(5)`
-:code:`BitwiseXor(a,b)`  :code:`^`   `a ^ b`, bitwise xor operation                    :code:`Int(3) ^ Int(7)`
-:code:`BitwiseNot(a)`    :code:`~`   `~a`, bitwise complement operation                :code:`~Int(1)`
-======================== =========== ================================================= ===========================
+=================================== ============== ================================================= ===========================
+Operator                            Overloaded     Semantics                                         Example
+=================================== ============== ================================================= ===========================
+:any:`Lt(a, b) <Lt>`                :code:`a < b`  `1` if `a` is less than `b`, `0` otherwise        :code:`Int(1) < Int(5)`
+:any:`Gt(a, b) <Gt>`                :code:`a > b`  `1` if `a` is greater than `b`, `0` otherwise     :code:`Int(1) > Int(5)`
+:any:`Le(a, b) <Le>`                :code:`a <= b` `1` if `a` is no greater than `b`, `0` otherwise  :code:`Int(1) <= Int(5)`
+:any:`Ge(a, b) <Ge>`                :code:`a >= b` `1` if `a` is no less than `b`, `0` otherwise     :code:`Int(1) >= Int(5)`
+:any:`Add(a, b) <Add>`              :code:`a + b`  `a + b`, error (panic) if overflow                :code:`Int(1) + Int(5)`
+:any:`Minus(a, b) <Minus>`          :code:`a - b`  `a - b`, error if underflow                       :code:`Int(5) - Int(1)`
+:any:`Mul(a, b) <Mul>`              :code:`a * b`  `a * b`, error if overflow                        :code:`Int(2) * Int(3)`
+:any:`Div(a, b) <Div>`              :code:`a / b`  `a / b`, error if divided by zero                 :code:`Int(3) / Int(2)`
+:any:`Mod(a, b) <Mod>`              :code:`a % b`  `a % b`, modulo operation                         :code:`Int(7) % Int(3)`
+:any:`Eq(a, b) <Eq>`                :code:`a == b` `1` if `a` equals `b`, `0` otherwise              :code:`Int(7) == Int(7)`
+:any:`Neq(a, b) <Neq>`              :code:`a != b` `0` if `a` equals `b`, `1` otherwise              :code:`Int(7) != Int(7)`
+:any:`And(a, b) <pyteal.And>`                      `1` if `a > 0 && b > 0`, `0` otherwise            :code:`And(Int(1), Int(1))`
+:any:`Or(a, b) <pyteal.Or>`                        `1` if `a > 0 || b > 0`, `0` otherwise            :code:`Or(Int(1), Int(0))`
+:any:`Not(a) <pyteal.Not>`                         `1` if `a` equals `0`, `0` otherwise              :code:`Not(Int(0))`
+:any:`BitwiseAnd(a,b) <BitwiseAnd>` :code:`a & b`  `a & b`, bitwise and operation                    :code:`Int(1) & Int(3)`
+:any:`BitwiseOr(a,b) <BitwiseOr>`   :code:`a | b`  `a | b`, bitwise or operation                     :code:`Int(2) | Int(5)`
+:any:`BitwiseXor(a,b) <BitwiseXor>` :code:`a ^ b`  `a ^ b`, bitwise xor operation                    :code:`Int(3) ^ Int(7)`
+:any:`BitwiseNot(a) <BitwiseNot>`   :code:`~a`     `~a`, bitwise complement operation                :code:`~Int(1)`
+=================================== ============== ================================================= ===========================
 
-All these operators takes two :code:`TealType.uint64` values.
+Most of the above operations take two :code:`TealType.uint64` values as inputs.
 In addition, :code:`Eq(a, b)` (:code:`==`) and :code:`Neq(a, b)` (:code:`!=`) also work for byte slices.
 For example, :code:`Arg(0) == Arg(1)` and :code:`Arg(0) != Arg(1)` are valid PyTeal expressions.
 
-Both :code:`And` and :code:`Or` also support more than 2 arguements when called as functions:
+Both :code:`And` and :code:`Or` also support more than 2 arguments when called as functions:
 
  * :code:`And(a, b, ...)`
  * :code:`Or(a, b, ...)`
 
-The associativity and precedence of the overloaded Python arithmatic operators are the same as the
+The associativity and precedence of the overloaded Python arithmetic operators are the same as the
 `original python operators <https://docs.python.org/3/reference/expressions.html#operator-precedence>`_ . For example:
 
  * :code:`Int(1) + Int(2) + Int(3)` is equivalent to :code:`Add(Add(Int(1), Int(2)), Int(3))`
  * :code:`Int(1) + Int(2) * Int(3)` is equivalent to :code:`Add(Int(1), Mul(Int(2), Int(3)))` 
 
+.. _bit_and_byte_manipulation:
+
+Bit and Byte Operations
+-----------------------
+
+In addition to the standard arithmetic operators above, PyTeal also supports operations that
+manipulate the individual bits and bytes of PyTeal values.
+
+To use these operations, you'll need to provide an index specifying which bit or byte to access.
+These indexes have different meanings depending on whether you are manipulating integers or byte slices:
+
+* For integers, bit indexing begins with low-order bits. For example, the bit at index 4 of the integer
+  16 (:code:`000...0001000` in binary) is 1. Every other index has a bit value of 0. Any index less
+  than 64 is valid, regardless of the integer's value.
+
+  Byte indexing is not supported for integers.
+
+* For byte strings, bit indexing begins at the first bit. For example, the bit at index 0 of the base16
+  byte string :code:`0xf0` (:code:`11110000` in binary) is 1. Any index less than 4 has a bit
+  value of 1, and any index 4 or greater has a bit value of 0. Any index less than 8 times the length
+  of the byte string is valid.
+  
+  Likewise, byte indexing begins at the first byte of the string. For example, the byte at index 0 of
+  that the base16 string :code:`0xff00` (:code:`1111111100000000` in binary) is 255 (:code:`111111111` in binary),
+  and the byte at index 1 is 0. Any index less than the length of the byte string is valid.
+
+Bit Manipulation
+~~~~~~~~~~~~~~~~
+
+The :any:`GetBit` expression can extract individual bit values from integers and byte strings. For example,
+
+.. code-block:: python
+
+    GetBit(Int(16), Int(0)) # get the 0th bit of 16, produces 0
+    GetBit(Int(16), Int(4)) # get the 4th bit of 16, produces 1
+    GetBit(Int(16), Int(63)) # get the 63rd bit of 16, produces 0
+    GetBit(Int(16), Int(64)) # get the 64th bit of 16, invalid index
+
+    GetBit(Bytes("base16", "0xf0"), Int(0)) # get the 0th bit of 0xf0, produces 1
+    GetBit(Bytes("base16", "0xf0"), Int(7)) # get the 7th bit of 0xf0, produces 0
+    GetBit(Bytes("base16", "0xf0"), Int(8)) # get the 8th bit of 0xf0, invalid index
+
+Additionally, the :any:`SetBit` expression can modify individual bit values from integers and byte strings. For example,
+
+.. code-block:: python
+
+    SetBit(Int(0), Int(4), Int(1)) # set the 4th bit of 0 to 1, produces 16
+    SetBit(Int(4), Int(0), Int(1)) # set the 0th bit of 4 to 1, produces 5
+    SetBit(Int(4), Int(0), Int(0)) # set the 0th bit of 4 to 0, produces 4
+    
+    SetBit(Bytes("base16", "0x00"), Int(0), Int(1)) # set the 0th bit of 0x00 to 1, produces 0x80
+    SetBit(Bytes("base16", "0x00"), Int(3), Int(1)) # set the 3rd bit of 0x00 to 1, produces 0x10
+    SetBit(Bytes("base16", "0x00"), Int(7), Int(1)) # set the 7th bit of 0x00 to 1, produces 0x01
+
+Byte Manipulation
+~~~~~~~~~~~~~~~~~
+
+In addition to manipulating bits, individual bytes in byte strings can be manipulated.
+
+The :any:`GetByte` expression can extract individual bytes from byte strings. For example,
+
+.. code-block:: python
+
+    GetByte(Bytes("base16", "0xff00"), Int(0)) # get the 0th byte of 0xff00, produces 255
+    GetByte(Bytes("base16", "0xff00"), Int(1)) # get the 1st byte of 0xff00, produces 0
+    GetByte(Bytes("base16", "0xff00"), Int(2)) # get the 2nd byte of 0xff00, invalid index
+    
+    GetByte(Bytes("abc"), Int(0)) # get the 0th byte of "abc", produces 97 (ASCII 'a')
+    GetByte(Bytes("abc"), Int(1)) # get the 1st byte of "abc", produces 98 (ASCII 'b')
+    GetByte(Bytes("abc"), Int(2)) # get the 2nd byte of "abc", produces 99 (ASCII 'c')
+
+Additionally, the :any:`SetByte` expression can modify individual bytes in byte strings. For example,
+
+.. code-block:: python
+
+    SetByte(Bytes("base16", "0xff00"), Int(0), Int(0)) # set the 0th byte of 0xff00 to 0, produces 0x0000
+    SetByte(Bytes("base16", "0xff00"), Int(0), Int(128)) # set the 0th byte of 0xff00 to 128, produces 0x8000
+
+    SetByte(Bytes("abc"), Int(0), Int(98)) # set the 0th byte of "abc" to 98 (ASCII 'b'), produces "bbc"
+    SetByte(Bytes("abc"), Int(1), Int(66)) # set the 1st byte of "abc" to 66 (ASCII 'B'), produces "aBc"

--- a/docs/assets.rst
+++ b/docs/assets.rst
@@ -1,0 +1,146 @@
+.. _assets:
+
+Asset Information
+=================
+
+In addition to :ref:`manipulating state on the blockchain <state>`, stateful
+smart contracts can also look up information about assets and account balances.
+
+Algo Balances
+-------------
+
+The :any:`Balance` expression can be used to look up an account's balance in microAlgos (1 Algo = 1,000,000 microAlgos).
+For example,
+
+.. code-block:: python
+
+    senderBalance = Balance(Int(0)) # get the balance of Txn.accounts[0] (the sender)
+    account1Balance = Balance(Int(1)) # get the balance of Txn.accounts[1]
+
+The :any:`MinBalance` expression can be used to find an account's `minimum balance <https://developer.algorand.org/docs/features/accounts/#minimum-balance>`_.
+This amount is also in microAlgos. For example,
+
+.. code-block:: python
+
+    senderMinBalance = MinBalance(Int(0)) # get the minimum balance of Txn.accounts[0] (the sender)
+    account1MinBalance = MinBalance(Int(1)) # get the minimum balance of Txn.accounts[1]
+
+Additionally, :any:`Balance` and :any:`MinBalance` can be used together to calculate how many Algos
+an account can spend without closing. For example,
+
+.. code-block:: python
+
+    senderSpendableBalance = Balance(Int(0)) - MinBalance(Int(0)) # calculate how many Algos Txn.accounts[0] (the sender) can spend
+    account1SpendableBalance = Balance(Int(1)) - MinBalance(Int(1)) # calculate how many Algos Txn.accounts[1] can spend
+
+Asset Holdings
+--------------
+
+In addition to Algos, the Algorand blockchain also supports additional on-chain assets called `Algorand Standard Assets (ASAs) <https://developer.algorand.org/docs/features/asa/>`_.
+The :any:`AssetHolding` group of expressions can be used to look up information about the ASAs that
+an account holds.
+
+Similar to :ref:`external state expressions <external_state>`, these expression return a :any:`MaybeValue`.
+This value cannot be used directly, but has methods :any:`MaybeValue.hasValue()` and :any:`MaybeValue.value()`.
+
+If the account has opted into the asset being looked up, :code:`hasValue()` will return :code:`1`
+and :code:`value()` will return the value being looked up (either the asset's balance or frozen status).
+Otherwise, :code:`hasValue()` and :code:`value()` will return :code:`0`.
+
+Balances
+~~~~~~~~
+
+The :any:`AssetHolding.balance` expression can be used to look up how many units of an asset an
+account holds. For example,
+
+.. code-block:: python
+
+    # get the balance of Txn.accounts[0] (the sender) for asset 31566704
+    # if the account is not opted into that asset, returns 0
+    senderAssetBalance = AssetHolding.balance(Int(0), Int(31566704))
+    program = Seq([
+        senderAssetBalance,
+        senderAssetBalance.value()
+    ])
+
+    # get the balance of Txn.accounts[1] for asset 27165954
+    # if the account is not opted into that asset, exit with an error
+    account1AssetBalance = AssetHolding.balance(Int(1), Int(27165954))
+    program = Seq([
+        account1AssetBalance,
+        Assert(account1AssetBalance.hasValue()),
+        account1AssetBalance.value()
+    ])
+
+Frozen
+~~~~~~
+
+The :any:`AssetHolding.frozen` expression can be used to check if an asset is frozen for an account.
+A value of :code:`1` indicates frozen and :code:`0` indicates not frozen. For example,
+
+.. code-block:: python
+
+    # get the frozen status of Txn.accounts[0] (the sender) for asset 31566704
+    # if the account is not opted into that asset, returns 0
+    senderAssetFrozen = AssetHolding.frozen(Int(0), Int(31566704))
+    program = Seq([
+        senderAssetFrozen,
+        senderAssetFrozen.value()
+    ])
+
+    # get the frozen status of Txn.accounts[1] for asset 27165954
+    # if the account is not opted into that asset, exit with an error
+    account1AssetFrozen = AssetHolding.frozen(Int(1), Int(27165954))
+    program = Seq([
+        account1AssetFrozen,
+        Assert(account1AssetFrozen.hasValue()),
+        account1AssetFrozen.value()
+    ])
+
+Asset Parameters
+----------------
+
+Every ASA has parameters that contain information about the asset and how it behaves. These
+parameters can be read by TEAL applications for any asset in the :any:`Txn.assets <TxnObject.assets>`
+array.
+
+The :any:`AssetParam` group of expressions are used to access asset parameters. Like :code:`AssetHolding`,
+these expressions return a :any:`MaybeValue`.
+
+The :code:`hasValue()` method will return :code:`0` only if the asset being looked up does not exist
+(i.e. the ID in :code:`Txn.assets` does not represent an asset).
+
+For optional parameters that are not set, :code:`hasValue()` will still return :code:`1` and :code:`value()`
+will return a zero-length byte string (all optional parameters are :code:`TealType.bytes`).
+
+The different parameters that can be accessed are summarized by the table below. More information
+about each parameter can be found on the `Algorand developer website <https://developer.algorand.org/docs/features/asa/#asset-parameters>`_.
+
+================================= ======================= ==========================================================
+Expression                        Type                    Description
+================================= ======================= ==========================================================
+:any:`AssetParam.total()`         :code:`TealType.uint64` The total number of units of the asset.
+:any:`AssetParam.decimals()`      :code:`TealType.uint64` The number of decimals the asset should be formatted with.
+:any:`AssetParam.defaultFrozen()` :code:`TealType.uint64` Whether the asset is frozen by default.
+:any:`AssetParam.unitName()`      :code:`TealType.bytes`  The name of the asset's units.
+:any:`AssetParam.name()`          :code:`TealType.bytes`  The name of the asset.
+:any:`AssetParam.url()`           :code:`TealType.bytes`  A URL associated with the asset.
+:any:`AssetParam.metadataHash()`  :code:`TealType.bytes`  A 32-byte hash associated with the asset.
+:any:`AssetParam.manager()`       :code:`TealType.bytes`  The address of the asset's manager account.
+:any:`AssetParam.reserve()`       :code:`TealType.bytes`  The address of the asset's reserve account.
+:any:`AssetParam.freeze()`        :code:`TealType.bytes`  The address of the asset's freeze account.
+:any:`AssetParam.clawback()`      :code:`TealType.bytes`  The address of the asset's clawback account.
+================================= ======================= ==========================================================
+
+Here's an example that uses an asset parameter:
+
+.. code-block:: python
+
+    # get the total number of units for Txn.assets[0]
+    # if the asset is invalid, exit with an error
+    assetTotal = AssetParam.total(Int(0))
+    program = Seq([
+        assetTotal,
+        Assert(assetTotal.hasValue()),
+        assetTotal.value()
+    ])

--- a/docs/byte_expression.rst
+++ b/docs/byte_expression.rst
@@ -35,3 +35,9 @@ expression can extract part of a byte slicing given start and end indices. For e
 .. code-block:: python
 
     Substring(Bytes("algorand"), Int(0), Int(4)) # will produce "algo"
+
+Manipulating Individual Bits and Bytes
+--------------------------------------
+
+The individual bits and bytes in a byte string can be extracted and changed. See :ref:`bit_and_byte_manipulation`
+for more information.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,8 +30,7 @@ author = 'Algorand'
 # extensions = ['m2r']
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autosectionlabel'
+    'sphinx.ext.napoleon'
 ]
 source_suffix = ['.rst', '.md']
 master_doc = 'index'

--- a/docs/data_type.rst
+++ b/docs/data_type.rst
@@ -45,7 +45,7 @@ Base32
 ~~~~~~
 
 Byte slices can be created from a :rfc:`4648#section-6` base32 encoded
-binary string **without padding**, e.g. :code:`"7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M"`.
+binary string with or without padding, e.g. :code:`"7Z5PWO2C6LFNQFGHWKSK5H47IQP5OJW2M3HA2QPXTY3WTNP5NU2MHBW27M"`.
 
 .. code-block:: Python
 
@@ -78,10 +78,10 @@ Conversion
 
 Converting a value to its corresponding value in the other data type is supported by the following two operators:
 
- * :code:`Itob(n)`: generate a :code:`TealType.bytes` value from a :code:`TealType.uint64` value :code:`n`
- * :code:`Btoi(b)`: generate a :code:`TealType.uint64` value from a :code:`TealType.bytes` value :code:`b`
+ * :any:`Itob(n) <Itob>`: generate a :code:`TealType.bytes` value from a :code:`TealType.uint64` value :code:`n`
+ * :any:`Btoi(b) <Btoi>`: generate a :code:`TealType.uint64` value from a :code:`TealType.bytes` value :code:`b`
 
 **Note:** These operations are **not** meant to convert between human-readable strings and numbers.
-:code:`Itob` produces a big-endian 8-byte encoding of an unsigned integers, not a human readable
+:code:`Itob` produces a big-endian 8-byte encoding of an unsigned integer, not a human readable
 string. For example, :code:`Itob(Int(1))` will produce the string :code:`"\x00\x00\x00\x00\x00\x00\x00\x01"`
 not the string :code:`"1"`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ PyTeal **hasn't been security audited**. Use it at your own risk.
    scratch
    control_structures
    state
+   assets
    versions
 
 .. toctree::

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -12,9 +12,10 @@ TEAL Version PyTeal Version
 ============ ==============
 1            <= 0.5.4
 2            >= 0.6.0
+3            >= 0.7.0
 ============ ==============
 
-In order to support TEAL v2, PyTeal v0.6.4 breaks backward compatibility with v0.5.4. PyTeal
+In order to support TEAL v2, PyTeal v0.6.0 breaks backward compatibility with v0.5.4. PyTeal
 programs written for PyTeal version 0.5.4 and below will not compile properly and most likely will
 display an error of the form :code:`AttributeError: * object has no attribute 'teal'`.
 

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -25,6 +25,8 @@ class AssetHolding:
     def frozen(cls, account: Expr, asset: Expr) -> MaybeValue:
         """Check if an asset is frozen for an account.
 
+        A value of 1 indicates frozen and 0 indicates not frozen.
+
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check. Must
                 evaluate to uint64.
@@ -108,6 +110,8 @@ class AssetParam:
     def metadataHash(cls, asset: Expr) -> MaybeValue:
         """Get the arbitrary commitment for an asset.
 
+        If set, this will be 32 bytes long.
+
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
@@ -117,7 +121,7 @@ class AssetParam:
     
     @classmethod
     def manager(cls, asset: Expr) -> MaybeValue:
-        """Get the manager commitment for an asset.
+        """Get the manager address for an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -510,7 +510,7 @@ class TxnObject:
     def global_num_uints(self) -> TxnExpr:
         """Get the schema count of global state integers in an application creation call.
 
-        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall`.
+        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall` and this is an app creation call.
 
         Requires TEAL version 3 or higher.
         """
@@ -519,7 +519,7 @@ class TxnObject:
     def global_num_byte_slices(self) -> TxnExpr:
         """Get the schema count of global state byte slices in an application creation call.
 
-        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall`.
+        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall` and this is an app creation call.
 
         Requires TEAL version 3 or higher.
         """
@@ -528,7 +528,7 @@ class TxnObject:
     def local_num_uints(self) -> TxnExpr:
         """Get the schema count of local state integers in an application creation call.
 
-        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall`.
+        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall` and this is an app creation call.
 
         Requires TEAL version 3 or higher.
         """
@@ -537,7 +537,7 @@ class TxnObject:
     def local_num_byte_slices(self) -> TxnExpr:
         """Get the schema count of local state byte slices in an application creation call.
 
-        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall`.
+        Only set when :any:`type_enum()` is :any:`TxnType.ApplicationCall` and this is an app creation call.
 
         Requires TEAL version 3 or higher.
         """


### PR DESCRIPTION
This PR adds documentation for:

- [x]  `AssetHolding` and `AssetParam`
- [x] New transaction fields from TEAL 3
- [x] Bit/byte manipulation expressions from TEAL 3

Closes #39, closes #51.