### PR TITLE
Expose gload op-codes and allow manual scratch slot id assignment

### DIFF
--- a/pyteal/__init__.py
+++ b/pyteal/__init__.py
@@ -19,4 +19,5 @@ __all__ = ast_all + ir_all + [
     "TealInputError",
     "TealCompileError",
     "MAX_GROUP_SIZE",
+    "NUM_SLOTS",
 ]

--- a/pyteal/__init__.py
+++ b/pyteal/__init__.py
@@ -5,7 +5,7 @@ from .ir import __all__ as ir_all
 from .compiler import MAX_TEAL_VERSION, MIN_TEAL_VERSION, DEFAULT_TEAL_VERSION, CompileOptions, compileTeal
 from .types import TealType
 from .errors import TealInternalError, TealTypeError, TealInputError, TealCompileError
-from .config import MAX_GROUP_SIZE
+from .config import MAX_GROUP_SIZE, NUM_SLOTS
 
 __all__ = ast_all + ir_all + [
     "MAX_TEAL_VERSION",

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -13,6 +13,7 @@ from .arg import Arg
 from .txn import TxnType, TxnField, TxnExpr, TxnaExpr, TxnArray, TxnObject, Txn
 from .gtxn import GtxnExpr, GtxnaExpr, TxnGroup, Gtxn
 from .gaid import GeneratedID
+from .gload import ImportScratchValue
 from .global_ import Global, GlobalField
 from .app import App, AppField, OnComplete
 from .asset import AssetHolding, AssetParam
@@ -66,6 +67,7 @@ __all__ = [
     "TxnGroup",
     "Gtxn",
     "GeneratedID",
+    "ImportScratchValue",
     "Global",
     "GlobalField",
     "App",

--- a/pyteal/ast/gload.py
+++ b/pyteal/ast/gload.py
@@ -1,0 +1,58 @@
+from typing import cast, Union, TYPE_CHECKING
+
+from ..types import TealType, require_type
+from ..ir import TealOp, Op, TealBlock
+from ..errors import TealInputError, verifyTealVersion
+from ..config import MAX_GROUP_SIZE, NUM_SLOTS
+from .expr import Expr
+from .int import Int
+from .leafexpr import LeafExpr
+
+if TYPE_CHECKING:
+    from ..compiler import CompileOptions
+
+class ImportScratchValue(LeafExpr):
+    """"An expression to load a scratch value created by another transaction in the current group"""
+
+    def __init__(self, txnIndex: Union[int, Expr], slotId: int) -> None:
+        """ Create an expression to load a scratch space slot from a transaction in the current group.
+
+        Requires TEAL version 4 or higher. This operation is only permitted in application mode.
+
+        Args:
+            txnIndex: The index of the transaction from which the created ID should be obtained.
+                This index may be a Python int, or it may be a PyTeal expression that evaluates at
+                runtime. If it's an expression, it must evaluate to a uint64. In all cases, the index
+                must be less than the index of the current transaction.
+            slotId: The index of the scratch slot that should be loaded. The index must be a Python int
+                in the range [0-256). 
+        """
+        super().__init__()
+        if type(txnIndex) == int:
+            if txnIndex < 0 or txnIndex >= MAX_GROUP_SIZE:
+                raise TealInputError("Invalid transaction index {}, shoud be in [0, {})".format(txnIndex, MAX_GROUP_SIZE))
+        else:
+            require_type(cast(Expr, txnIndex).type_of(), TealType.uint64)
+        if slotId < 0 or slotId >= NUM_SLOTS:
+                raise TealInputError("Invalid slot ID {}, shoud be in [0, {})".format(slotId, NUM_SLOTS))
+        
+        self.txnIndex = txnIndex
+        self.slotId = slotId
+
+    def __str__(self) -> str:
+        return "(Gload {} {})".format(self.txnIndex, self.slotId)
+
+    def __teal__(self, options: 'CompileOptions'):
+        verifyTealVersion(Op.gaid.min_version, options.version, "TEAL version too low to use Gload expression")
+
+        if type(self.txnIndex) == int:
+            op = TealOp(self, Op.gload, cast(int, self.txnIndex), cast(int, self.slotId))
+            return TealBlock.FromOp(options, op)
+        
+        op = TealOp(self, Op.gloads, cast(int, self.slotId))
+        return TealBlock.FromOp(options, op, cast(Expr, self.txnIndex))
+
+    def type_of(self):
+        return TealType.uint64
+
+ImportScratchValue.__module__ = "pyteal"

--- a/pyteal/ast/gload.py
+++ b/pyteal/ast/gload.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from ..compiler import CompileOptions
 
 class ImportScratchValue(LeafExpr):
-    """"An expression to load a scratch value created by another transaction in the current group"""
+    """An expression to load a scratch value created by another transaction in the current group"""
 
     def __init__(self, txnIndex: Union[int, Expr], slotId: int) -> None:
         """ Create an expression to load a scratch space slot from a transaction in the current group.
@@ -43,16 +43,16 @@ class ImportScratchValue(LeafExpr):
         return "(Gload {} {})".format(self.txnIndex, self.slotId)
 
     def __teal__(self, options: 'CompileOptions'):
-        verifyTealVersion(Op.gaid.min_version, options.version, "TEAL version too low to use Gload expression")
+        verifyTealVersion(Op.gload.min_version, options.version, "TEAL version too low to use Gload expression")
 
         if type(self.txnIndex) == int:
             op = TealOp(self, Op.gload, cast(int, self.txnIndex), cast(int, self.slotId))
             return TealBlock.FromOp(options, op)
         
-        op = TealOp(self, Op.gloads, cast(int, self.slotId))
+        op = TealOp(self, Op.gloads, self.slotId)
         return TealBlock.FromOp(options, op, cast(Expr, self.txnIndex))
 
     def type_of(self):
-        return TealType.uint64
+        return TealType.anytype
 
 ImportScratchValue.__module__ = "pyteal"

--- a/pyteal/ast/gload_test.py
+++ b/pyteal/ast/gload_test.py
@@ -1,0 +1,60 @@
+from pyteal.compiler.compiler import compileTeal
+from pyteal.config import NUM_SLOTS
+import pytest
+
+from .. import *
+from .gload import ImportScratchValue
+# this is not necessary but mypy complains if it's not included
+from .. import MAX_GROUP_SIZE, CompileOptions
+
+teal3Options = CompileOptions(version=3)
+teal4Options = CompileOptions(version=4)
+
+def test_gload_teal_3():
+    with pytest.raises(TealInputError):
+        ImportScratchValue(0, 0).__teal__(teal3Options)
+
+    with pytest.raises(TealInputError):
+        ImportScratchValue(Int(0), 0).__teal__(teal3Options)
+
+def test_gload():
+    expr = ImportScratchValue(0, 0)
+    assert expr.type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(expr, Op.gload, 0, 0)
+    ])
+    
+    actual, _ = expr.__teal__(teal4Options)
+
+    assert actual == expected
+
+def test_gload_dynamic():
+    arg = Int(0)
+    expr = ImportScratchValue(arg, 0)
+    assert expr.type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.int, 0),
+        TealOp(expr, Op.gloads, 0)
+    ])
+    
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    assert actual == expected
+
+def test_gload_invalid():
+    with pytest.raises(TealInputError):
+        ImportScratchValue(-1, 0)
+
+    with pytest.raises(TealInputError):
+        ImportScratchValue(MAX_GROUP_SIZE, 0)
+
+    with pytest.raises(TealInputError):
+        ImportScratchValue(0, -1)
+
+    with pytest.raises(TealInputError):
+        ImportScratchValue(0, NUM_SLOTS)
+    

--- a/pyteal/ast/gload_test.py
+++ b/pyteal/ast/gload_test.py
@@ -1,11 +1,8 @@
-from pyteal.compiler.compiler import compileTeal
-from pyteal.config import NUM_SLOTS
 import pytest
 
 from .. import *
-from .gload import ImportScratchValue
 # this is not necessary but mypy complains if it's not included
-from .. import MAX_GROUP_SIZE, CompileOptions
+from .. import MAX_GROUP_SIZE, NUM_SLOTS, CompileOptions
 
 teal3Options = CompileOptions(version=3)
 teal4Options = CompileOptions(version=4)
@@ -19,7 +16,7 @@ def test_gload_teal_3():
 
 def test_gload():
     expr = ImportScratchValue(0, 0)
-    assert expr.type_of() == TealType.uint64
+    assert expr.type_of() == TealType.anytype
 
     expected = TealSimpleBlock([
         TealOp(expr, Op.gload, 0, 0)
@@ -32,7 +29,7 @@ def test_gload():
 def test_gload_dynamic():
     arg = Int(0)
     expr = ImportScratchValue(arg, 0)
-    assert expr.type_of() == TealType.uint64
+    assert expr.type_of() == TealType.anytype
 
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),

--- a/pyteal/ast/gload_test.py
+++ b/pyteal/ast/gload_test.py
@@ -9,17 +9,17 @@ teal4Options = CompileOptions(version=4)
 
 def test_gload_teal_3():
     with pytest.raises(TealInputError):
-        ImportScratchValue(0, 0).__teal__(teal3Options)
+        ImportScratchValue(0, 1).__teal__(teal3Options)
 
     with pytest.raises(TealInputError):
-        ImportScratchValue(Int(0), 0).__teal__(teal3Options)
+        ImportScratchValue(Int(0), 1).__teal__(teal3Options)
 
 def test_gload():
-    expr = ImportScratchValue(0, 0)
+    expr = ImportScratchValue(0, 1)
     assert expr.type_of() == TealType.anytype
 
     expected = TealSimpleBlock([
-        TealOp(expr, Op.gload, 0, 0)
+        TealOp(expr, Op.gload, 0, 1)
     ])
     
     actual, _ = expr.__teal__(teal4Options)
@@ -27,12 +27,12 @@ def test_gload():
     assert actual == expected
 
 def test_gload_dynamic():
-    arg = Int(0)
+    arg = Int(1)
     expr = ImportScratchValue(arg, 0)
     assert expr.type_of() == TealType.anytype
 
     expected = TealSimpleBlock([
-        TealOp(arg, Op.int, 0),
+        TealOp(arg, Op.int, 1),
         TealOp(expr, Op.gloads, 0)
     ])
     

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -28,8 +28,6 @@ class ScratchSlot:
             ScratchSlot.nextSlotId += 1
             self.isReservedSlot = False
         else:
-            # TODO: Is there a way to check whether the user hasn't alloted more than 
-            # NUM_SLOTS slots here? 
             if requestedSlotId < 0 or requestedSlotId >= NUM_SLOTS:
                 raise TealInputError("Invalid slot ID {}, shoud be in [0, {})".format(requestedSlotId, NUM_SLOTS))
             self.id = requestedSlotId

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -1,5 +1,5 @@
 from pyteal.config import NUM_SLOTS
-from typing import cast, Union, TYPE_CHECKING
+from typing import cast, Set, Union, TYPE_CHECKING
 
 from ..types import TealType, require_type
 from ..errors import TealInputError
@@ -12,7 +12,7 @@ class ScratchSlot:
     """Represents the allocation of a scratch space slot."""
 
     nextSlotId = 0 # Next slot ID for compiler to assign 
-    reservedSlots: set[int] = set()
+    reservedSlots: Set[int] = set()
 
     def __init__(self, requestedSlotId: int = None):
         """Initializes a scratch slot with a particular id

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -11,8 +11,10 @@ if TYPE_CHECKING:
 class ScratchSlot:
     """Represents the allocation of a scratch space slot."""
 
-    nextSlotId = 0 # Next slot ID for compiler to assign 
-    reservedSlots: Set[int] = set()
+    # Unique identifier for the compiler to automatically assign slots
+    # The id field is used by the compiler to map to an actual slot in the source code
+    # Slot ids under 256 are manually reserved slots
+    nextSlotId = 256 
 
     def __init__(self, requestedSlotId: int = None):
         """Initializes a scratch slot with a particular id
@@ -23,19 +25,16 @@ class ScratchSlot:
         """
         if requestedSlotId is None:
             self.id = ScratchSlot.nextSlotId
+            ScratchSlot.nextSlotId += 1
+            self.isReservedSlot = False
         else:
             # TODO: Is there a way to check whether the user hasn't alloted more than 
             # NUM_SLOTS slots here? 
             if requestedSlotId < 0 or requestedSlotId >= NUM_SLOTS:
                 raise TealInputError("Invalid slot ID {}, shoud be in [0, {})".format(requestedSlotId, NUM_SLOTS))
             self.id = requestedSlotId
+            self.isReservedSlot = True
         
-        self.reservedSlots.add(self.id)
-        while ScratchSlot.nextSlotId in self.reservedSlots:
-            if ScratchSlot.nextSlotId == NUM_SLOTS:
-                raise TealInputError("No more scratch slots can be alloted")
-            ScratchSlot.nextSlotId += 1
-
     def store(self, value: Expr = None) -> Expr:
         """Get an expression to store a value in this slot.
         

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -1,7 +1,7 @@
-from pyteal.config import NUM_SLOTS
-from typing import cast, Set, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
-from ..types import TealType, require_type
+from ..types import TealType
+from ..config import NUM_SLOTS
 from ..errors import TealInputError
 from .expr import Expr
 
@@ -14,7 +14,7 @@ class ScratchSlot:
     # Unique identifier for the compiler to automatically assign slots
     # The id field is used by the compiler to map to an actual slot in the source code
     # Slot ids under 256 are manually reserved slots
-    nextSlotId = 256 
+    nextSlotId = NUM_SLOTS 
 
     def __init__(self, requestedSlotId: int = None):
         """Initializes a scratch slot with a particular id

--- a/pyteal/ast/scratch_test.py
+++ b/pyteal/ast/scratch_test.py
@@ -1,7 +1,3 @@
-from pyteal.config import NUM_SLOTS
-from pyteal.compiler.compiler import compileTeal
-from pyteal.errors import TealInputError
-from pyteal.ast.scratch import ScratchSlot
 import pytest
 
 from .. import *

--- a/pyteal/ast/scratch_test.py
+++ b/pyteal/ast/scratch_test.py
@@ -1,3 +1,7 @@
+from pyteal.config import NUM_SLOTS
+from pyteal.compiler.compiler import compileTeal
+from pyteal.errors import TealInputError
+from pyteal.ast.scratch import ScratchSlot
 import pytest
 
 from .. import *
@@ -75,3 +79,23 @@ def test_scratch_stack_store():
     actual, _ = expr.__teal__(options)
 
     assert actual == expected
+
+def test_scratch_assign_id():
+    slot = ScratchSlot(255)
+    expr = ScratchStackStore(slot)
+    assert expr.type_of() == TealType.none
+    
+    expected = TealSimpleBlock([
+        TealOp(expr, Op.store, slot)
+    ])
+
+    actual, _ = expr.__teal__(options)
+
+    assert actual == expected
+
+def test_scratch_assign_id_invalid():
+    with pytest.raises(TealInputError):
+        slot = ScratchSlot(-1)
+
+    with pytest.raises(TealInputError):
+        slot = ScratchSlot(NUM_SLOTS)

--- a/pyteal/ast/scratchvar.py
+++ b/pyteal/ast/scratchvar.py
@@ -23,6 +23,8 @@ class ScratchVar:
             type (optional): The type that this variable can hold. An error will be thrown if an
                 expression with an incompatiable type is stored in this variable. Defaults to
                 TealType.anytype.
+            slotId (optional): A scratch slot id that the compiler must store the value. 
+                This id may be a Python int in the range [0-256).  
         """
         self.slot = ScratchSlot(requestedSlotId=slotId)
         self.type = type

--- a/pyteal/ast/scratchvar.py
+++ b/pyteal/ast/scratchvar.py
@@ -16,7 +16,7 @@ class ScratchVar:
             ])
     """
 
-    def __init__(self, type: TealType = TealType.anytype):
+    def __init__(self, type: TealType = TealType.anytype, slotId: int = None):
         """Create a new ScratchVar with an optional type.
 
         Args:
@@ -24,7 +24,7 @@ class ScratchVar:
                 expression with an incompatiable type is stored in this variable. Defaults to
                 TealType.anytype.
         """
-        self.slot = ScratchSlot()
+        self.slot = ScratchSlot(requestedSlotId=slotId)
         self.type = type
     
     def storage_type(self) -> TealType:

--- a/pyteal/ast/scratchvar_test.py
+++ b/pyteal/ast/scratchvar_test.py
@@ -68,6 +68,20 @@ def test_scratchvar_load():
 
     assert actual == expected
 
+def test_scratchvar_assign_slot():
+    myScratch       = ScratchVar(TealType.uint64)
+    otherScratch    = ScratchVar(TealType.uint64, 1)
+    anotherScratch  = ScratchVar(TealType.uint64, 0)
+    lastScratch     = ScratchVar(TealType.uint64)
+    prog            = Seq([
+                        myScratch.store(Int(5)),      # Slot 2
+                        otherScratch.store(Int(0)),   # Slot 1
+                        anotherScratch.store(Int(7)), # Slot 0
+                        lastScratch.store(Int(9)),    # Slot 3
+                      ])
+
+    compileTeal(prog, mode=Mode.Signature, version=4) 
+
 def test_scratchvar_double_assign_invalid():
     myvar    = ScratchVar(TealType.uint64, 10)
     otherVar = ScratchVar(TealType.uint64, 10)
@@ -75,16 +89,5 @@ def test_scratchvar_double_assign_invalid():
                 myvar.store(Int(5)),
                 otherVar.store(Int(0))
             ])
-    with pytest.raises(TealInternalError):
-        compileTeal(prog, mode=Mode.Signature, version=4) 
-
-    # Users cannot assign a slot that has been automatically
-    # assigned by the compiler
-    myScratch     = ScratchVar(TealType.uint64)
-    otherScratch  = ScratchVar(TealType.uint64, ScratchSlot.nextSlotId-1)
-    prog          = Seq([
-                        myScratch.store(Int(5)),
-                        otherScratch.store(Int(0))
-                    ])
     with pytest.raises(TealInternalError):
         compileTeal(prog, mode=Mode.Signature, version=4) 

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -1,10 +1,10 @@
-from pyteal.ast.scratch import ScratchSlot
 from typing import List, Set
 
 from ..ast import Expr
 from ..ir import Mode, TealComponent, TealOp, TealBlock
 from ..errors import TealInputError, TealInternalError
 from ..config import NUM_SLOTS
+from ..ast import ScratchSlot
 
 from .sort import sortBlocks
 from .flatten import flattenBlocks

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -1,10 +1,9 @@
 from typing import List, Set
 
-from ..ast import Expr
+from ..ast import Expr, ScratchSlot
 from ..ir import Mode, TealComponent, TealOp, TealBlock
 from ..errors import TealInputError, TealInternalError
 from ..config import NUM_SLOTS
-from ..ast import ScratchSlot
 
 from .sort import sortBlocks
 from .flatten import flattenBlocks

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -1,5 +1,5 @@
 from pyteal.ast.scratch import ScratchSlot
-from typing import List
+from typing import List, Set
 
 from ..ast import Expr
 from ..ir import Mode, TealComponent, TealOp, TealBlock
@@ -97,8 +97,8 @@ def compileTeal(ast: Expr, mode: Mode, *, version: int = DEFAULT_TEAL_VERSION, a
     verifyOpsForVersion(teal, version)
     verifyOpsForMode(teal, mode)
 
-    slots: set[ScratchSlot] = set()
-    slotIds: set[int] = set()
+    slots: Set[ScratchSlot] = set()
+    slotIds: Set[int] = set()
     for stmt in teal:
         for slot in stmt.getSlots():
             # If there are two unique slots with same IDs, raise an error

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -99,6 +99,7 @@ def compileTeal(ast: Expr, mode: Mode, *, version: int = DEFAULT_TEAL_VERSION, a
 
     slots: Set[ScratchSlot] = set()
     slotIds: Set[int] = set()
+    nextSlotIndex = 0
     for stmt in teal:
         for slot in stmt.getSlots():
             # If there are two unique slots with same IDs, raise an error
@@ -111,9 +112,17 @@ def compileTeal(ast: Expr, mode: Mode, *, version: int = DEFAULT_TEAL_VERSION, a
         # TODO: identify which slots can be reused
         raise TealInternalError("Too many slots in use: {}, maximum is {}".format(len(slots), NUM_SLOTS))
     
-    for index, slot in enumerate(sorted(slots, key=lambda slot: slot.id)):
+    for slot in sorted(slots, key=lambda slot: slot.id):
+        # Find next vacant slot that compiler can assign to
+        while nextSlotIndex in slotIds:
+            nextSlotIndex += 1
         for stmt in teal:
-            stmt.assignSlot(slot, index)
+            if slot.isReservedSlot:
+                # Slot ids under 256 are manually reserved slots
+                stmt.assignSlot(slot, slot.id)
+            else:
+                stmt.assignSlot(slot, nextSlotIndex)
+                slotIds.add(nextSlotIndex)
     
     if assembleConstants:
         if version < 3:


### PR DESCRIPTION
Exposes `gload` and `gloads` op codes and allows users to manually specify scratch slot IDs in Pyteal code.

Closes #74 