### PR TITLE
Fix const assembly with templates

### DIFF
--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -130,14 +130,14 @@ def test_slot_load_before_store():
         compileTeal(program, Mode.Application, version=2)
 
 def test_assembleConstants():
-    program = Itob(Int(1) + Int(1) + Int(2)) == Concat(Bytes("test"), Bytes("test"), Bytes("test2"))
+    program = Itob(Int(1) + Int(1) + Tmpl.Int("TMPL_VAR")) == Concat(Bytes("test"), Bytes("test"), Bytes("test2"))
 
     expectedNoAssemble = """
 #pragma version 3
 int 1
 int 1
 +
-int 2
+int TMPL_VAR
 +
 itob
 byte "test"
@@ -157,7 +157,7 @@ bytecblock 0x74657374
 intc_0 // 1
 intc_0 // 1
 +
-pushint 2 // 2
+pushint TMPL_VAR // TMPL_VAR
 +
 itob
 bytec_0 // "test"

--- a/pyteal/compiler/constants.py
+++ b/pyteal/compiler/constants.py
@@ -114,8 +114,8 @@ def createConstantBlocks(ops: List[TealComponent]) -> List[TealComponent]:
             byteFreqs[addrValue] += 1
 
     assembled: List[TealComponent] = []
-    sortedInts = sorted(intFreqs.keys(), key=lambda x: (intFreqs[x], x), reverse=True)
-    sortedBytes = sorted(byteFreqs.keys(), key=lambda x: (byteFreqs[x], x), reverse=True)
+    sortedInts = sorted(intFreqs.keys(), key=lambda x: (intFreqs[x], str(x)), reverse=True)
+    sortedBytes = sorted(byteFreqs.keys(), key=lambda x: (byteFreqs[x], x.hex() if type(x) == bytes else x), reverse=True)
 
     intBlock = [i for i in sortedInts if intFreqs[i] > 1]
     byteBlock = [('0x'+cast(bytes, b).hex()) if type(b) == bytes else cast(str, b) for b in sortedBytes if byteFreqs[b] > 1]

--- a/pyteal/compiler/constants.py
+++ b/pyteal/compiler/constants.py
@@ -115,7 +115,7 @@ def createConstantBlocks(ops: List[TealComponent]) -> List[TealComponent]:
 
     assembled: List[TealComponent] = []
     sortedInts = sorted(intFreqs.keys(), key=lambda x: (intFreqs[x], str(x)), reverse=True)
-    sortedBytes = sorted(byteFreqs.keys(), key=lambda x: (byteFreqs[x], x.hex() if type(x) == bytes else x), reverse=True)
+    sortedBytes = sorted(byteFreqs.keys(), key=lambda x: (byteFreqs[x], cast(bytes, x).hex() if type(x) == bytes else x), reverse=True)
 
     intBlock = [i for i in sortedInts if intFreqs[i] > 1]
     byteBlock = [('0x'+cast(bytes, b).hex()) if type(b) == bytes else cast(str, b) for b in sortedBytes if byteFreqs[b] > 1]

--- a/pyteal/compiler/constants_test.py
+++ b/pyteal/compiler/constants_test.py
@@ -318,3 +318,162 @@ def test_createConstantBlocks_all():
     actual = createConstantBlocks(ops)
     assert actual == expected
 
+def test_createConstantBlocks_tmpl_int():
+    ops = [
+        TealOp(None, Op.int, "TMPL_INT_1"),
+        TealOp(None, Op.int, "TMPL_INT_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.int, "TMPL_INT_2"),
+        TealOp(None, Op.add),
+    ]
+
+    expected = [
+        TealOp(None, Op.intcblock, "TMPL_INT_1"),
+        TealOp(None, Op.intc_0, "//", "TMPL_INT_1"),
+        TealOp(None, Op.intc_0, "//", "TMPL_INT_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.pushint, "TMPL_INT_2", "//", "TMPL_INT_2"),
+        TealOp(None, Op.add),
+    ]
+
+    actual = createConstantBlocks(ops)
+    assert actual == expected
+
+def test_createConstantBlocks_tmpl_int_mixed():
+    ops = [
+        TealOp(None, Op.int, "TMPL_INT_1"),
+        TealOp(None, Op.int, "TMPL_INT_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.int, "TMPL_INT_2"),
+        TealOp(None, Op.add),
+        TealOp(None, Op.int, 0),
+        TealOp(None, Op.int, 0),
+        TealOp(None, Op.add),
+        TealOp(None, Op.int, 1),
+        TealOp(None, Op.add),
+    ]
+
+    expected = [
+        TealOp(None, Op.intcblock, "TMPL_INT_1", 0),
+        TealOp(None, Op.intc_0, "//", "TMPL_INT_1"),
+        TealOp(None, Op.intc_0, "//", "TMPL_INT_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.pushint, "TMPL_INT_2", "//", "TMPL_INT_2"),
+        TealOp(None, Op.add),
+        TealOp(None, Op.intc_1, "//", 0),
+        TealOp(None, Op.intc_1, "//", 0),
+        TealOp(None, Op.add),
+        TealOp(None, Op.pushint, 1, "//", 1),
+        TealOp(None, Op.add),
+    ]
+
+    actual = createConstantBlocks(ops)
+    assert actual == expected
+
+def test_createConstantBlocks_tmpl_bytes():
+    ops = [
+        TealOp(None, Op.byte, "TMPL_BYTES_1"),
+        TealOp(None, Op.byte, "TMPL_BYTES_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.byte, "TMPL_BYTES_2"),
+        TealOp(None, Op.concat),
+    ]
+
+    expected = [
+        TealOp(None, Op.bytecblock, "TMPL_BYTES_1"),
+        TealOp(None, Op.bytec_0, "//", "TMPL_BYTES_1"),
+        TealOp(None, Op.bytec_0, "//", "TMPL_BYTES_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.pushbytes, "TMPL_BYTES_2", "//", "TMPL_BYTES_2"),
+        TealOp(None, Op.concat),
+    ]
+
+    actual = createConstantBlocks(ops)
+    assert actual == expected
+
+def test_createConstantBlocks_tmpl_bytes_mixed():
+    ops = [
+        TealOp(None, Op.byte, "TMPL_BYTES_1"),
+        TealOp(None, Op.byte, "TMPL_BYTES_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.byte, "TMPL_BYTES_2"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.byte, "0x00"),
+        TealOp(None, Op.byte, "0x00"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.byte, "0x01"),
+        TealOp(None, Op.concat),
+    ]
+
+    expected = [
+        TealOp(None, Op.bytecblock, "TMPL_BYTES_1", "0x00"),
+        TealOp(None, Op.bytec_0, "//", "TMPL_BYTES_1"),
+        TealOp(None, Op.bytec_0, "//", "TMPL_BYTES_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.pushbytes, "TMPL_BYTES_2", "//", "TMPL_BYTES_2"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.bytec_1, "//", "0x00"),
+        TealOp(None, Op.bytec_1, "//", "0x00"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.pushbytes, "0x01", "//", "0x01"),
+        TealOp(None, Op.concat),
+    ]
+
+    actual = createConstantBlocks(ops)
+    assert actual == expected
+
+def test_createConstantBlocks_tmpl_all():
+    ops = [
+        TealOp(None, Op.byte, "TMPL_BYTES_1"),
+        TealOp(None, Op.byte, "TMPL_BYTES_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.byte, "TMPL_BYTES_2"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.byte, "0x00"),
+        TealOp(None, Op.byte, "0x00"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.byte, "0x01"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.len),
+        TealOp(None, Op.int, "TMPL_INT_1"),
+        TealOp(None, Op.int, "TMPL_INT_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.int, "TMPL_INT_2"),
+        TealOp(None, Op.add),
+        TealOp(None, Op.int, 0),
+        TealOp(None, Op.int, 0),
+        TealOp(None, Op.add),
+        TealOp(None, Op.int, 1),
+        TealOp(None, Op.add),
+        TealOp(None, Op.eq),
+    ]
+
+    expected = [
+        TealOp(None, Op.intcblock, "TMPL_INT_1", 0),
+        TealOp(None, Op.bytecblock, "TMPL_BYTES_1", "0x00"),
+        TealOp(None, Op.bytec_0, "//", "TMPL_BYTES_1"),
+        TealOp(None, Op.bytec_0, "//", "TMPL_BYTES_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.pushbytes, "TMPL_BYTES_2", "//", "TMPL_BYTES_2"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.bytec_1, "//", "0x00"),
+        TealOp(None, Op.bytec_1, "//", "0x00"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.pushbytes, "0x01", "//", "0x01"),
+        TealOp(None, Op.concat),
+        TealOp(None, Op.len),
+        TealOp(None, Op.intc_0, "//", "TMPL_INT_1"),
+        TealOp(None, Op.intc_0, "//", "TMPL_INT_1"),
+        TealOp(None, Op.eq),
+        TealOp(None, Op.pushint, "TMPL_INT_2", "//", "TMPL_INT_2"),
+        TealOp(None, Op.add),
+        TealOp(None, Op.intc_1, "//", 0),
+        TealOp(None, Op.intc_1, "//", 0),
+        TealOp(None, Op.add),
+        TealOp(None, Op.pushint, 1, "//", 1),
+        TealOp(None, Op.add),
+        TealOp(None, Op.eq),
+    ]
+
+    actual = createConstantBlocks(ops)
+    assert actual == expected


### PR DESCRIPTION
The constant assembly introduced by #57 included a bug that did not allow a program to use both concrete constants and templated constants. The bug was in the sorting function, since ints or bytes were being compared with strings. This PR fixes this and adds regression tests.