### PR TITLE
Add algosdk to docs deps

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 m2r
 sphinx_rtd_theme
+py-algorand-sdk


### PR DESCRIPTION
Add py-algorand-sdk to the docs dependencies.

Closes #59.