### PR TITLE
Add `AppParam` opcode for TEAL v5

### DIFF
--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -15,7 +15,7 @@ from .gtxn import GtxnExpr, GtxnaExpr, TxnGroup, Gtxn
 from .gaid import GeneratedID
 from .gload import ImportScratchValue
 from .global_ import Global, GlobalField
-from .app import App, AppField, OnComplete
+from .app import App, AppField, OnComplete, AppParam
 from .asset import AssetHolding, AssetParam
 
 # meta
@@ -73,6 +73,7 @@ __all__ = [
     "App",
     "AppField",
     "OnComplete",
+    "AppParam",
     "AssetHolding",
     "AssetParam",
     "Array",
@@ -135,15 +136,15 @@ __all__ = [
     "BytesMinus",
     "BytesDiv",
     "BytesMul",
-    "BytesMod", 
-    "BytesAnd", 
-    "BytesOr", 
-    "BytesXor", 
-    "BytesEq", 
-    "BytesNeq", 
-    "BytesLt", 
-    "BytesLe", 
-    "BytesGt", 
+    "BytesMod",
+    "BytesAnd",
+    "BytesOr",
+    "BytesXor",
+    "BytesEq",
+    "BytesNeq",
+    "BytesLt",
+    "BytesLe",
+    "BytesGt",
     "BytesGe",
     "BytesNot",
     "BytesZero",

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -197,42 +197,89 @@ class AppParam:
 
     @classmethod
     def approvalProgram(cls, app: Expr) -> MaybeValue:
-        """TODO need to start the documentation"""
+        """Get the bytecode of Approval Program for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(Op.app_params_get, TealType.bytes, immediate_args=["AppApprovalProgram"], args=[app])
 
     @classmethod
     def clearStateProgram(cls, app: Expr) -> MaybeValue:
+        """Get the bytecode of Clear State Program for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(Op.app_params_get, TealType.bytes, immediate_args=["AppClearStateProgram"], args=[app])
 
     @classmethod
     def globalNumUnit(cls, app: Expr) -> MaybeValue:
+        """Get the number of uint64 values allowed in Global State for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppGlobalNumUnit"], args=[app])
 
     @classmethod
     def globalNumByteSlice(cls, app: Expr) -> MaybeValue:
+        """Get the number of byte array values allowed in Global State for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppGlobalNumByteSlice"], args=[app])
 
     @classmethod
     def localNumUnit(cls, app: Expr) -> MaybeValue:
+        """Get the number of uint64 values allowed in Local State for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppLocalNumUnit"], args=[app])
 
     @classmethod
     def localNumByteSlice(cls, app: Expr) -> MaybeValue:
+        """Get the number of byte array values allowed in Local State for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppLocalNumByteSlice"], args=[app])
 
     @classmethod
     def extraProgramPages(cls, app: Expr) -> MaybeValue:
+        """Get the number of Extra Program Pages of code space for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppExtraProgramPages"], args=[app])
 
     @classmethod
     def creator(cls, app: Expr) -> MaybeValue:
+        """Get the creator address for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(Op.app_params_get, TealType.bytes, immediate_args=["AppCreator"], args=[app])
 

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -38,10 +38,10 @@ class AppField(Enum):
     def __init__(self, op: Op, type: TealType) -> None:
         self.op = op
         self.ret_type = type
-    
+
     def get_op(self) -> Op:
         return self.op
-    
+
     def type_of(self) -> TealType:
         return self.ret_type
 
@@ -50,7 +50,7 @@ AppField.__module__ = "pyteal"
 class App(LeafExpr):
     """An expression related to applications."""
 
-    def __init__(self, field:AppField, args) -> None:
+    def __init__(self, field: AppField, args) -> None:
         super().__init__()
         self.field = field
         self.args = args
@@ -71,7 +71,7 @@ class App(LeafExpr):
     @classmethod
     def id(cls) -> Global:
         """Get the ID of the current running application.
-        
+
         This is the same as :any:`Global.current_application_id()`.
         """
         return Global.current_application_id()
@@ -88,7 +88,7 @@ class App(LeafExpr):
         require_type(account.type_of(), TealType.uint64)
         require_type(app.type_of(), TealType.uint64)
         return cls(AppField.optedIn, [account, app])
-    
+
     @classmethod
     def localGet(cls, account: Expr, key: Expr) -> 'App':
         """Read from an account's local state for the current application.
@@ -101,7 +101,7 @@ class App(LeafExpr):
         require_type(account.type_of(), TealType.uint64)
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.localGet, [account, key])
-    
+
     @classmethod
     def localGetEx(cls, account: Expr, app: Expr, key: Expr) -> MaybeValue:
         """Read from an account's local state for an application.
@@ -126,7 +126,7 @@ class App(LeafExpr):
         """
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.globalGet, [key])
-    
+
     @classmethod
     def globalGetEx(cls, app: Expr, key: Expr) -> MaybeValue:
         """Read from the global state of an application.
@@ -154,7 +154,7 @@ class App(LeafExpr):
         require_type(key.type_of(), TealType.bytes)
         require_type(value.type_of(), TealType.anytype)
         return cls(AppField.localPut, [account, key, value])
-    
+
     @classmethod
     def globalPut(cls, key: Expr, value: Expr) -> 'App':
         """Write to the global state of the current application.
@@ -179,7 +179,7 @@ class App(LeafExpr):
         require_type(account.type_of(), TealType.uint64)
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.localDel, [account, key])
-    
+
     @classmethod
     def globalDel(cls, key: Expr) -> 'App':
         """Delete a key from the global state of the current application.
@@ -191,3 +191,50 @@ class App(LeafExpr):
         return cls(AppField.globalDel, [key])
 
 App.__module__ = "pyteal"
+
+
+class AppParam:
+
+    @classmethod
+    def approvalProgram(cls, app: Expr) -> MaybeValue:
+        """TODO need to start the documentation"""
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(Op.app_params_get, TealType.bytes, immediate_args=["AppApprovalProgram"], args=[app])
+
+    @classmethod
+    def clearStateProgram(cls, app: Expr) -> MaybeValue:
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(Op.app_params_get, TealType.bytes, immediate_args=["AppClearStateProgram"], args=[app])
+
+    @classmethod
+    def globalNumUnit(cls, app: Expr) -> MaybeValue:
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppGlobalNumUnit"], args=[app])
+
+    @classmethod
+    def globalNumByteSlice(cls, app: Expr) -> MaybeValue:
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppGlobalNumByteSlice"], args=[app])
+
+    @classmethod
+    def localNumUnit(cls, app: Expr) -> MaybeValue:
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppLocalNumUnit"], args=[app])
+
+    @classmethod
+    def localNumByteSlice(cls, app: Expr) -> MaybeValue:
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppLocalNumByteSlice"], args=[app])
+
+    @classmethod
+    def extraProgramPages(cls, app: Expr) -> MaybeValue:
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(Op.app_params_get, TealType.uint64, immediate_args=["AppExtraProgramPages"], args=[app])
+
+    @classmethod
+    def creator(cls, app: Expr) -> MaybeValue:
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(Op.app_params_get, TealType.bytes, immediate_args=["AppCreator"], args=[app])
+
+
+AppParam.__module__ = "pyteal"

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -255,49 +255,209 @@ def test_global_del_invalid():
         App.globalDel(Int(2))
 
 
-def test_app_param_approval_program_valid(): ...
+def test_app_param_approval_program_valid():
+    _app = Int(1)
+    expr = AppParam.approvalProgram(_app)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(_app, Op.int, 1),
+        TealOp(expr, Op.app_params_get, "AppApprovalProgram"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
-def test_app_param_approval_program_invalid(): ...
+def test_app_param_approval_program_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.approvalProgram(Txn.sender())
 
 
-def test_app_param_clear_state_program_valid(): ...
+def test_app_param_clear_state_program_valid():
+    _app = Int(0)
+    expr = AppParam.clearStateProgram(_app)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(_app, Op.int, 0),
+        TealOp(expr, Op.app_params_get, "AppClearStateProgram"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
-def test_app_param_clear_state_program_invalid(): ...
+def test_app_param_clear_state_program_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.clearStateProgram(Txn.sender())
 
 
-def test_app_param_global_num_unit_valid(): ...
+def test_app_param_global_num_unit_valid():
+    _app = Int(1)
+    expr = AppParam.globalNumUnit(_app)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(_app, Op.int, 1),
+        TealOp(expr, Op.app_params_get, "AppGlobalNumUnit"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
-def test_app_param_global_num_unit_invalid(): ...
+def test_app_param_global_num_unit_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.globalNumUnit(Txn.sender())
 
 
-def test_app_param_global_num_byte_slice_valid(): ...
+def test_app_param_global_num_byte_slice_valid():
+    _app = Int(1)
+    expr = AppParam.globalNumByteSlice(_app)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(_app, Op.int, 1),
+        TealOp(expr, Op.app_params_get, "AppGlobalNumByteSlice"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
-def test_app_param_global_num_byte_slice_invalid(): ...
+def test_app_param_global_num_byte_slice_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.globalNumByteSlice(Txn.sender())
 
 
-def test_app_param_local_num_unit_valid(): ...
+def test_app_param_local_num_unit_valid():
+    _app = Int(1)
+    expr = AppParam.localNumUnit(_app)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(_app, Op.int, 1),
+        TealOp(expr, Op.app_params_get, "AppLocalNumUnit"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
-def test_app_param_local_num_unit_invalid(): ...
+def test_app_param_local_num_unit_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.localNumUnit(Txn.sender())
 
 
-def test_app_param_local_num_byte_slice_valid(): ...
+def test_app_param_local_num_byte_slice_valid():
+    _app = Int(1)
+    expr = AppParam.localNumByteSlice(_app)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(_app, Op.int, 1),
+        TealOp(expr, Op.app_params_get, "AppLocalNumByteSlice"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
-def test_app_param_local_num_byte_slice_invalid(): ...
+def test_app_param_local_num_byte_slice_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.localNumByteSlice(Txn.sender())
 
 
-def test_app_param_extra_program_page_valid(): ...
+def test_app_param_extra_programs_page_valid():
+    _app = Int(1)
+    expr = AppParam.extraProgramPages(_app)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(_app, Op.int, 1),
+        TealOp(expr, Op.app_params_get, "AppExtraProgramPages"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
-def test_app_param_extra_program_page_invalid(): ...
+def test_app_param_extra_program_pages_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.extraProgramPages(Txn.sender())
 
 
-def test_app_param_creator_valid(): ...
+def test_app_param_creator_valid():
+    _app = Int(1)
+    expr = AppParam.creator(_app)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(_app, Op.int, 1),
+        TealOp(expr, Op.app_params_get, "AppCreator"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
-def test_app_param_creator_invalid(): ...
+def test_app_param_creator_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.creator(Txn.sender())

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -254,15 +254,14 @@ def test_global_del_invalid():
     with pytest.raises(TealTypeError):
         App.globalDel(Int(2))
 
-
 def test_app_param_approval_program_valid():
-    _app = Int(1)
-    expr = AppParam.approvalProgram(_app)
+    arg = Int(1)
+    expr = AppParam.approvalProgram(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
 
     expected = TealSimpleBlock([
-        TealOp(_app, Op.int, 1),
+        TealOp(arg, Op.int, 1),
         TealOp(expr, Op.app_params_get, "AppApprovalProgram"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
@@ -275,20 +274,18 @@ def test_app_param_approval_program_valid():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-
 def test_app_param_approval_program_invalid():
     with pytest.raises(TealTypeError):
         AppParam.approvalProgram(Txn.sender())
 
-
 def test_app_param_clear_state_program_valid():
-    _app = Int(0)
-    expr = AppParam.clearStateProgram(_app)
+    arg = Int(0)
+    expr = AppParam.clearStateProgram(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
 
     expected = TealSimpleBlock([
-        TealOp(_app, Op.int, 0),
+        TealOp(arg, Op.int, 0),
         TealOp(expr, Op.app_params_get, "AppClearStateProgram"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
@@ -301,20 +298,18 @@ def test_app_param_clear_state_program_valid():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-
 def test_app_param_clear_state_program_invalid():
     with pytest.raises(TealTypeError):
         AppParam.clearStateProgram(Txn.sender())
 
-
 def test_app_param_global_num_unit_valid():
-    _app = Int(1)
-    expr = AppParam.globalNumUnit(_app)
+    arg = Int(1)
+    expr = AppParam.globalNumUnit(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
 
     expected = TealSimpleBlock([
-        TealOp(_app, Op.int, 1),
+        TealOp(arg, Op.int, 1),
         TealOp(expr, Op.app_params_get, "AppGlobalNumUnit"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
@@ -327,20 +322,18 @@ def test_app_param_global_num_unit_valid():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-
 def test_app_param_global_num_unit_invalid():
     with pytest.raises(TealTypeError):
         AppParam.globalNumUnit(Txn.sender())
 
-
 def test_app_param_global_num_byte_slice_valid():
-    _app = Int(1)
-    expr = AppParam.globalNumByteSlice(_app)
+    arg = Int(1)
+    expr = AppParam.globalNumByteSlice(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
 
     expected = TealSimpleBlock([
-        TealOp(_app, Op.int, 1),
+        TealOp(arg, Op.int, 1),
         TealOp(expr, Op.app_params_get, "AppGlobalNumByteSlice"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
@@ -353,20 +346,18 @@ def test_app_param_global_num_byte_slice_valid():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-
 def test_app_param_global_num_byte_slice_invalid():
     with pytest.raises(TealTypeError):
         AppParam.globalNumByteSlice(Txn.sender())
 
-
 def test_app_param_local_num_unit_valid():
-    _app = Int(1)
-    expr = AppParam.localNumUnit(_app)
+    arg = Int(1)
+    expr = AppParam.localNumUnit(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
 
     expected = TealSimpleBlock([
-        TealOp(_app, Op.int, 1),
+        TealOp(arg, Op.int, 1),
         TealOp(expr, Op.app_params_get, "AppLocalNumUnit"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
@@ -379,20 +370,18 @@ def test_app_param_local_num_unit_valid():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-
 def test_app_param_local_num_unit_invalid():
     with pytest.raises(TealTypeError):
         AppParam.localNumUnit(Txn.sender())
 
-
 def test_app_param_local_num_byte_slice_valid():
-    _app = Int(1)
-    expr = AppParam.localNumByteSlice(_app)
+    arg = Int(1)
+    expr = AppParam.localNumByteSlice(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
 
     expected = TealSimpleBlock([
-        TealOp(_app, Op.int, 1),
+        TealOp(arg, Op.int, 1),
         TealOp(expr, Op.app_params_get, "AppLocalNumByteSlice"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
@@ -405,20 +394,18 @@ def test_app_param_local_num_byte_slice_valid():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-
 def test_app_param_local_num_byte_slice_invalid():
     with pytest.raises(TealTypeError):
         AppParam.localNumByteSlice(Txn.sender())
 
-
 def test_app_param_extra_programs_page_valid():
-    _app = Int(1)
-    expr = AppParam.extraProgramPages(_app)
+    arg = Int(1)
+    expr = AppParam.extraProgramPages(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
 
     expected = TealSimpleBlock([
-        TealOp(_app, Op.int, 1),
+        TealOp(arg, Op.int, 1),
         TealOp(expr, Op.app_params_get, "AppExtraProgramPages"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
@@ -431,20 +418,18 @@ def test_app_param_extra_programs_page_valid():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-
 def test_app_param_extra_program_pages_invalid():
     with pytest.raises(TealTypeError):
         AppParam.extraProgramPages(Txn.sender())
 
-
 def test_app_param_creator_valid():
-    _app = Int(1)
-    expr = AppParam.creator(_app)
+    arg = Int(1)
+    expr = AppParam.creator(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
 
     expected = TealSimpleBlock([
-        TealOp(_app, Op.int, 1),
+        TealOp(arg, Op.int, 1),
         TealOp(expr, Op.app_params_get, "AppCreator"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
@@ -456,7 +441,6 @@ def test_app_param_creator_valid():
 
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
-
 
 def test_app_param_creator_invalid():
     with pytest.raises(TealTypeError):

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -41,40 +41,40 @@ def test_opted_in():
     args = [Int(1), Int(12)]
     expr = App.optedIn(args[0], args[1])
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 1),
         TealOp(args[1], Op.int, 12),
         TealOp(expr, Op.app_opted_in)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_local_get():
     args = [Int(0), Bytes("key")]
     expr = App.localGet(args[0], args[1])
     assert expr.type_of() == TealType.anytype
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.byte, "\"key\""),
         TealOp(expr, Op.app_local_get)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_local_get_invalid():
     with pytest.raises(TealTypeError):
         App.localGet(Txn.sender(), Bytes("key"))
-    
+
     with pytest.raises(TealTypeError):
         App.localGet(Int(0), Int(1))
 
@@ -83,7 +83,7 @@ def test_local_get_ex():
     expr = App.localGetEx(args[0], args[1], args[2])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.anytype
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.int, 6),
@@ -92,18 +92,18 @@ def test_local_get_ex():
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 def test_local_get_ex_invalid():
     with pytest.raises(TealTypeError):
         App.localGetEx(Txn.sender(), Int(0), Bytes("key"))
-    
+
     with pytest.raises(TealTypeError):
         App.localGetEx(Int(0), Bytes("app"), Bytes("key"))
 
@@ -114,16 +114,16 @@ def test_global_get():
     arg = Bytes("key")
     expr = App.globalGet(arg)
     assert expr.type_of() == TealType.anytype
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.byte, "\"key\""),
         TealOp(expr, Op.app_global_get)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_global_get_invalid():
@@ -135,7 +135,7 @@ def test_global_get_ex():
     expr = App.globalGetEx(args[0], args[1])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.anytype
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 6),
         TealOp(args[1], Op.byte, "\"key\""),
@@ -143,11 +143,11 @@ def test_global_get_ex():
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -162,27 +162,27 @@ def test_local_put():
     args = [Int(0), Bytes("key"), Int(5)]
     expr = App.localPut(args[0], args[1], args[2])
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.byte, "\"key\""),
         TealOp(args[2], Op.int, 5),
         TealOp(expr, Op.app_local_put)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_local_put_invalid():
     with pytest.raises(TealTypeError):
         App.localPut(Txn.sender(), Bytes("key"), Int(5))
-    
+
     with pytest.raises(TealTypeError):
         App.localPut(Int(1), Int(0), Int(5))
-    
+
     with pytest.raises(TealTypeError):
         App.localPut(Int(1), Bytes("key"), Pop(Int(1)))
 
@@ -190,23 +190,23 @@ def test_global_put():
     args = [Bytes("key"), Int(5)]
     expr = App.globalPut(args[0], args[1])
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.byte, "\"key\""),
         TealOp(args[1], Op.int, 5),
         TealOp(expr, Op.app_global_put)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_global_put_invalid():
     with pytest.raises(TealTypeError):
         App.globalPut(Int(0), Int(5))
-    
+
     with pytest.raises(TealTypeError):
         App.globalPut(Bytes("key"), Pop(Int(1)))
 
@@ -214,23 +214,23 @@ def test_local_del():
     args = [Int(0), Bytes("key")]
     expr = App.localDel(args[0], args[1])
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.byte, "\"key\""),
         TealOp(expr, Op.app_local_del)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_local_del_invalid():
     with pytest.raises(TealTypeError):
         App.localDel(Txn.sender(), Bytes("key"))
-    
+
     with pytest.raises(TealTypeError):
         App.localDel(Int(1), Int(2))
 
@@ -238,18 +238,66 @@ def test_global_del():
     arg = Bytes("key")
     expr = App.globalDel(arg)
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.byte, "\"key\""),
         TealOp(expr, Op.app_global_del)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_global_del_invalid():
     with pytest.raises(TealTypeError):
         App.globalDel(Int(2))
+
+
+def test_app_param_approval_program_valid(): ...
+
+
+def test_app_param_approval_program_invalid(): ...
+
+
+def test_app_param_clear_state_program_valid(): ...
+
+
+def test_app_param_clear_state_program_invalid(): ...
+
+
+def test_app_param_global_num_unit_valid(): ...
+
+
+def test_app_param_global_num_unit_invalid(): ...
+
+
+def test_app_param_global_num_byte_slice_valid(): ...
+
+
+def test_app_param_global_num_byte_slice_invalid(): ...
+
+
+def test_app_param_local_num_unit_valid(): ...
+
+
+def test_app_param_local_num_unit_invalid(): ...
+
+
+def test_app_param_local_num_byte_slice_valid(): ...
+
+
+def test_app_param_local_num_byte_slice_invalid(): ...
+
+
+def test_app_param_extra_program_page_valid(): ...
+
+
+def test_app_param_extra_program_page_invalid(): ...
+
+
+def test_app_param_creator_valid(): ...
+
+
+def test_app_param_creator_invalid(): ...

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -7,7 +7,7 @@ from .leafexpr import LeafExpr
 from .maybe import MaybeValue
 
 class AssetHolding:
-    
+
     @classmethod
     def balance(cls, account: Expr, asset: Expr) -> MaybeValue:
         """Get the amount of an asset held by an account.
@@ -20,7 +20,7 @@ class AssetHolding:
         require_type(account.type_of(), TealType.uint64)
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetBalance"], args=[account, asset])
-    
+
     @classmethod
     def frozen(cls, account: Expr, asset: Expr) -> MaybeValue:
         """Check if an asset is frozen for an account.
@@ -50,7 +50,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetTotal"], args=[asset])
-    
+
     @classmethod
     def decimals(cls, asset: Expr) -> MaybeValue:
         """Get the number of decimals for an asset.
@@ -61,7 +61,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDecimals"], args=[asset])
-    
+
     @classmethod
     def defaultFrozen(cls, asset: Expr) -> MaybeValue:
         """Check if an asset is frozen by default.
@@ -72,7 +72,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDefaultFrozen"], args=[asset])
-    
+
     @classmethod
     def unitName(cls, asset: Expr) -> MaybeValue:
         """Get the unit name of an asset.
@@ -83,7 +83,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetUnitName"], args=[asset])
-    
+
     @classmethod
     def name(cls, asset: Expr) -> MaybeValue:
         """Get the name of an asset.
@@ -94,7 +94,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetName"], args=[asset])
-    
+
     @classmethod
     def url(cls, asset: Expr) -> MaybeValue:
         """Get the URL of an asset.
@@ -105,7 +105,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetURL"], args=[asset])
-    
+
     @classmethod
     def metadataHash(cls, asset: Expr) -> MaybeValue:
         """Get the arbitrary commitment for an asset.
@@ -118,7 +118,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetMetadataHash"], args=[asset])
-    
+
     @classmethod
     def manager(cls, asset: Expr) -> MaybeValue:
         """Get the manager address for an asset.
@@ -129,7 +129,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetManager"], args=[asset])
-    
+
     @classmethod
     def reserve(cls, asset: Expr) -> MaybeValue:
         """Get the reserve address for an asset.
@@ -140,7 +140,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetReserve"], args=[asset])
-    
+
     @classmethod
     def freeze(cls, asset: Expr) -> MaybeValue:
         """Get the freeze address for an asset.
@@ -151,7 +151,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetFreeze"], args=[asset])
-    
+
     @classmethod
     def clawback(cls, asset: Expr) -> MaybeValue:
         """Get the clawback address for an asset.
@@ -162,5 +162,17 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetClawback"], args=[asset])
+
+    @classmethod
+    def creator(cls, asset: Expr) -> MaybeValue:
+        """Get the creator address for an asset.
+
+        Args:
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
+                evaluate to uint64.
+        """
+        require_type(asset.type_of(), TealType.uint64)
+        return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetCreator"], args=[asset])
+
 
 AssetParam.__module__ = "pyteal"

--- a/pyteal/ast/asset_test.py
+++ b/pyteal/ast/asset_test.py
@@ -11,7 +11,7 @@ def test_asset_holding_balance():
     expr = AssetHolding.balance(args[0], args[1])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.int, 17),
@@ -19,18 +19,18 @@ def test_asset_holding_balance():
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 def test_asset_holding_balance_invalid():
     with pytest.raises(TealTypeError):
         AssetHolding.balance(Txn.sender(), Int(17))
-    
+
     with pytest.raises(TealTypeError):
         AssetHolding.balance(Int(0), Txn.receiver())
 
@@ -39,7 +39,7 @@ def test_asset_holding_frozen():
     expr = AssetHolding.frozen(args[0], args[1])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.int, 17),
@@ -47,18 +47,18 @@ def test_asset_holding_frozen():
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 def test_asset_holding_frozen_invalid():
     with pytest.raises(TealTypeError):
         AssetHolding.frozen(Txn.sender(), Int(17))
-    
+
     with pytest.raises(TealTypeError):
         AssetHolding.frozen(Int(0), Txn.receiver())
 
@@ -67,18 +67,18 @@ def test_asset_param_total():
     expr = AssetParam.total(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetTotal"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -91,18 +91,18 @@ def test_asset_param_decimals():
     expr = AssetParam.decimals(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetDecimals"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -115,18 +115,18 @@ def test_asset_param_default_frozen():
     expr = AssetParam.defaultFrozen(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetDefaultFrozen"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -139,18 +139,18 @@ def test_asset_param_unit_name():
     expr = AssetParam.unitName(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetUnitName"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -163,18 +163,18 @@ def test_asset_param_name():
     expr = AssetParam.name(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetName"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -187,18 +187,18 @@ def test_asset_param_url():
     expr = AssetParam.url(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetURL"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -211,18 +211,18 @@ def test_asset_param_metadata_hash():
     expr = AssetParam.metadataHash(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetMetadataHash"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -235,18 +235,18 @@ def test_asset_param_manager():
     expr = AssetParam.manager(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetManager"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -259,18 +259,18 @@ def test_asset_param_reserve():
     expr = AssetParam.reserve(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 2),
         TealOp(expr, Op.asset_params_get, "AssetReserve"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -283,18 +283,18 @@ def test_asset_param_freeze():
     expr = AssetParam.freeze(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetFreeze"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -307,21 +307,30 @@ def test_asset_param_clawback():
     expr = AssetParam.clawback(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 1),
         TealOp(expr, Op.asset_params_get, "AssetClawback"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 def test_asset_param_clawback_invalid():
     with pytest.raises(TealTypeError):
         AssetParam.clawback(Txn.sender())
+
+
+def test_asset_param_creator_valid():
+    ...
+
+
+def test_asset_param_creator_invalid():
+    with pytest.raises(TealTypeError):
+        ...

--- a/pyteal/ast/asset_test.py
+++ b/pyteal/ast/asset_test.py
@@ -326,7 +326,6 @@ def test_asset_param_clawback_invalid():
     with pytest.raises(TealTypeError):
         AssetParam.clawback(Txn.sender())
 
-
 def test_asset_param_creator_valid():
     arg = Int(1)
     expr = AssetParam.creator(arg)

--- a/pyteal/ast/asset_test.py
+++ b/pyteal/ast/asset_test.py
@@ -328,9 +328,26 @@ def test_asset_param_clawback_invalid():
 
 
 def test_asset_param_creator_valid():
-    ...
+    arg = Int(1)
+    expr = AssetParam.creator(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.int, 1),
+        TealOp(expr, Op.asset_params_get, "AssetCreator"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
 def test_asset_param_creator_invalid():
     with pytest.raises(TealTypeError):
-        ...
+        AssetParam.creator(Txn.sender())

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -9,7 +9,7 @@ from .sort import sortBlocks
 from .flatten import flattenBlocks
 from .constants import createConstantBlocks
 
-MAX_TEAL_VERSION = 4
+MAX_TEAL_VERSION = 5
 MIN_TEAL_VERSION = 2
 DEFAULT_TEAL_VERSION = MIN_TEAL_VERSION
 
@@ -84,7 +84,7 @@ def compileTeal(ast: Expr, mode: Mode, *, version: int = DEFAULT_TEAL_VERSION, a
 
     start = TealBlock.NormalizeBlocks(start)
     start.validateTree()
-    
+
     errors = start.validateSlots()
     if len(errors) > 0:
         msg = 'Encountered {} error{} during compilation'.format(len(errors), 's' if len(errors) != 1 else '')
@@ -106,11 +106,11 @@ def compileTeal(ast: Expr, mode: Mode, *, version: int = DEFAULT_TEAL_VERSION, a
                 raise TealInternalError("Slot ID {} has been assigned multiple times".format(slot.id))
             slotIds.add(slot.id)
             slots.add(slot)
-    
+
     if len(slots) > NUM_SLOTS:
         # TODO: identify which slots can be reused
         raise TealInternalError("Too many slots in use: {}, maximum is {}".format(len(slots), NUM_SLOTS))
-    
+
     for slot in sorted(slots, key=lambda slot: slot.id):
         # Find next vacant slot that compiler can assign to
         while nextSlotIndex in slotIds:
@@ -122,7 +122,7 @@ def compileTeal(ast: Expr, mode: Mode, *, version: int = DEFAULT_TEAL_VERSION, a
             else:
                 stmt.assignSlot(slot, nextSlotIndex)
                 slotIds.add(nextSlotIndex)
-    
+
     if assembleConstants:
         if version < 3:
             raise TealInternalError("The minimum TEAL version required to enable assembleConstants is 3. The current version is {}".format(version))

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -75,14 +75,14 @@ def test_compile_version_invalid():
         compileTeal(expr, Mode.Signature, version=1) # too small
 
     with pytest.raises(TealInputError):
-        compileTeal(expr, Mode.Signature, version=5) # too large
-    
+        compileTeal(expr, Mode.Signature, version=6) # too large
+
     with pytest.raises(TealInputError):
         compileTeal(expr, Mode.Signature, version=2.0) # decimal
 
 def test_compile_version_2():
     expr = Int(1)
-    
+
     expected = """
 #pragma version 2
 int 1
@@ -99,7 +99,7 @@ def test_compile_version_default():
 
 def test_compile_version_3():
     expr = Int(1)
-    
+
     expected = """
 #pragma version 3
 int 1
@@ -109,7 +109,7 @@ int 1
 
 def test_compile_version_4():
     expr = Int(1)
-    
+
     expected = """
 #pragma version 4
 int 1
@@ -122,11 +122,11 @@ def test_slot_load_before_store():
     program = AssetHolding.balance(Int(0), Int(0)).value()
     with pytest.raises(TealInternalError):
         compileTeal(program, Mode.Application, version=2)
-    
+
     program = AssetHolding.balance(Int(0), Int(0)).hasValue()
     with pytest.raises(TealInternalError):
         compileTeal(program, Mode.Application, version=2)
-    
+
     program = App.globalGetEx(Int(0), Bytes("key")).value()
     with pytest.raises(TealInternalError):
         compileTeal(program, Mode.Application, version=2)
@@ -134,7 +134,7 @@ def test_slot_load_before_store():
     program = App.globalGetEx(Int(0), Bytes("key")).hasValue()
     with pytest.raises(TealInternalError):
         compileTeal(program, Mode.Application, version=2)
-    
+
     program = ScratchVar().load()
     with pytest.raises(TealInternalError):
         compileTeal(program, Mode.Application, version=2)
@@ -162,7 +162,7 @@ store 0
 int 9
 store 3
 """.strip()
-    actual = compileTeal(prog, mode=Mode.Signature, version=4) 
+    actual = compileTeal(prog, mode=Mode.Signature, version=4)
     assert actual == expected
 
 def test_scratchvar_double_assign_invalid():
@@ -173,7 +173,7 @@ def test_scratchvar_double_assign_invalid():
                 otherVar.store(Int(0))
             ])
     with pytest.raises(TealInternalError):
-        compileTeal(prog, mode=Mode.Signature, version=4) 
+        compileTeal(prog, mode=Mode.Signature, version=4)
 
 def test_assembleConstants():
     program = Itob(Int(1) + Int(1) + Tmpl.Int("TMPL_VAR")) == Concat(Bytes("test"), Bytes("test"), Bytes("test2"))

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -117,6 +117,15 @@ int 1
     actual = compileTeal(expr, Mode.Signature, version=4)
     assert actual == expected
 
+def test_compile_version_5():
+    expr = Int(1)
+    expected = """
+#pragma version 5
+int 1    
+""".strip()
+    actual = compileTeal(expr, Mode.Signature, version=5)
+    assert actual == expected
+
 def test_slot_load_before_store():
 
     program = AssetHolding.balance(Int(0), Int(0)).value()

--- a/pyteal/ir/ops.py
+++ b/pyteal/ir/ops.py
@@ -3,7 +3,7 @@ from enum import Enum, Flag, auto
 
 class Mode(Flag):
     """Enum of program running modes."""
-    
+
     Signature = auto()
     Application = auto()
 
@@ -142,5 +142,6 @@ class Op(Enum):
     gaids             = OpType("gaids",             Mode.Application,                  4)
     callsub           = OpType("callsub",           Mode.Signature | Mode.Application, 4)
     retsub            = OpType("retsub",            Mode.Signature | Mode.Application, 4)
+    app_params_get    = OpType("app_params_get",    Mode.Application,                  5)
 
 Op.__module__ = "pyteal"


### PR DESCRIPTION
This commit introduces `AppParam` class for a new opcode in TEAL v5 (#84). Minor changes are also applied on `AssetParam` and compiler version.