### PR TITLE
Update docs on group transaction ops (gaid, gload)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,9 @@ PyTeal is a Python language binding for [Algorand Smart Contracts (ASC1s)](https
 
 Algorand Smart Contracts are implemented using a new language that is stack-based, 
 called [Transaction Execution Approval Language (TEAL)](https://developer.algorand.org/docs/features/asc1/teal/). 
-This is a non-Turing complete language that allows branch forwards but prevents recursive logic 
-to maximize safety and performance. 
 
 However, TEAL is essentially an assembly language. With PyTeal, developers can express smart contract logic purely using Python. 
 PyTeal provides high level, functional programming style abstractions over TEAL and does type checking at construction time.
-
-PyTeal **hasn't been security audited**. Use it at your own risk.
 
 ### Install 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ PyTeal **hasn't been security audited**. Use it at your own risk.
    accessing_transaction_field
    crypto
    scratch
+   loading_group_transaction
    control_structures
    state
    assets

--- a/docs/loading_group_transaction.rst
+++ b/docs/loading_group_transaction.rst
@@ -1,0 +1,51 @@
+.. _loading_group_transaction:
+
+Loading Values from Group Transactions
+======================================
+
+Since TEAL version 4 and above, programs can load values from transactions within an atomic 
+group transaction. For instance, you can access the ID or scratch slot of another contract 
+that is being created within an atomic group of transactions. These operations are only 
+permitted in application mode.
+
+Accessing IDs
+~~~~~~~~~~~~~
+
+The ID of an asset or application from another transaction in the current atomic group
+can be accessed using the :code:`GeneratedID` expression. The specified transaction index 
+may be a Python int or a PyTeal expression that must be evaluated to a uint64 at runtime. 
+The transaction index must be less than the index of the current transaction and the 
+maximum allowed group size (16).
+
+For example:
+
+.. code-block:: python
+
+    GeneratedID(0) # retrieves the ID from the 0th transaction in current group
+    GeneratedID(Int(10)) # retrieves the ID from the 10th transaction in group
+
+Note that if the index is a Python int, it is interpreted as an immediate value (uint8) 
+and will be translated to a TEAL :code:`gaid` op. Otherwise, it will be translated 
+to a TEAL :code:`gaids` op.
+
+Loading Scratch Slots
+~~~~~~~~~~~~~~~~~~~~~
+
+The scratch value from another transaction in the current atomic group can be accessed
+using the :code:`ImportScratchValue` expression. The transaction index may be a Python int 
+or a PyTeal expression that must be evaluated to a uint64 at runtime, and the scratch slot
+ID to load from must be a Python int. 
+The transaction index must be less than the index of the current transaction and the 
+maximum allowed group size (16), and the slot ID must be less than the maximum number of
+scratch slots (256). 
+
+For example:
+
+.. code-block:: python
+
+    ImportScratchValue(0, 1) # retrieves the 1st scratch slot from the 0th transaction in group
+    ImportScratchValue(Int(5), 255) # retrieves the 255th scratch slot from the 5th transaction in group
+
+Note that if the index is a Python int, it is interpreted as an immediate value (uint8) 
+and will be translated to a TEAL :code:`gload` op. Otherwise, it will be translated 
+to a TEAL :code:`gloads` op.

--- a/docs/loading_group_transaction.rst
+++ b/docs/loading_group_transaction.rst
@@ -4,14 +4,14 @@ Loading Values from Group Transactions
 ======================================
 
 Since TEAL version 4 and above, programs can load values from transactions within an atomic 
-group transaction. For instance, you can access the ID or scratch slot of another contract 
-that is being created within an atomic group of transactions. These operations are only 
-permitted in application mode.
+group transaction. For instance, you can import values from the scratch space of another 
+application call, and you can access the generated ID of a new application or asset.
+These operations are only permitted in application mode.
 
-Accessing IDs
-~~~~~~~~~~~~~
+Accessing IDs of New Apps and Assets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ID of an asset or application from another transaction in the current atomic group
+The generated ID of an asset or application from a creation transaction in the current atomic group
 can be accessed using the :code:`GeneratedID` expression. The specified transaction index 
 may be a Python int or a PyTeal expression that must be evaluated to a uint64 at runtime. 
 The transaction index must be less than the index of the current transaction and the 
@@ -39,12 +39,33 @@ The transaction index must be less than the index of the current transaction and
 maximum allowed group size (16), and the slot ID must be less than the maximum number of
 scratch slots (256). 
 
-For example:
+For example, assume an atomic transaction group contains app calls to the following applications,
+where App A is called from the first transaction (index 0) and App B is called from the second 
+or later transaction. Then the greeting value will be successfully passed between the two contracts.
+
+App A:
 
 .. code-block:: python
 
-    ImportScratchValue(0, 1) # retrieves the 1st scratch slot from the 0th transaction in group
-    ImportScratchValue(Int(5), 255) # retrieves the 255th scratch slot from the 5th transaction in group
+    # App is called at transaction index 0
+    greeting = ScratchVar(TealType.bytes, 20) # this variable will live in scratch slot 20
+    program = Seq([
+    If(Txn.sender() == App.globalGet(Bytes("creator")))
+        .Then(greeting.store(Bytes("hi creator!")))
+        .Else(greeting.store(Bytes("hi user!"))),
+    Return(Int(1))
+    ])
+
+App B:
+
+.. code-block:: python
+
+    greetingFromPreviousApp = ImportScratchValue(0, 20) # loading scratch slot 20 from the transaction at index 0
+    program = Seq([
+        # not shown: make sure that the transaction at index 0 is an app call to App A
+        App.globalPut(Bytes("greeting from prev app"), greetingFromPreviousApp),
+        Return(Int(1))
+    ]) 
 
 Note that if the index is a Python int, it is interpreted as an immediate value (uint8) 
 and will be translated to a TEAL :code:`gload` op. Otherwise, it will be translated 

--- a/docs/loading_group_transaction.rst
+++ b/docs/loading_group_transaction.rst
@@ -50,7 +50,7 @@ App A:
     # App is called at transaction index 0
     greeting = ScratchVar(TealType.bytes, 20) # this variable will live in scratch slot 20
     program = Seq([
-    If(Txn.sender() == App.globalGet(Bytes("creator")))
+        If(Txn.sender() == App.globalGet(Bytes("creator")))
         .Then(greeting.store(Bytes("hi creator!")))
         .Else(greeting.store(Bytes("hi user!"))),
     Return(Int(1))

--- a/docs/scratch.rst
+++ b/docs/scratch.rst
@@ -18,7 +18,9 @@ Writing and Reading
 To write to scratch space, first create a :any:`ScratchVar` object and pass in the :any:`TealType`
 of the values that you will store there. It is possible to create a :any:`ScratchVar` that can store
 both integers and byte slices by passing no arguments to the :any:`ScratchVar` constructor, but note
-that no type checking takes places in this situation.
+that no type checking takes places in this situation. It is also possible to manually specify which 
+slot ID the compiler should assign the scratch slot to in the TEAL code. If no slot ID is specified,
+the compiler will assign it to any available slot. 
 
 To write or read values, use the corresponding :any:`ScratchVar.store` or :any:`ScratchVar.load` methods.
 
@@ -26,8 +28,9 @@ For example:
 
 .. code-block:: python
 
-    myvar = ScratchVar(TealType.uint64)
+    myvar = ScratchVar(TealType.uint64) # assign a scratch slot in any available slot
     program = Seq([
         myvar.store(Int(5)),
         Assert(myvar.load() == Int(5))
     ])
+    anotherVar = ScratchVar(TealType.bytes, 4) # assign this scratch slot to slot #4


### PR DESCRIPTION
This commit makes minor changes to the README and adds docs on how to use the `GenerateID` (gaid) and `ImportScratchValue` (gload) expressions in Pyteal.