### PR TITLE
Add ops for Byteslice arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ pyteal requires python version >= 3.6
 
 * `pip3 install pyteal`
 
+Install dependencies :
+
+* `pip3 install -r requirements.txt`
+
 ### Documentation
 
 [PyTeal Docs](https://pyteal.readthedocs.io/)

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ pyteal requires python version >= 3.6
 
 * `pip3 install pyteal`
 
-Install dependencies :
-
-* `pip3 install -r requirements.txt`
-
 ### Documentation
 
 [PyTeal Docs](https://pyteal.readthedocs.io/)
@@ -42,14 +38,15 @@ In pyteal root directory:
 Setup venv (one time):
  * `python3 -m venv venv`
 
-
 Active venv:
  * `. venv/bin/activate.fish` (if your shell is fish)
  * `. venv/bin/activate` (if your shell is bash/zsh)
 
-
 Pip install pyteal in editable state
  * `pip install -e .`
+
+Install dependencies :
+* `pip3 install -r requirements.txt`
  
 Type checking using mypy
 * `mypy pyteal`

--- a/docs/arithmetic_expression.rst
+++ b/docs/arithmetic_expression.rst
@@ -45,6 +45,36 @@ The associativity and precedence of the overloaded Python arithmetic operators a
  * :code:`Int(1) + Int(2) + Int(3)` is equivalent to :code:`Add(Add(Int(1), Int(2)), Int(3))`
  * :code:`Int(1) + Int(2) * Int(3)` is equivalent to :code:`Add(Int(1), Mul(Int(2), Int(3)))` 
 
+Byteslice Arithmetic
+~~~~~~~~~~~~~~~~~~~~
+
+Byteslice arithemetic is available for Teal V4 and above. 
+In PyTeal, byteslice arithmetic expressions include :code:`TealType.Bytes` values as arguments (with the exception of :code:`BZero`).
+The table below summarizes the byteslize arithmetic operations in PyTeal.
+
+=================================== ================================================= ===========================
+Operator                            Semantics                                         Example
+=================================== ================================================= ===========================
+:any:`BLt(a, b) <BLt>`              `1` if `a` is less than `b`, `0` otherwise        :code:`BLt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
+:any:`BGt(a, b) <BGt>`              `1` if `a` is greater than `b`, `0` otherwise     :code:`BGt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
+:any:`BLe(a, b) <BLe>`              `1` if `a` is no greater than `b`, `0` otherwise  :code:`BLe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
+:any:`BGe(a, b) <BGe>`              `1` if `a` is no less than `b`, `0` otherwise     :code:`BGe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
+:any:`BAdd(a, b) <BAdd>`            `a + b`, error (panic) if overflow                :code:`BAdd(Bytes("base16", "0x10"), Bytes("base16", "0x11"))`
+:any:`BMinus(a, b) <BMinus>`        `a - b`, error if underflow                       :code:`BMinus(Bytes("base16", "0x10"), Bytes("base16", "0x11"))`
+:any:`BMul(a, b) <BMul>`            `a * b`, error if overflow                        :code:`BMul(Bytes("base16", "0x10"), Bytes("base16", "0x11"))`
+:any:`BDiv(a, b) <BDiv>`            `a / b`, error if divided by zero                 :code:`BDiv(Bytes("base16", "0x10"), Bytes("base16", "0x11"))`
+:any:`BMod(a, b) <BMod>`            `a % b`, modulo operation                         :code:`BMod(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
+:any:`BEq(a, b) <BEq>`              `1` if `a` equals `b`, `0` otherwise              :code:`BEq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`
+:any:`BNeq(a, b) <BNeq>`            `0` if `a` equals `b`, `1` otherwise              :code:`BNeq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`
+:any:`BAnd(a, b) <pyteal.BAnd>`     `1` if `a > 0 && b > 0`, `0` otherwise            :code:`BAnd(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
+:any:`BOr(a, b) <pyteal.BOr>`       `1` if `a > 0 || b > 0`, `0` otherwise            :code:`BOr(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
+:any:`BXOr(a, b) <pyteal.BXor>`     `a ^ b`, bit-wise xor operation                   :code:`BXor(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
+:any:`BNot(a) <pyteal.BNot>`        `~a`, invert all its bits                         :code:`BNot(Bytes("base16", "0xFF00"))`
+:any:`BZero(a) <pyteal.BZero>`      return bytearray of length a with all zero bytes  :code:`BZero(Int(8))`
+=================================== ================================================= ===========================
+
+Currently, byteslice arithmetic operations are not overloaded, and must be explicitly called.
+
 .. _bit_and_byte_manipulation:
 
 Bit and Byte Operations

--- a/docs/arithmetic_expression.rst
+++ b/docs/arithmetic_expression.rst
@@ -55,26 +55,26 @@ In PyTeal, byteslice arithmetic expressions include
 and must be 64 bytes or less.
 The table below summarizes the byteslize arithmetic operations in PyTeal.
 
-======================================= ============= ====================================================================== ==================
-Operator                                Return Type   Example                                                                Example Result
-======================================= ============= ====================================================================== ==================
-:any:`BytesLt(a, b) <BytesLt>`          :code:`Int`   :code:`BytesLt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`0`
-:any:`BytesGt(a, b) <BytesGt>`          :code:`Int`   :code:`BytesGt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`1`
-:any:`BytesLe(a, b) <BytesLe>`          :code:`Int`   :code:`BytesLe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`0`
-:any:`BytesGe(a, b) <BytesGe>`          :code:`Int`   :code:`BytesGe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`1`
-:any:`BytesAdd(a, b) <BytesAdd>`        :code:`Bytes` :code:`BytesAdd(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`     :code:`0x1FD`
-:any:`BytesMinus(a, b) <BytesMinus>`    :code:`Bytes` :code:`BytesMinus(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`   :code:`0x1`
-:any:`BytesMul(a, b) <BytesMul>`        :code:`Bytes` :code:`BytesMul(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`     :code:`0xFD02`
-:any:`BytesDiv(a, b) <BytesDiv>`        :code:`Bytes` :code:`BytesDiv(Bytes("base16", "0xFF"), Bytes("base16", "0x11"))`     :code:`0xF`
-:any:`BytesMod(a, b) <BytesMod>`        :code:`Bytes` :code:`BytesMod(Bytes("base16", "0xFF"), Bytes("base16", "0x12"))`     :code:`0x3`
-:any:`BytesEq(a, b) <BytesEq>`          :code:`Int`   :code:`BytesEq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`      :code:`1`
-:any:`BytesNeq(a, b) <BytesNeq>`        :code:`Int`   :code:`BytesNeq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`     :code:`0`
-:any:`BytesAnd(a, b) <pyteal.BytesAnd>` :code:`Bytes` :code:`BytesAnd(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))` :code:`0x1227`
-:any:`BytesOr(a, b) <pyteal.BytesOr>`   :code:`Bytes` :code:`BytesOr(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))`  :code:`0xBFFF`
-:any:`BytesXor(a, b) <pyteal.BytesXor>` :code:`Bytes` :code:`BytesXor(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))` :code:`0xADD8`
-:any:`BytesNot(a) <pyteal.BytesNot>`    :code:`Bytes` :code:`BytesNot(Bytes("base16", "0xFF00"))`                            :code:`0x00FF`
-:any:`BytesZero(a) <pyteal.BytesZero>`  :code:`Bytes` :code:`BytesZero(Int(8))`                                              :code:`0x00000000`
-======================================= ============= ====================================================================== ==================
+======================================= ======================= ====================================================================== ==================
+Operator                                Return Type             Example                                                                Example Result
+======================================= ======================= ====================================================================== ==================
+:any:`BytesLt(a, b) <BytesLt>`          :code:`TealType.uint64` :code:`BytesLt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`0`
+:any:`BytesGt(a, b) <BytesGt>`          :code:`TealType.uint64` :code:`BytesGt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`1`
+:any:`BytesLe(a, b) <BytesLe>`          :code:`TealType.uint64` :code:`BytesLe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`0`
+:any:`BytesGe(a, b) <BytesGe>`          :code:`TealType.uint64` :code:`BytesGe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`1`
+:any:`BytesEq(a, b) <BytesEq>`          :code:`TealType.uint64` :code:`BytesEq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`      :code:`1`
+:any:`BytesNeq(a, b) <BytesNeq>`        :code:`TealType.uint64` :code:`BytesNeq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`     :code:`0`
+:any:`BytesAdd(a, b) <BytesAdd>`        :code:`TealType.Bytes`  :code:`BytesAdd(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`     :code:`0x01FD`
+:any:`BytesMinus(a, b) <BytesMinus>`    :code:`TealType.Bytes`  :code:`BytesMinus(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`   :code:`0x01`
+:any:`BytesMul(a, b) <BytesMul>`        :code:`TealType.Bytes`  :code:`BytesMul(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`     :code:`0xFD02`
+:any:`BytesDiv(a, b) <BytesDiv>`        :code:`TealType.Bytes`  :code:`BytesDiv(Bytes("base16", "0xFF"), Bytes("base16", "0x11"))`     :code:`0x0F`
+:any:`BytesMod(a, b) <BytesMod>`        :code:`TealType.Bytes`  :code:`BytesMod(Bytes("base16", "0xFF"), Bytes("base16", "0x12"))`     :code:`0x03`
+:any:`BytesAnd(a, b) <pyteal.BytesAnd>` :code:`TealType.Bytes`  :code:`BytesAnd(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))` :code:`0x1227`
+:any:`BytesOr(a, b) <pyteal.BytesOr>`   :code:`TealType.Bytes`  :code:`BytesOr(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))`  :code:`0xBFFF`
+:any:`BytesXor(a, b) <pyteal.BytesXor>` :code:`TealType.Bytes`  :code:`BytesXor(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))` :code:`0xADD8`
+:any:`BytesNot(a) <pyteal.BytesNot>`    :code:`TealType.Bytes`  :code:`BytesNot(Bytes("base16", "0xFF00"))`                            :code:`0x00FF`
+:any:`BytesZero(a) <pyteal.BytesZero>`  :code:`TealType.Bytes`  :code:`BytesZero(Int(8))`                                              :code:`0x00000000`
+======================================= ======================= ====================================================================== ==================
 
 Currently, byteslice arithmetic operations are not overloaded, and must be explicitly called.
 

--- a/docs/arithmetic_expression.rst
+++ b/docs/arithmetic_expression.rst
@@ -46,7 +46,7 @@ The associativity and precedence of the overloaded Python arithmetic operators a
  * :code:`Int(1) + Int(2) * Int(3)` is equivalent to :code:`Add(Int(1), Mul(Int(2), Int(3)))` 
 
 Byteslice Arithmetic
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Byteslice arithemetic is available for Teal V4 and above. 
 Byteslice arithmetic operators allow up to 512-bit arithmetic.
@@ -73,7 +73,7 @@ Operator                                Return Type             Example         
 :any:`BytesOr(a, b) <pyteal.BytesOr>`   :code:`TealType.Bytes`  :code:`BytesOr(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))`  :code:`0xBFFF`
 :any:`BytesXor(a, b) <pyteal.BytesXor>` :code:`TealType.Bytes`  :code:`BytesXor(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))` :code:`0xADD8`
 :any:`BytesNot(a) <pyteal.BytesNot>`    :code:`TealType.Bytes`  :code:`BytesNot(Bytes("base16", "0xFF00"))`                            :code:`0x00FF`
-:any:`BytesZero(a) <pyteal.BytesZero>`  :code:`TealType.Bytes`  :code:`BytesZero(Int(8))`                                              :code:`0x00000000`
+:any:`BytesZero(a) <pyteal.BytesZero>`  :code:`TealType.Bytes`  :code:`BytesZero(Int(4))`                                              :code:`0x00000000`
 ======================================= ======================= ====================================================================== ==================
 
 Currently, byteslice arithmetic operations are not overloaded, and must be explicitly called.

--- a/docs/arithmetic_expression.rst
+++ b/docs/arithmetic_expression.rst
@@ -49,29 +49,32 @@ Byteslice Arithmetic
 ~~~~~~~~~~~~~~~~~~~~
 
 Byteslice arithemetic is available for Teal V4 and above. 
-In PyTeal, byteslice arithmetic expressions include :code:`TealType.Bytes` values as arguments (with the exception of :code:`BZero`).
+Byteslice arithmetic operators allow up to 512-bit arithmetic.
+In PyTeal, byteslice arithmetic expressions include 
+:code:`TealType.Bytes` values as arguments (with the exception of :code:`BytesZero`)
+and must be 64 bytes or less.
 The table below summarizes the byteslize arithmetic operations in PyTeal.
 
-=================================== ================================================= ===========================
-Operator                            Semantics                                         Example
-=================================== ================================================= ===========================
-:any:`BLt(a, b) <BLt>`              `1` if `a` is less than `b`, `0` otherwise        :code:`BLt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
-:any:`BGt(a, b) <BGt>`              `1` if `a` is greater than `b`, `0` otherwise     :code:`BGt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
-:any:`BLe(a, b) <BLe>`              `1` if `a` is no greater than `b`, `0` otherwise  :code:`BLe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
-:any:`BGe(a, b) <BGe>`              `1` if `a` is no less than `b`, `0` otherwise     :code:`BGe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
-:any:`BAdd(a, b) <BAdd>`            `a + b`, error (panic) if overflow                :code:`BAdd(Bytes("base16", "0x10"), Bytes("base16", "0x11"))`
-:any:`BMinus(a, b) <BMinus>`        `a - b`, error if underflow                       :code:`BMinus(Bytes("base16", "0x10"), Bytes("base16", "0x11"))`
-:any:`BMul(a, b) <BMul>`            `a * b`, error if overflow                        :code:`BMul(Bytes("base16", "0x10"), Bytes("base16", "0x11"))`
-:any:`BDiv(a, b) <BDiv>`            `a / b`, error if divided by zero                 :code:`BDiv(Bytes("base16", "0x10"), Bytes("base16", "0x11"))`
-:any:`BMod(a, b) <BMod>`            `a % b`, modulo operation                         :code:`BMod(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
-:any:`BEq(a, b) <BEq>`              `1` if `a` equals `b`, `0` otherwise              :code:`BEq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`
-:any:`BNeq(a, b) <BNeq>`            `0` if `a` equals `b`, `1` otherwise              :code:`BNeq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`
-:any:`BAnd(a, b) <pyteal.BAnd>`     `1` if `a > 0 && b > 0`, `0` otherwise            :code:`BAnd(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
-:any:`BOr(a, b) <pyteal.BOr>`       `1` if `a > 0 || b > 0`, `0` otherwise            :code:`BOr(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
-:any:`BXOr(a, b) <pyteal.BXor>`     `a ^ b`, bit-wise xor operation                   :code:`BXor(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`
-:any:`BNot(a) <pyteal.BNot>`        `~a`, invert all its bits                         :code:`BNot(Bytes("base16", "0xFF00"))`
-:any:`BZero(a) <pyteal.BZero>`      return bytearray of length a with all zero bytes  :code:`BZero(Int(8))`
-=================================== ================================================= ===========================
+======================================= ============= ====================================================================== ==================
+Operator                                Return Type   Example                                                                Example Result
+======================================= ============= ====================================================================== ==================
+:any:`BytesLt(a, b) <BytesLt>`          :code:`Int`   :code:`BytesLt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`0`
+:any:`BytesGt(a, b) <BytesGt>`          :code:`Int`   :code:`BytesGt(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`1`
+:any:`BytesLe(a, b) <BytesLe>`          :code:`Int`   :code:`BytesLe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`0`
+:any:`BytesGe(a, b) <BytesGe>`          :code:`Int`   :code:`BytesGe(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`      :code:`1`
+:any:`BytesAdd(a, b) <BytesAdd>`        :code:`Bytes` :code:`BytesAdd(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`     :code:`0x1FD`
+:any:`BytesMinus(a, b) <BytesMinus>`    :code:`Bytes` :code:`BytesMinus(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`   :code:`0x1`
+:any:`BytesMul(a, b) <BytesMul>`        :code:`Bytes` :code:`BytesMul(Bytes("base16", "0xFF"), Bytes("base16", "0xFE"))`     :code:`0xFD02`
+:any:`BytesDiv(a, b) <BytesDiv>`        :code:`Bytes` :code:`BytesDiv(Bytes("base16", "0xFF"), Bytes("base16", "0x11"))`     :code:`0xF`
+:any:`BytesMod(a, b) <BytesMod>`        :code:`Bytes` :code:`BytesMod(Bytes("base16", "0xFF"), Bytes("base16", "0x12"))`     :code:`0x3`
+:any:`BytesEq(a, b) <BytesEq>`          :code:`Int`   :code:`BytesEq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`      :code:`1`
+:any:`BytesNeq(a, b) <BytesNeq>`        :code:`Int`   :code:`BytesNeq(Bytes("base16", "0xFF"), Bytes("base16", "0xFF"))`     :code:`0`
+:any:`BytesAnd(a, b) <pyteal.BytesAnd>` :code:`Bytes` :code:`BytesAnd(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))` :code:`0x1227`
+:any:`BytesOr(a, b) <pyteal.BytesOr>`   :code:`Bytes` :code:`BytesOr(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))`  :code:`0xBFFF`
+:any:`BytesXor(a, b) <pyteal.BytesXor>` :code:`Bytes` :code:`BytesXor(Bytes("base16", "0xBEEF"), Bytes("base16", "0x1337"))` :code:`0xADD8`
+:any:`BytesNot(a) <pyteal.BytesNot>`    :code:`Bytes` :code:`BytesNot(Bytes("base16", "0xFF00"))`                            :code:`0x00FF`
+:any:`BytesZero(a) <pyteal.BytesZero>`  :code:`Bytes` :code:`BytesZero(Int(8))`                                              :code:`0x00000000`
+======================================= ============= ====================================================================== ==================
 
 Currently, byteslice arithmetic operations are not overloaded, and must be explicitly called.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'PyTeal'
-copyright = '2020, Algorand'
+copyright = '2021, Algorand'
 author = 'Algorand'
 
 

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -23,10 +23,10 @@ from .tmpl import Tmpl
 from .nonce import Nonce
 
 # unary ops
-from .unaryexpr import UnaryExpr, Btoi, Itob, Len, BitLen, Sha256, Sha512_256, Keccak256, Not, BitwiseNot, Sqrt, Pop, Return, Balance, MinBalance, BNot, BZero
+from .unaryexpr import UnaryExpr, Btoi, Itob, Len, BitLen, Sha256, Sha512_256, Keccak256, Not, BitwiseNot, Sqrt, Pop, Return, Balance, MinBalance, BytesNot, BytesZero
 
 # binary ops
-from .binaryexpr import BinaryExpr, Add, Minus, Mul, Div, Mod, Exp, BitwiseAnd, BitwiseOr, BitwiseXor, ShiftLeft, ShiftRight, Eq, Neq, Lt, Le, Gt, Ge, GetBit, GetByte, BAdd, BMinus, BDiv, BMul, BMod, BAnd, BOr, BXor, BEq, BNeq, BLt, BLe, BGt, BGe
+from .binaryexpr import BinaryExpr, Add, Minus, Mul, Div, Mod, Exp, BitwiseAnd, BitwiseOr, BitwiseXor, ShiftLeft, ShiftRight, Eq, Neq, Lt, Le, Gt, Ge, GetBit, GetByte, BytesAdd, BytesMinus, BytesDiv, BytesMul, BytesMod, BytesAnd, BytesOr, BytesXor, BytesEq, BytesNeq, BytesLt, BytesLe, BytesGt, BytesGe
 
 # ternary ops
 from .ternaryexpr import Ed25519Verify, Substring, SetBit, SetByte
@@ -129,20 +129,20 @@ __all__ = [
     "ScratchStackStore",
     "ScratchVar",
     "MaybeValue",
-    "BAdd",
-    "BMinus",
-    "BDiv",
-    "BMul",
-    "BMod", 
-    "BAnd", 
-    "BOr", 
-    "BXor", 
-    "BEq", 
-    "BNeq", 
-    "BLt", 
-    "BLe", 
-    "BGt", 
-    "BGe",
-    "BNot",
-    "BZero",
+    "BytesAdd",
+    "BytesMinus",
+    "BytesDiv",
+    "BytesMul",
+    "BytesMod", 
+    "BytesAnd", 
+    "BytesOr", 
+    "BytesXor", 
+    "BytesEq", 
+    "BytesNeq", 
+    "BytesLt", 
+    "BytesLe", 
+    "BytesGt", 
+    "BytesGe",
+    "BytesNot",
+    "BytesZero",
 ]

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -23,10 +23,10 @@ from .tmpl import Tmpl
 from .nonce import Nonce
 
 # unary ops
-from .unaryexpr import UnaryExpr, Btoi, Itob, Len, BitLen, Sha256, Sha512_256, Keccak256, Not, BitwiseNot, Sqrt, Pop, Return, Balance, MinBalance
+from .unaryexpr import UnaryExpr, Btoi, Itob, Len, BitLen, Sha256, Sha512_256, Keccak256, Not, BitwiseNot, Sqrt, Pop, Return, Balance, MinBalance, BNot, BZero
 
 # binary ops
-from .binaryexpr import BinaryExpr, Add, Minus, Mul, Div, Mod, Exp, BitwiseAnd, BitwiseOr, BitwiseXor, ShiftLeft, ShiftRight, Eq, Neq, Lt, Le, Gt, Ge, GetBit, GetByte
+from .binaryexpr import BinaryExpr, Add, Minus, Mul, Div, Mod, Exp, BitwiseAnd, BitwiseOr, BitwiseXor, ShiftLeft, ShiftRight, Eq, Neq, Lt, Le, Gt, Ge, GetBit, GetByte, BAdd, BMinus, BDiv, BMul, BMod, BAnd, BOr, BXor, BEq, BNeq, BLt, BLe, BGt, BGe
 
 # ternary ops
 from .ternaryexpr import Ed25519Verify, Substring, SetBit, SetByte
@@ -129,4 +129,20 @@ __all__ = [
     "ScratchStackStore",
     "ScratchVar",
     "MaybeValue",
+    "BAdd",
+    "BMinus",
+    "BDiv",
+    "BMul",
+    "BMod", 
+    "BAnd", 
+    "BOr", 
+    "BXor", 
+    "BEq", 
+    "BNeq", 
+    "BLt", 
+    "BLe", 
+    "BGt", 
+    "BGe",
+    "BNot",
+    "BZero",
 ]

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -260,10 +260,11 @@ def GetByte(value: Expr, index: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.getbyte, (TealType.bytes, TealType.uint64), TealType.uint64, value, index)
 
-def BAdd(left: Expr, right: Expr) -> BinaryExpr:
+def BytesAdd(left: Expr, right: Expr) -> BinaryExpr:
     """Add two numbers as bytes.
     
-    Produces left + right.
+    Produces left + right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -273,10 +274,11 @@ def BAdd(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_add, TealType.bytes, TealType.bytes, left, right)
 
-def BMinus(left: Expr, right: Expr) -> BinaryExpr:
+def BytesMinus(left: Expr, right: Expr) -> BinaryExpr:
     """Subtract two numbers as bytes.
     
-    Produces left - right.
+    Produces left - right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -286,10 +288,13 @@ def BMinus(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_minus, TealType.bytes, TealType.bytes, left, right)
     
-def BDiv(left: Expr, right: Expr) -> BinaryExpr:
+def BytesDiv(left: Expr, right: Expr) -> BinaryExpr:
     """Divide two numbers as bytes.
     
-    Produces left / right.
+    Produces left / right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
+
+    Panics if right is 0. 
 
     Requires TEAL version 4 or higher.
 
@@ -299,10 +304,11 @@ def BDiv(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_div, TealType.bytes, TealType.bytes, left, right)
     
-def BMul(left: Expr, right: Expr) -> BinaryExpr:
+def BytesMul(left: Expr, right: Expr) -> BinaryExpr:
     """Multiply two numbers as bytes.
     
-    Produces left * right.
+    Produces left * right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -312,10 +318,13 @@ def BMul(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_mul, TealType.bytes, TealType.bytes, left, right)
 
-def BMod(left: Expr, right: Expr) -> BinaryExpr:
+def BytesMod(left: Expr, right: Expr) -> BinaryExpr:
     """Modulo expression with bytes as arguments.
     
-    Produces left % right.
+    Produces left % right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
+
+    Panics if right is 0. 
 
     Requires TEAL version 4 or higher.
 
@@ -325,10 +334,12 @@ def BMod(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_mod, TealType.bytes, TealType.bytes, left, right)
 
-def BAnd(left: Expr, right: Expr) -> BinaryExpr:
+def BytesAnd(left: Expr, right: Expr) -> BinaryExpr:
     """Bitwise and expression with bytes as arguments.
 
     Produces left & right.
+    Left and right are zero-left extended to the greater of their lengths.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -338,10 +349,12 @@ def BAnd(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_and, TealType.bytes, TealType.bytes, left, right)
 
-def BOr(left: Expr, right: Expr) -> BinaryExpr:
+def BytesOr(left: Expr, right: Expr) -> BinaryExpr:
     """Bitwise or expression with bytes as arguments.
 
     Produces left | right.
+    Left and right are zero-left extended to the greater of their lengths.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -351,10 +364,12 @@ def BOr(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_or, TealType.bytes, TealType.bytes, left, right)
 
-def BXor(left: Expr, right: Expr) -> BinaryExpr:
+def BytesXor(left: Expr, right: Expr) -> BinaryExpr:
     """Bitwise xor expression with bytes as arguments.
 
     Produces left ^ right.
+    Left and right are zero-left extended to the greater of their lengths.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -364,36 +379,39 @@ def BXor(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_xor, TealType.bytes, TealType.bytes, left, right)
 
-def BEq(left: Expr, right: Expr) -> BinaryExpr:
+def BytesEq(left: Expr, right: Expr) -> BinaryExpr:
     """Equality expression with bytes as arguments.
     
-    Checks if left == right.
+    Checks if left == right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
     Args:
-        left: A value to check.
-        right: The other value to check. Must evaluate to the same type as left.
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
     """
     return BinaryExpr(Op.b_eq, TealType.bytes, TealType.uint64, left, right)
 
-def BNeq(left: Expr, right: Expr) -> BinaryExpr:
+def BytesNeq(left: Expr, right: Expr) -> BinaryExpr:
     """Difference expression with bytes as arguments.
     
-    Checks if left != right.
+    Checks if left != right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
     Args:
-        left: A value to check.
-        right: The other value to check. Must evaluate to the same type as left.
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
     """
     return BinaryExpr(Op.b_neq, TealType.bytes, TealType.uint64, left, right)
 
-def BLt(left: Expr, right: Expr) -> BinaryExpr:
+def BytesLt(left: Expr, right: Expr) -> BinaryExpr:
     """Less than expression with bytes as arguments.
     
-    Checks if left < right.
+    Checks if left < right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -403,10 +421,11 @@ def BLt(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_lt, TealType.bytes, TealType.uint64, left, right)
 
-def BLe(left: Expr, right: Expr) -> BinaryExpr:
+def BytesLe(left: Expr, right: Expr) -> BinaryExpr:
     """Less than or equal to expression with bytes as arguments.
     
-    Checks if left <= right.
+    Checks if left <= right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -416,10 +435,11 @@ def BLe(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_le, TealType.bytes, TealType.uint64, left, right)
 
-def BGt(left: Expr, right: Expr) -> BinaryExpr:
+def BytesGt(left: Expr, right: Expr) -> BinaryExpr:
     """Greater than expression with bytes as arguments.
     
-    Checks if left > right.
+    Checks if left > right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
 
@@ -429,10 +449,11 @@ def BGt(left: Expr, right: Expr) -> BinaryExpr:
     """
     return BinaryExpr(Op.b_gt, TealType.bytes, TealType.uint64, left, right)
 
-def BGe(left: Expr, right: Expr) -> BinaryExpr:
+def BytesGe(left: Expr, right: Expr) -> BinaryExpr:
     """Greater than or equal to expression with bytes as arguments.
     
-    Checks if left >= right.
+    Checks if left >= right, where left and right are interpreted as big-endian unsigned integers.
+    Arguments must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
     

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -375,7 +375,7 @@ def BEq(left: Expr, right: Expr) -> BinaryExpr:
         left: A value to check.
         right: The other value to check. Must evaluate to the same type as left.
     """
-    return BinaryExpr(Op.b_eq, right.type_of(), TealType.bytes, left, right)
+    return BinaryExpr(Op.b_eq, TealType.bytes, TealType.uint64, left, right)
 
 def BNeq(left: Expr, right: Expr) -> BinaryExpr:
     """Difference expression with bytes as arguments.
@@ -388,7 +388,7 @@ def BNeq(left: Expr, right: Expr) -> BinaryExpr:
         left: A value to check.
         right: The other value to check. Must evaluate to the same type as left.
     """
-    return BinaryExpr(Op.b_neq, right.type_of(), TealType.bytes, left, right)
+    return BinaryExpr(Op.b_neq, TealType.bytes, TealType.uint64, left, right)
 
 def BLt(left: Expr, right: Expr) -> BinaryExpr:
     """Less than expression with bytes as arguments.
@@ -401,7 +401,7 @@ def BLt(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
-    return BinaryExpr(Op.b_lt, TealType.bytes, TealType.bytes, left, right)
+    return BinaryExpr(Op.b_lt, TealType.bytes, TealType.uint64, left, right)
 
 def BLe(left: Expr, right: Expr) -> BinaryExpr:
     """Less than or equal to expression with bytes as arguments.
@@ -414,7 +414,7 @@ def BLe(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
-    return BinaryExpr(Op.b_le, TealType.bytes, TealType.bytes, left, right)
+    return BinaryExpr(Op.b_le, TealType.bytes, TealType.uint64, left, right)
 
 def BGt(left: Expr, right: Expr) -> BinaryExpr:
     """Greater than expression with bytes as arguments.
@@ -427,7 +427,7 @@ def BGt(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
-    return BinaryExpr(Op.b_gt, TealType.bytes, TealType.bytes, left, right)
+    return BinaryExpr(Op.b_gt, TealType.bytes, TealType.uint64, left, right)
 
 def BGe(left: Expr, right: Expr) -> BinaryExpr:
     """Greater than or equal to expression with bytes as arguments.
@@ -440,4 +440,4 @@ def BGe(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
-    return BinaryExpr(Op.b_ge, TealType.bytes, TealType.bytes, left, right)
+    return BinaryExpr(Op.b_ge, TealType.bytes, TealType.uint64, left, right)

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -259,3 +259,185 @@ def GetByte(value: Expr, index: Expr) -> BinaryExpr:
         index: The index of the byte to extract. Must evaluate to an integer less than Len(value).
     """
     return BinaryExpr(Op.getbyte, (TealType.bytes, TealType.uint64), TealType.uint64, value, index)
+
+def BAdd(left: Expr, right: Expr) -> BinaryExpr:
+    """Add two numbers as bytes.
+    
+    Produces left + right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_add, TealType.bytes, TealType.bytes, left, right)
+
+def BMinus(left: Expr, right: Expr) -> BinaryExpr:
+    """Subtract two numbers as bytes.
+    
+    Produces left - right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_minus, TealType.bytes, TealType.bytes, left, right)
+    
+def BDiv(left: Expr, right: Expr) -> BinaryExpr:
+    """Divide two numbers as bytes.
+    
+    Produces left / right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_div, TealType.bytes, TealType.bytes, left, right)
+    
+def BMul(left: Expr, right: Expr) -> BinaryExpr:
+    """Multiply two numbers as bytes.
+    
+    Produces left * right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_mul, TealType.bytes, TealType.bytes, left, right)
+
+def BMod(left: Expr, right: Expr) -> BinaryExpr:
+    """Modulo expression with bytes as arguments.
+    
+    Produces left % right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_mod, TealType.bytes, TealType.bytes, left, right)
+
+def BAnd(left: Expr, right: Expr) -> BinaryExpr:
+    """Bitwise and expression with bytes as arguments.
+
+    Produces left & right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_and, TealType.bytes, TealType.bytes, left, right)
+
+def BOr(left: Expr, right: Expr) -> BinaryExpr:
+    """Bitwise or expression with bytes as arguments.
+
+    Produces left | right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_or, TealType.bytes, TealType.bytes, left, right)
+
+def BXor(left: Expr, right: Expr) -> BinaryExpr:
+    """Bitwise xor expression with bytes as arguments.
+
+    Produces left ^ right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_xor, TealType.bytes, TealType.bytes, left, right)
+
+def BEq(left: Expr, right: Expr) -> BinaryExpr:
+    """Equality expression with bytes as arguments.
+    
+    Checks if left == right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: A value to check.
+        right: The other value to check. Must evaluate to the same type as left.
+    """
+    return BinaryExpr(Op.b_eq, right.type_of(), TealType.bytes, left, right)
+
+def BNeq(left: Expr, right: Expr) -> BinaryExpr:
+    """Difference expression with bytes as arguments.
+    
+    Checks if left != right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: A value to check.
+        right: The other value to check. Must evaluate to the same type as left.
+    """
+    return BinaryExpr(Op.b_neq, right.type_of(), TealType.bytes, left, right)
+
+def BLt(left: Expr, right: Expr) -> BinaryExpr:
+    """Less than expression with bytes as arguments.
+    
+    Checks if left < right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_lt, TealType.bytes, TealType.bytes, left, right)
+
+def BLe(left: Expr, right: Expr) -> BinaryExpr:
+    """Less than or equal to expression with bytes as arguments.
+    
+    Checks if left <= right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_le, TealType.bytes, TealType.bytes, left, right)
+
+def BGt(left: Expr, right: Expr) -> BinaryExpr:
+    """Greater than expression with bytes as arguments.
+    
+    Checks if left > right.
+
+    Requires TEAL version 4 or higher.
+
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_gt, TealType.bytes, TealType.bytes, left, right)
+
+def BGe(left: Expr, right: Expr) -> BinaryExpr:
+    """Greater than or equal to expression with bytes as arguments.
+    
+    Checks if left >= right.
+
+    Requires TEAL version 4 or higher.
+    
+    Args:
+        left: Must evaluate to bytes.
+        right: Must evaluate to bytes.
+    """
+    return BinaryExpr(Op.b_ge, TealType.bytes, TealType.bytes, left, right)

--- a/pyteal/ast/binaryexpr_test.py
+++ b/pyteal/ast/binaryexpr_test.py
@@ -894,7 +894,7 @@ def test_get_byte_invalid():
 
 def test_b_add():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFE")]
-    expr = BAdd(args[0], args[1])
+    expr = BytesAdd(args[0], args[1])
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -911,14 +911,14 @@ def test_b_add():
 
 def test_b_add_invalid():
     with pytest.raises(TealTypeError):
-        BAdd(Int(2), Txn.receiver())
+        BytesAdd(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BAdd(Bytes("base16", "0xFF"), Int(2))
+        BytesAdd(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_minus():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFE")]
-    expr = BMinus(args[0], args[1])
+    expr = BytesMinus(args[0], args[1])
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -935,14 +935,14 @@ def test_b_minus():
 
 def test_b_minus_invalid():
     with pytest.raises(TealTypeError):
-        BMinus(Int(2), Txn.receiver())
+        BytesMinus(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BMinus(Bytes("base16", "0xFF"), Int(2))
+        BytesMinus(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_div():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFF00"), Bytes("base16", "0xFF")]
-    expr = BDiv(args[0], args[1])
+    expr = BytesDiv(args[0], args[1])
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -959,14 +959,14 @@ def test_b_div():
 
 def test_b_div_invalid():
     with pytest.raises(TealTypeError):
-        BDiv(Int(2), Txn.receiver())
+        BytesDiv(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BDiv(Bytes("base16", "0xFF"), Int(2))
+        BytesDiv(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_mul():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFF")]
-    expr = BMul(args[0], args[1])
+    expr = BytesMul(args[0], args[1])
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -983,14 +983,14 @@ def test_b_mul():
 
 def test_b_mul_invalid():
     with pytest.raises(TealTypeError):
-        BMul(Int(2), Txn.receiver())
+        BytesMul(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BMul(Bytes("base16", "0xFF"), Int(2))
+        BytesMul(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_mod():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFF")]
-    expr = BMod(args[0], args[1])
+    expr = BytesMod(args[0], args[1])
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -1007,14 +1007,14 @@ def test_b_mod():
 
 def test_b_mod_invalid():
     with pytest.raises(TealTypeError):
-        BMod(Int(2), Txn.receiver())
+        BytesMod(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BMod(Bytes("base16", "0xFF"), Int(2))
+        BytesMod(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_and():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFF")]
-    expr = BAnd(args[0], args[1])
+    expr = BytesAnd(args[0], args[1])
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -1031,14 +1031,14 @@ def test_b_and():
 
 def test_b_and_invalid():
     with pytest.raises(TealTypeError):
-        BAnd(Int(2), Txn.receiver())
+        BytesAnd(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BAnd(Bytes("base16", "0xFF"), Int(2))
+        BytesAnd(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_or():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFF")]
-    expr = BOr(args[0], args[1])
+    expr = BytesOr(args[0], args[1])
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -1055,14 +1055,14 @@ def test_b_or():
 
 def test_b_or_invalid():
     with pytest.raises(TealTypeError):
-        BOr(Int(2), Txn.receiver())
+        BytesOr(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BOr(Bytes("base16", "0xFF"), Int(2))
+        BytesOr(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_xor():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFF")]
-    expr = BXor(args[0], args[1])
+    expr = BytesXor(args[0], args[1])
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -1079,14 +1079,14 @@ def test_b_xor():
 
 def test_b_xor_invalid():
     with pytest.raises(TealTypeError):
-        BXor(Int(2), Txn.receiver())
+        BytesXor(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BXor(Bytes("base16", "0xFF"), Int(2))
+        BytesXor(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_eq():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
-    expr = BEq(args[0], args[1])
+    expr = BytesEq(args[0], args[1])
     assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
@@ -1103,14 +1103,14 @@ def test_b_eq():
 
 def test_b_eq_invalid():
     with pytest.raises(TealTypeError):
-        BEq(Int(2), Txn.receiver())
+        BytesEq(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BEq(Bytes("base16", "0xFF"), Int(2))
+        BytesEq(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_neq():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
-    expr = BNeq(args[0], args[1])
+    expr = BytesNeq(args[0], args[1])
     assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
@@ -1127,14 +1127,14 @@ def test_b_neq():
 
 def test_b_neq_invalid():
     with pytest.raises(TealTypeError):
-        BNeq(Int(2), Txn.receiver())
+        BytesNeq(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BNeq(Bytes("base16", "0xFF"), Int(2))
+        BytesNeq(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_lt():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
-    expr = BLt(args[0], args[1])
+    expr = BytesLt(args[0], args[1])
     assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
@@ -1151,14 +1151,14 @@ def test_b_lt():
 
 def test_b_lt_invalid():
     with pytest.raises(TealTypeError):
-        BLt(Int(2), Txn.receiver())
+        BytesLt(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BLt(Bytes("base16", "0xFF"), Int(2))
+        BytesLt(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_le():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
-    expr = BLe(args[0], args[1])
+    expr = BytesLe(args[0], args[1])
     assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
@@ -1175,14 +1175,14 @@ def test_b_le():
 
 def test_b_le_invalid():
     with pytest.raises(TealTypeError):
-        BLe(Int(2), Txn.receiver())
+        BytesLe(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BLe(Bytes("base16", "0xFF"), Int(2))
+        BytesLe(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_gt():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFF0")]
-    expr = BGt(args[0], args[1])
+    expr = BytesGt(args[0], args[1])
     assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
@@ -1199,14 +1199,14 @@ def test_b_gt():
 
 def test_b_gt_invalid():
     with pytest.raises(TealTypeError):
-        BGt(Int(2), Txn.receiver())
+        BytesGt(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BGt(Bytes("base16", "0xFF"), Int(2))
+        BytesGt(Bytes("base16", "0xFF"), Int(2))
 
 def test_b_ge():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFF0")]
-    expr = BGe(args[0], args[1])
+    expr = BytesGe(args[0], args[1])
     assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
@@ -1223,7 +1223,7 @@ def test_b_ge():
 
 def test_b_ge_invalid():
     with pytest.raises(TealTypeError):
-        BGe(Int(2), Txn.receiver())
+        BytesGe(Int(2), Txn.receiver())
     
     with pytest.raises(TealTypeError):
-        BGe(Bytes("base16", "0xFF"), Int(2))
+        BytesGe(Bytes("base16", "0xFF"), Int(2))

--- a/pyteal/ast/binaryexpr_test.py
+++ b/pyteal/ast/binaryexpr_test.py
@@ -1087,7 +1087,7 @@ def test_b_xor_invalid():
 def test_b_eq():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
     expr = BEq(args[0], args[1])
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
         TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
@@ -1111,7 +1111,7 @@ def test_b_eq_invalid():
 def test_b_neq():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
     expr = BNeq(args[0], args[1])
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
         TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
@@ -1135,7 +1135,7 @@ def test_b_neq_invalid():
 def test_b_lt():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
     expr = BLt(args[0], args[1])
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
         TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
@@ -1159,7 +1159,7 @@ def test_b_lt_invalid():
 def test_b_le():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
     expr = BLe(args[0], args[1])
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
         TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
@@ -1183,7 +1183,7 @@ def test_b_le_invalid():
 def test_b_gt():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFF0")]
     expr = BGt(args[0], args[1])
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
         TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
@@ -1207,7 +1207,7 @@ def test_b_gt_invalid():
 def test_b_ge():
     args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFF0")]
     expr = BGe(args[0], args[1])
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == TealType.uint64
     
     expected = TealSimpleBlock([
         TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),

--- a/pyteal/ast/binaryexpr_test.py
+++ b/pyteal/ast/binaryexpr_test.py
@@ -891,3 +891,339 @@ def test_get_byte_invalid():
     
     with pytest.raises(TealTypeError):
         GetBit(Bytes("base16", "0xFF"), Bytes("index"))
+
+def test_b_add():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFE")]
+    expr = BAdd(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(args[1], Op.byte, "0xFFFFFFFFFFFFFFFFFE"),
+        TealOp(expr, Op.b_add)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_add_invalid():
+    with pytest.raises(TealTypeError):
+        BAdd(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BAdd(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_minus():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFE")]
+    expr = BMinus(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(args[1], Op.byte, "0xFFFFFFFFFFFFFFFFFE"),
+        TealOp(expr, Op.b_minus)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_minus_invalid():
+    with pytest.raises(TealTypeError):
+        BMinus(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BMinus(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_div():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFF00"), Bytes("base16", "0xFF")]
+    expr = BDiv(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFF00"),
+        TealOp(args[1], Op.byte, "0xFF"),
+        TealOp(expr, Op.b_div)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_div_invalid():
+    with pytest.raises(TealTypeError):
+        BDiv(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BDiv(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_mul():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFF")]
+    expr = BMul(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFF"),
+        TealOp(args[1], Op.byte, "0xFF"),
+        TealOp(expr, Op.b_mul)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_mul_invalid():
+    with pytest.raises(TealTypeError):
+        BMul(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BMul(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_mod():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFF")]
+    expr = BMod(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(args[1], Op.byte, "0xFF"),
+        TealOp(expr, Op.b_mod)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_mod_invalid():
+    with pytest.raises(TealTypeError):
+        BMod(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BMod(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_and():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFF")]
+    expr = BAnd(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
+        TealOp(args[1], Op.byte, "0xFF"),
+        TealOp(expr, Op.b_and)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_and_invalid():
+    with pytest.raises(TealTypeError):
+        BAnd(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BAnd(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_or():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFF")]
+    expr = BOr(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
+        TealOp(args[1], Op.byte, "0xFF"),
+        TealOp(expr, Op.b_or)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_or_invalid():
+    with pytest.raises(TealTypeError):
+        BOr(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BOr(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_xor():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFF")]
+    expr = BXor(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
+        TealOp(args[1], Op.byte, "0xFF"),
+        TealOp(expr, Op.b_xor)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_xor_invalid():
+    with pytest.raises(TealTypeError):
+        BXor(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BXor(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_eq():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
+    expr = BEq(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(args[1], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(expr, Op.b_eq)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_eq_invalid():
+    with pytest.raises(TealTypeError):
+        BEq(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BEq(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_neq():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
+    expr = BNeq(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(args[1], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(expr, Op.b_neq)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_neq_invalid():
+    with pytest.raises(TealTypeError):
+        BNeq(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BNeq(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_lt():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
+    expr = BLt(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
+        TealOp(args[1], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(expr, Op.b_lt)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_lt_invalid():
+    with pytest.raises(TealTypeError):
+        BLt(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BLt(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_le():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFF0"), Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")]
+    expr = BLe(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
+        TealOp(args[1], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(expr, Op.b_le)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_le_invalid():
+    with pytest.raises(TealTypeError):
+        BLe(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BLe(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_gt():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFF0")]
+    expr = BGt(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(args[1], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
+        TealOp(expr, Op.b_gt)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_gt_invalid():
+    with pytest.raises(TealTypeError):
+        BGt(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BGt(Bytes("base16", "0xFF"), Int(2))
+
+def test_b_ge():
+    args = [Bytes("base16", "0xFFFFFFFFFFFFFFFFFF"), Bytes("base16", "0xFFFFFFFFFFFFFFFFF0")]
+    expr = BGe(args[0], args[1])
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(args[1], Op.byte, "0xFFFFFFFFFFFFFFFFF0"),
+        TealOp(expr, Op.b_ge)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_ge_invalid():
+    with pytest.raises(TealTypeError):
+        BGe(Int(2), Txn.receiver())
+    
+    with pytest.raises(TealTypeError):
+        BGe(Bytes("base16", "0xFF"), Int(2))

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -115,3 +115,21 @@ def MinBalance(account: Expr) -> UnaryExpr:
     Requires TEAL version 3 or higher. This operation is only permitted in application mode.
     """
     return UnaryExpr(Op.min_balance, TealType.uint64, TealType.uint64, account)
+
+def BNot(arg: Expr) -> UnaryExpr:
+    """Get the bitwise inverse of bytes.
+    
+    Produces ~arg.
+
+    Requires TEAL version 4 or higher.
+    """
+    return UnaryExpr(Op.b_not, TealType.bytes, TealType.bytes, arg)
+
+def BZero(arg: Expr) -> UnaryExpr:
+    """Get a byte-array of a specified length, containing all zero bytes.
+
+    Argument must evaluate to uint64. 
+
+    Requires TEAL version 4 or higher.    
+    """
+    return UnaryExpr(Op.bzero, TealType.uint64, TealType.bytes, arg)

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -116,16 +116,17 @@ def MinBalance(account: Expr) -> UnaryExpr:
     """
     return UnaryExpr(Op.min_balance, TealType.uint64, TealType.uint64, account)
 
-def BNot(arg: Expr) -> UnaryExpr:
+def BytesNot(arg: Expr) -> UnaryExpr:
     """Get the bitwise inverse of bytes.
     
     Produces ~arg.
+    Argument must not exceed 64 bytes.
 
     Requires TEAL version 4 or higher.
     """
     return UnaryExpr(Op.b_not, TealType.bytes, TealType.bytes, arg)
 
-def BZero(arg: Expr) -> UnaryExpr:
+def BytesZero(arg: Expr) -> UnaryExpr:
     """Get a byte-array of a specified length, containing all zero bytes.
 
     Argument must evaluate to uint64. 

--- a/pyteal/ast/unaryexpr_test.py
+++ b/pyteal/ast/unaryexpr_test.py
@@ -331,3 +331,43 @@ def test_min_balance():
 def test_min_balance_invalid():
     with pytest.raises(TealTypeError):
         MinBalance(Txn.receiver())
+
+def test_b_not():
+    arg = Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")
+    expr = BNot(arg)
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
+        TealOp(expr, Op.b_not)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_not_invalid():
+    with pytest.raises(TealTypeError):
+        BNot(Int(2))
+
+def test_b_zero():
+    arg = Int(8)
+    expr = BZero(arg)
+    assert expr.type_of() == TealType.bytes
+    
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.int, 8),
+        TealOp(expr, Op.bzero)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+    
+    assert actual == expected
+
+def test_b_zero_invalid():
+    with pytest.raises(TealTypeError):
+        BZero(Bytes("base16", "0x11"))

--- a/pyteal/ast/unaryexpr_test.py
+++ b/pyteal/ast/unaryexpr_test.py
@@ -334,7 +334,7 @@ def test_min_balance_invalid():
 
 def test_b_not():
     arg = Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")
-    expr = BNot(arg)
+    expr = BytesNot(arg)
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -350,11 +350,11 @@ def test_b_not():
 
 def test_b_not_invalid():
     with pytest.raises(TealTypeError):
-        BNot(Int(2))
+        BytesNot(Int(2))
 
 def test_b_zero():
     arg = Int(8)
-    expr = BZero(arg)
+    expr = BytesZero(arg)
     assert expr.type_of() == TealType.bytes
     
     expected = TealSimpleBlock([
@@ -370,4 +370,4 @@ def test_b_zero():
 
 def test_b_zero_invalid():
     with pytest.raises(TealTypeError):
-        BZero(Bytes("base16", "0x11"))
+        BytesZero(Bytes("base16", "0x11"))


### PR DESCRIPTION
This commit adds support for Byteslice arithmetic operations (e.g. `b+`, `b~`, etc.) that were introduced in Teal V4 (#73). 

* Adds byteslice arithmetic operations (see [Algorand Opcodes](https://developer.algorand.org/docs/reference/teal/opcodes/))
* Updates documentation for byteslice arithmetic operations
* Add a line to README.md for installing requirements.txt 

Closes #73 