### PR TITLE
Modify constant order for same frequency

### DIFF
--- a/pyteal/compiler/constants.py
+++ b/pyteal/compiler/constants.py
@@ -1,7 +1,7 @@
 import base64
-import collections
 
 from typing import Union, List, Dict, cast
+from collections import OrderedDict
 from algosdk import encoding
 
 from ..ir import Op, TealOp, TealLabel, TealComponent, TealBlock, TealSimpleBlock, TealConditionalBlock
@@ -94,8 +94,8 @@ def createConstantBlocks(ops: List[TealComponent]) -> List[TealComponent]:
         A list of TealComponent that are functionally the same as the input, but with all constants
         loaded either through blocks or the `pushint`/`pushbytes` single-use ops.
     """
-    intFreqs: Dict[Union[str, int], int] = collections.OrderedDict()
-    byteFreqs: Dict[Union[str, bytes], int] = collections.OrderedDict()
+    intFreqs: Dict[Union[str, int], int] = OrderedDict()
+    byteFreqs: Dict[Union[str, bytes], int] = OrderedDict()
 
     for op in ops:
         if not isinstance(op, TealOp):

--- a/pyteal/compiler/constants.py
+++ b/pyteal/compiler/constants.py
@@ -1,7 +1,7 @@
 import base64
+import collections
 
-from typing import Union, List, DefaultDict, cast
-from collections import defaultdict
+from typing import Union, List, OrderedDict, cast
 from algosdk import encoding
 
 from ..ir import Op, TealOp, TealLabel, TealComponent, TealBlock, TealSimpleBlock, TealConditionalBlock
@@ -94,8 +94,8 @@ def createConstantBlocks(ops: List[TealComponent]) -> List[TealComponent]:
         A list of TealComponent that are functionally the same as the input, but with all constants
         loaded either through blocks or the `pushint`/`pushbytes` single-use ops.
     """
-    intFreqs: DefaultDict[Union[str, int], int] = defaultdict(int)
-    byteFreqs: DefaultDict[Union[str, bytes], int] = defaultdict(int)
+    intFreqs: OrderedDict[Union[str, int], int] = collections.OrderedDict()
+    byteFreqs: OrderedDict[Union[str, bytes], int] = collections.OrderedDict()
 
     for op in ops:
         if not isinstance(op, TealOp):
@@ -105,17 +105,20 @@ def createConstantBlocks(ops: List[TealComponent]) -> List[TealComponent]:
 
         if basicOp == Op.int:
             intValue = extractIntValue(op)
-            intFreqs[intValue] += 1
+            intFreqs[intValue] = intFreqs.get(intValue, 0) + 1
         elif basicOp == Op.byte:
             byteValue = extractBytesValue(op)
-            byteFreqs[byteValue] += 1
+            byteFreqs[byteValue] = byteFreqs.get(byteValue, 0) + 1
         elif basicOp == Op.addr:
             addrValue = extractAddrValue(op)
-            byteFreqs[addrValue] += 1
+            byteFreqs[addrValue] = byteFreqs.get(addrValue, 0) + 1
 
     assembled: List[TealComponent] = []
-    sortedInts = sorted(intFreqs.keys(), key=lambda x: (intFreqs[x], str(x)), reverse=True)
-    sortedBytes = sorted(byteFreqs.keys(), key=lambda x: (byteFreqs[x], cast(bytes, x).hex() if type(x) == bytes else x), reverse=True)
+
+    # because we used OrderedDicts and python sorting is stable, constants with the same frequency
+    # will remain in the same order, i.e. first defined, first in block
+    sortedInts = sorted(intFreqs, key=lambda x: intFreqs[x], reverse=True)
+    sortedBytes = sorted(byteFreqs, key=lambda x: byteFreqs[x], reverse=True)
 
     intBlock = [i for i in sortedInts if intFreqs[i] > 1]
     byteBlock = [('0x'+cast(bytes, b).hex()) if type(b) == bytes else cast(str, b) for b in sortedBytes if byteFreqs[b] > 1]

--- a/pyteal/compiler/constants.py
+++ b/pyteal/compiler/constants.py
@@ -1,7 +1,7 @@
 import base64
 import collections
 
-from typing import Union, List, OrderedDict, cast
+from typing import Union, List, Dict, cast
 from algosdk import encoding
 
 from ..ir import Op, TealOp, TealLabel, TealComponent, TealBlock, TealSimpleBlock, TealConditionalBlock
@@ -94,8 +94,8 @@ def createConstantBlocks(ops: List[TealComponent]) -> List[TealComponent]:
         A list of TealComponent that are functionally the same as the input, but with all constants
         loaded either through blocks or the `pushint`/`pushbytes` single-use ops.
     """
-    intFreqs: OrderedDict[Union[str, int], int] = collections.OrderedDict()
-    byteFreqs: OrderedDict[Union[str, bytes], int] = collections.OrderedDict()
+    intFreqs: Dict[Union[str, int], int] = collections.OrderedDict()
+    byteFreqs: Dict[Union[str, bytes], int] = collections.OrderedDict()
 
     for op in ops:
         if not isinstance(op, TealOp):

--- a/pyteal/compiler/constants_test.py
+++ b/pyteal/compiler/constants_test.py
@@ -115,15 +115,15 @@ def test_createConstantBlocks_intblock_multiple():
     ]
 
     expected = [
-        TealOp(None, Op.intcblock, 3, 2, 1),
-        TealOp(None, Op.intc_2, "//", 1),
-        TealOp(None, Op.intc_2, "//", "OptIn"),
+        TealOp(None, Op.intcblock, 1, 2, 3),
+        TealOp(None, Op.intc_0, "//", 1),
+        TealOp(None, Op.intc_0, "//", "OptIn"),
         TealOp(None, Op.add),
         TealOp(None, Op.intc_1, "//", 2),
         TealOp(None, Op.intc_1, "//", "keyreg"),
         TealOp(None, Op.add),
-        TealOp(None, Op.intc_0, "//", 3),
-        TealOp(None, Op.intc_0, "//", "ClearState"),
+        TealOp(None, Op.intc_2, "//", 3),
+        TealOp(None, Op.intc_2, "//", "ClearState"),
         TealOp(None, Op.add),
     ]
 
@@ -214,19 +214,19 @@ def test_createConstantBlocks_byteblock_multiple():
     ]
 
     expected = [
-        TealOp(None, Op.bytecblock, "0x0102", "0xb49276bd3ec0977eab86a321c449ead802c96c0bd97c2956131511d2f11eebec", "0x74657374"),
+        TealOp(None, Op.bytecblock, "0x0102", "0x74657374", "0xb49276bd3ec0977eab86a321c449ead802c96c0bd97c2956131511d2f11eebec"),
         TealOp(None, Op.bytec_0, "//", "0x0102"),
         TealOp(None, Op.bytec_0, "//", "base64(AQI=)"),
         TealOp(None, Op.concat),
         TealOp(None, Op.bytec_0, "//", "base32(AEBA====)"),
         TealOp(None, Op.concat),
-        TealOp(None, Op.bytec_2, "//", "\"test\""),
+        TealOp(None, Op.bytec_1, "//", "\"test\""),
         TealOp(None, Op.concat),
-        TealOp(None, Op.bytec_2, "//", "base32(ORSXG5A=)"),
+        TealOp(None, Op.bytec_1, "//", "base32(ORSXG5A=)"),
         TealOp(None, Op.concat),
-        TealOp(None, Op.bytec_1, "//", "0xb49276bd3ec0977eab86a321c449ead802c96c0bd97c2956131511d2f11eebec"),
+        TealOp(None, Op.bytec_2, "//", "0xb49276bd3ec0977eab86a321c449ead802c96c0bd97c2956131511d2f11eebec"),
         TealOp(None, Op.concat),
-        TealOp(None, Op.bytec_1, "//", "WSJHNPJ6YCLX5K4GUMQ4ISPK3ABMS3AL3F6CSVQTCUI5F4I65PWEMCWT3M"),
+        TealOp(None, Op.bytec_2, "//", "WSJHNPJ6YCLX5K4GUMQ4ISPK3ABMS3AL3F6CSVQTCUI5F4I65PWEMCWT3M"),
         TealOp(None, Op.concat),
     ]
 


### PR DESCRIPTION
Prior to this PR, when compiling with `assembleConstants` enabled, constants referenced with the same frequency would have their order determined by comparing the value of the constant being referenced. This PR takes advantage of Python's stable sorting to maintain the relative order of constants with the same frequency instead of using their value as an arbitrary tiebreaker.

This change should make PyTeal's constant assembly identical to the optimized assembly implemented in algorand/go-algorand#2215.