### PR TITLE
Direct Reference for Application/Account/Asset

### DIFF
--- a/docs/assets.rst
+++ b/docs/assets.rst
@@ -55,17 +55,17 @@ account holds. For example,
 
 .. code-block:: python
 
-    # get the balance of the sender for asset 31566704
+    # get the balance of the sender for asset `Txn.assets[0]`
     # if the account is not opted into that asset, returns 0
-    senderAssetBalance = AssetHolding.balance(Txn.sender(), Txn.assets[31566704])
+    senderAssetBalance = AssetHolding.balance(Txn.sender(), Txn.assets[0])
     program = Seq([
         senderAssetBalance,
         senderAssetBalance.value()
     ])
 
-    # get the balance of Txn.accounts[1] for asset 27165954
+    # get the balance of Txn.accounts[1] for asset `Txn.assets[1]`
     # if the account is not opted into that asset, exit with an error
-    account1AssetBalance = AssetHolding.balance(Txn.accounts[1], Txn.assets[27165954])
+    account1AssetBalance = AssetHolding.balance(Txn.accounts[1], Txn.assets[1])
     program = Seq([
         account1AssetBalance,
         Assert(account1AssetBalance.hasValue()),
@@ -80,17 +80,17 @@ A value of :code:`1` indicates frozen and :code:`0` indicates not frozen. For ex
 
 .. code-block:: python
 
-    # get the frozen status of the sender for asset 31566704
+    # get the frozen status of the sender for asset `Txn.assets[0]`
     # if the account is not opted into that asset, returns 0
-    senderAssetFrozen = AssetHolding.frozen(Txn.sender(), Txn.assets[31566704])
+    senderAssetFrozen = AssetHolding.frozen(Txn.sender(), Txn.assets[0])
     program = Seq([
         senderAssetFrozen,
         senderAssetFrozen.value()
     ])
 
-    # get the frozen status of Txn.accounts[1] for asset 27165954
+    # get the frozen status of Txn.accounts[1] for asset `Txn.assets[1]`
     # if the account is not opted into that asset, exit with an error
-    account1AssetFrozen = AssetHolding.frozen(Txn.accounts[1], Txn.assets[27165954])
+    account1AssetFrozen = AssetHolding.frozen(Txn.accounts[1], Txn.assets[1])
     program = Seq([
         account1AssetFrozen,
         Assert(account1AssetFrozen.hasValue()),
@@ -136,7 +136,7 @@ Here's an example that uses an asset parameter:
 
 .. code-block:: python
 
-    # get the total number of units for Txn.assets[0]
+    # get the total number of units for asset `Txn.assets[0]`
     # if the asset is invalid, exit with an error
     assetTotal = AssetParam.total(Txn.assets[0])
 

--- a/docs/assets.rst
+++ b/docs/assets.rst
@@ -152,6 +152,9 @@ Here's an example that uses an asset parameter:
     # get the total number of units for Txn.assets[0]
     # if the asset is invalid, exit with an error
     assetTotal = AssetParam.total(Int(0))
+    # another way to get the total number of units for Txn.assets[0]
+    assetTotalDirectRef = AssetParam.total(Txn.assets[0])
+
     program = Seq([
         assetTotal,
         Assert(assetTotal.hasValue()),

--- a/docs/assets.rst
+++ b/docs/assets.rst
@@ -15,7 +15,9 @@ For example,
 .. code-block:: python
 
     senderBalance = Balance(Int(0)) # get the balance of Txn.accounts[0] (the sender)
+    senderBalanceDirectRef = Balance(Txn.Sender()) # get the balance of the sender by passing the account address (bytes)
     account1Balance = Balance(Int(1)) # get the balance of Txn.accounts[1]
+    account1BalanceDirectRef = Balance(Txn.accounts[1]) # get the balance of Txn.accounts[1] by passing the account address (bytes)
 
 The :any:`MinBalance` expression can be used to find an account's `minimum balance <https://developer.algorand.org/docs/features/accounts/#minimum-balance>`_.
 This amount is also in microAlgos. For example,
@@ -23,7 +25,9 @@ This amount is also in microAlgos. For example,
 .. code-block:: python
 
     senderMinBalance = MinBalance(Int(0)) # get the minimum balance of Txn.accounts[0] (the sender)
+    senderMinBalanceDirectRef = MinBalance(Txn.Sender()) # get the minimum balance of the sender by passing the account address (bytes)
     account1MinBalance = MinBalance(Int(1)) # get the minimum balance of Txn.accounts[1]
+    account1MinBalance = MinBalance(Txn.accounts[1]) # get the minimum balance of Txn.accounts[1] by passing the account address (bytes)
 
 Additionally, :any:`Balance` and :any:`MinBalance` can be used together to calculate how many Algos
 an account can spend without closing. For example,
@@ -58,6 +62,8 @@ account holds. For example,
     # get the balance of Txn.accounts[0] (the sender) for asset 31566704
     # if the account is not opted into that asset, returns 0
     senderAssetBalance = AssetHolding.balance(Int(0), Int(31566704))
+    # get the balance of the sender by passing the sender's account address
+    senderAssetBalanceDirectRef = AssetHolding.balance(Txn.Sender(), Int(31566704))
     program = Seq([
         senderAssetBalance,
         senderAssetBalance.value()
@@ -66,6 +72,8 @@ account holds. For example,
     # get the balance of Txn.accounts[1] for asset 27165954
     # if the account is not opted into that asset, exit with an error
     account1AssetBalance = AssetHolding.balance(Int(1), Int(27165954))
+    # get the balance of Txn.accounts[1] by passing the account address
+    account1AssetBalanceDirectRef = AssetHolding.balance(Txn.Sender(), Int(27165954))
     program = Seq([
         account1AssetBalance,
         Assert(account1AssetBalance.hasValue()),
@@ -83,6 +91,8 @@ A value of :code:`1` indicates frozen and :code:`0` indicates not frozen. For ex
     # get the frozen status of Txn.accounts[0] (the sender) for asset 31566704
     # if the account is not opted into that asset, returns 0
     senderAssetFrozen = AssetHolding.frozen(Int(0), Int(31566704))
+    # get the frozen status of the sender by passing the sender's account address
+    senderAssetFrozenDirectRef = AssetHolding.frozen(Txn.Sender(), Int(31566704))
     program = Seq([
         senderAssetFrozen,
         senderAssetFrozen.value()
@@ -91,6 +101,8 @@ A value of :code:`1` indicates frozen and :code:`0` indicates not frozen. For ex
     # get the frozen status of Txn.accounts[1] for asset 27165954
     # if the account is not opted into that asset, exit with an error
     account1AssetFrozen = AssetHolding.frozen(Int(1), Int(27165954))
+    # get the frozen status of Txn.account[1] by passing the account address
+    account1AssetFrozenDirectRef = AssetHolding.frozen(Txn.Sender(), Int(27165954))
     program = Seq([
         account1AssetFrozen,
         Assert(account1AssetFrozen.hasValue()),
@@ -130,6 +142,7 @@ Expression                        Type                    Description
 :any:`AssetParam.reserve()`       :code:`TealType.bytes`  The address of the asset's reserve account.
 :any:`AssetParam.freeze()`        :code:`TealType.bytes`  The address of the asset's freeze account.
 :any:`AssetParam.clawback()`      :code:`TealType.bytes`  The address of the asset's clawback account.
+:any:`AssetParam.creator()`       :code:`TealType.bytes`  The address of the asset's creator account.
 ================================= ======================= ==========================================================
 
 Here's an example that uses an asset parameter:

--- a/docs/assets.rst
+++ b/docs/assets.rst
@@ -15,7 +15,7 @@ For example,
 .. code-block:: python
 
     senderBalance = Balance(Int(0)) # get the balance of Txn.accounts[0] (the sender)
-    senderBalanceDirectRef = Balance(Txn.Sender()) # get the balance of the sender by passing the account address (bytes)
+    senderBalanceDirectRef = Balance(Txn.sender()) # get the balance of the sender by passing the account address (bytes)
     account1Balance = Balance(Int(1)) # get the balance of Txn.accounts[1]
     account1BalanceDirectRef = Balance(Txn.accounts[1]) # get the balance of Txn.accounts[1] by passing the account address (bytes)
 
@@ -25,7 +25,7 @@ This amount is also in microAlgos. For example,
 .. code-block:: python
 
     senderMinBalance = MinBalance(Int(0)) # get the minimum balance of Txn.accounts[0] (the sender)
-    senderMinBalanceDirectRef = MinBalance(Txn.Sender()) # get the minimum balance of the sender by passing the account address (bytes)
+    senderMinBalanceDirectRef = MinBalance(Txn.sender()) # get the minimum balance of the sender by passing the account address (bytes)
     account1MinBalance = MinBalance(Int(1)) # get the minimum balance of Txn.accounts[1]
     account1MinBalance = MinBalance(Txn.accounts[1]) # get the minimum balance of Txn.accounts[1] by passing the account address (bytes)
 
@@ -63,7 +63,7 @@ account holds. For example,
     # if the account is not opted into that asset, returns 0
     senderAssetBalance = AssetHolding.balance(Int(0), Int(31566704))
     # get the balance of the sender by passing the sender's account address
-    senderAssetBalanceDirectRef = AssetHolding.balance(Txn.Sender(), Int(31566704))
+    senderAssetBalanceDirectRef = AssetHolding.balance(Txn.sender(), Int(31566704))
     program = Seq([
         senderAssetBalance,
         senderAssetBalance.value()
@@ -73,7 +73,7 @@ account holds. For example,
     # if the account is not opted into that asset, exit with an error
     account1AssetBalance = AssetHolding.balance(Int(1), Int(27165954))
     # get the balance of Txn.accounts[1] by passing the account address
-    account1AssetBalanceDirectRef = AssetHolding.balance(Txn.Sender(), Int(27165954))
+    account1AssetBalanceDirectRef = AssetHolding.balance(Txn.sender(), Int(27165954))
     program = Seq([
         account1AssetBalance,
         Assert(account1AssetBalance.hasValue()),
@@ -92,7 +92,7 @@ A value of :code:`1` indicates frozen and :code:`0` indicates not frozen. For ex
     # if the account is not opted into that asset, returns 0
     senderAssetFrozen = AssetHolding.frozen(Int(0), Int(31566704))
     # get the frozen status of the sender by passing the sender's account address
-    senderAssetFrozenDirectRef = AssetHolding.frozen(Txn.Sender(), Int(31566704))
+    senderAssetFrozenDirectRef = AssetHolding.frozen(Txn.sender(), Int(31566704))
     program = Seq([
         senderAssetFrozen,
         senderAssetFrozen.value()
@@ -102,7 +102,7 @@ A value of :code:`1` indicates frozen and :code:`0` indicates not frozen. For ex
     # if the account is not opted into that asset, exit with an error
     account1AssetFrozen = AssetHolding.frozen(Int(1), Int(27165954))
     # get the frozen status of Txn.account[1] by passing the account address
-    account1AssetFrozenDirectRef = AssetHolding.frozen(Txn.Sender(), Int(27165954))
+    account1AssetFrozenDirectRef = AssetHolding.frozen(Txn.sender(), Int(27165954))
     program = Seq([
         account1AssetFrozen,
         Assert(account1AssetFrozen.hasValue()),

--- a/docs/assets.rst
+++ b/docs/assets.rst
@@ -14,19 +14,15 @@ For example,
 
 .. code-block:: python
 
-    senderBalance = Balance(Int(0)) # get the balance of Txn.accounts[0] (the sender)
-    senderBalanceDirectRef = Balance(Txn.sender()) # get the balance of the sender by passing the account address (bytes)
-    account1Balance = Balance(Int(1)) # get the balance of Txn.accounts[1]
-    account1BalanceDirectRef = Balance(Txn.accounts[1]) # get the balance of Txn.accounts[1] by passing the account address (bytes)
+    senderBalance = Balance(Txn.sender()) # get the balance of the sender
+    account1Balance = Balance(Txn.accounts[1]) # get the balance of Txn.accounts[1]
 
 The :any:`MinBalance` expression can be used to find an account's `minimum balance <https://developer.algorand.org/docs/features/accounts/#minimum-balance>`_.
 This amount is also in microAlgos. For example,
 
 .. code-block:: python
 
-    senderMinBalance = MinBalance(Int(0)) # get the minimum balance of Txn.accounts[0] (the sender)
-    senderMinBalanceDirectRef = MinBalance(Txn.sender()) # get the minimum balance of the sender by passing the account address (bytes)
-    account1MinBalance = MinBalance(Int(1)) # get the minimum balance of Txn.accounts[1]
+    senderMinBalance = MinBalance(Txn.sender()) # get the minimum balance of the sender by passing the account address (bytes)
     account1MinBalance = MinBalance(Txn.accounts[1]) # get the minimum balance of Txn.accounts[1] by passing the account address (bytes)
 
 Additionally, :any:`Balance` and :any:`MinBalance` can be used together to calculate how many Algos
@@ -34,8 +30,8 @@ an account can spend without closing. For example,
 
 .. code-block:: python
 
-    senderSpendableBalance = Balance(Int(0)) - MinBalance(Int(0)) # calculate how many Algos Txn.accounts[0] (the sender) can spend
-    account1SpendableBalance = Balance(Int(1)) - MinBalance(Int(1)) # calculate how many Algos Txn.accounts[1] can spend
+    senderSpendableBalance = Balance(Txn.sender()) - MinBalance(Txn.sender()) # calculate how many Algos the sender can spend
+    account1SpendableBalance = Balance(Txn.accounts[1]) - MinBalance(Txn.accounts[1]) # calculate how many Algos Txn.accounts[1] can spend
 
 Asset Holdings
 --------------
@@ -59,11 +55,9 @@ account holds. For example,
 
 .. code-block:: python
 
-    # get the balance of Txn.accounts[0] (the sender) for asset 31566704
+    # get the balance of the sender for asset 31566704
     # if the account is not opted into that asset, returns 0
-    senderAssetBalance = AssetHolding.balance(Int(0), Int(31566704))
-    # get the balance of the sender by passing the sender's account address
-    senderAssetBalanceDirectRef = AssetHolding.balance(Txn.sender(), Int(31566704))
+    senderAssetBalance = AssetHolding.balance(Txn.sender(), Txn.assets[31566704])
     program = Seq([
         senderAssetBalance,
         senderAssetBalance.value()
@@ -71,9 +65,7 @@ account holds. For example,
 
     # get the balance of Txn.accounts[1] for asset 27165954
     # if the account is not opted into that asset, exit with an error
-    account1AssetBalance = AssetHolding.balance(Int(1), Int(27165954))
-    # get the balance of Txn.accounts[1] by passing the account address
-    account1AssetBalanceDirectRef = AssetHolding.balance(Txn.sender(), Int(27165954))
+    account1AssetBalance = AssetHolding.balance(Txn.accounts[1], Txn.assets[27165954])
     program = Seq([
         account1AssetBalance,
         Assert(account1AssetBalance.hasValue()),
@@ -88,11 +80,9 @@ A value of :code:`1` indicates frozen and :code:`0` indicates not frozen. For ex
 
 .. code-block:: python
 
-    # get the frozen status of Txn.accounts[0] (the sender) for asset 31566704
+    # get the frozen status of the sender for asset 31566704
     # if the account is not opted into that asset, returns 0
-    senderAssetFrozen = AssetHolding.frozen(Int(0), Int(31566704))
-    # get the frozen status of the sender by passing the sender's account address
-    senderAssetFrozenDirectRef = AssetHolding.frozen(Txn.sender(), Int(31566704))
+    senderAssetFrozen = AssetHolding.frozen(Txn.sender(), Txn.assets[31566704])
     program = Seq([
         senderAssetFrozen,
         senderAssetFrozen.value()
@@ -100,9 +90,7 @@ A value of :code:`1` indicates frozen and :code:`0` indicates not frozen. For ex
 
     # get the frozen status of Txn.accounts[1] for asset 27165954
     # if the account is not opted into that asset, exit with an error
-    account1AssetFrozen = AssetHolding.frozen(Int(1), Int(27165954))
-    # get the frozen status of Txn.account[1] by passing the account address
-    account1AssetFrozenDirectRef = AssetHolding.frozen(Txn.sender(), Int(27165954))
+    account1AssetFrozen = AssetHolding.frozen(Txn.accounts[1], Txn.assets[27165954])
     program = Seq([
         account1AssetFrozen,
         Assert(account1AssetFrozen.hasValue()),
@@ -142,7 +130,6 @@ Expression                        Type                    Description
 :any:`AssetParam.reserve()`       :code:`TealType.bytes`  The address of the asset's reserve account.
 :any:`AssetParam.freeze()`        :code:`TealType.bytes`  The address of the asset's freeze account.
 :any:`AssetParam.clawback()`      :code:`TealType.bytes`  The address of the asset's clawback account.
-:any:`AssetParam.creator()`       :code:`TealType.bytes`  The address of the asset's creator account.
 ================================= ======================= ==========================================================
 
 Here's an example that uses an asset parameter:
@@ -151,9 +138,7 @@ Here's an example that uses an asset parameter:
 
     # get the total number of units for Txn.assets[0]
     # if the asset is invalid, exit with an error
-    assetTotal = AssetParam.total(Int(0))
-    # another way to get the total number of units for Txn.assets[0]
-    assetTotalDirectRef = AssetParam.total(Txn.assets[0])
+    assetTotal = AssetParam.total(Txn.assets[0])
 
     program = Seq([
         assetTotal,

--- a/docs/state.rst
+++ b/docs/state.rst
@@ -186,6 +186,7 @@ argument to :any:`App.globalGetEx`, and pass the key to read as the second argum
     # get "status" from the global context of Txn.applications[0] (the current app)
     # if "status" has not been set, returns "none"
     myStatus = App.globalGetEx(Int(0), Bytes("status"))
+
     program = Seq([
         myStatus,
         If(myStatus.hasValue(), myStatus.value(), Bytes("none"))
@@ -230,6 +231,7 @@ For example:
     # get "role" from the local state of Txn.accounts[0] (the sender) for the current app
     # if "role" has not been set, returns "none"
     myAppSenderRole = App.localGetEx(Int(0), Int(0), Bytes("role"))
+    myAppSenderRoleDirectRef = App.localGetEx(Txn.sender(), Int(0), Bytes("role"))
     program = Seq([
         myAppSenderRole,
         If(myAppSenderRole.hasValue(), myAppSenderRole.value(), Bytes("none"))
@@ -238,6 +240,7 @@ For example:
     # get "role" from the local state of Txn.accounts[1] for the current app
     # if "role" has not been set, returns "none"
     myAppOtherAccountRole = App.localGetEx(Int(1), Int(0), Bytes("role"))
+    myAppOtherAccountRoleDirectRef = App.localGetEx(Txn.sender(), Int(0), Bytes("role"))
     program = Seq([
         myAppOtherAccountRole,
         If(myAppOtherAccountRole.hasValue(), myAppOtherAccountRole.value(), Bytes("none"))
@@ -246,6 +249,7 @@ For example:
     # get "role" from the local state of Txn.accounts[0] (the sender) for the app with ID 31
     # if "role" has not been set, returns "none"
     otherAppSenderRole = App.localGetEx(Int(0), Int(31), Bytes("role"))
+    otherAppSenderRoleDirectRef = App.localGetEx(Txn.sender(), Int(31), Bytes("role"))
     program = Seq([
         otherAppSenderRole,
         If(otherAppSenderRole.hasValue(), otherAppSenderRole.value(), Bytes("none"))
@@ -254,6 +258,7 @@ For example:
     # get "role" from the local state of Txn.accounts[1] for the app with ID 31
     # if "role" has not been set, returns "none"
     otherAppOtherAccountRole = App.localGetEx(Int(1), Int(31), Bytes("role"))
+    otherAppOtherAccountRoleDirectRef = App.localGetEx(Txn.sender(), Int(31), Bytes("role"))
     program = Seq([
         otherAppOtherAccountRole,
         If(otherAppOtherAccountRole.hasValue(), otherAppOtherAccountRole.value(), Bytes("none"))

--- a/docs/state.rst
+++ b/docs/state.rst
@@ -72,10 +72,8 @@ Local State
 Local state consists of key-value pairs that are stored in a unique context for each account that
 has opted into your application. As a result, you will need to specify an account when manipulating
 local state. This is done by passing in an integer that corresponds to the index of the account in
-the :any:`Txn.accounts <TxnObject.accounts>` array.
-
-In order to read or manipulate an account's local state, that account must be present in the
-application call transaction's :code:`Txn.accounts` array.
+the :any:`Txn.accounts <TxnObject.accounts>` array (or since TEAL version 4, by passing in a byte
+string that appears in :code:`Txn.accounts` array).
 
 **Note:** The :code:`Txn.accounts` array does not behave like a normal array. It's actually a
 :code:`1`-indexed array with a special value at index :code:`0`, the sender's account.
@@ -85,16 +83,13 @@ Writing Local State
 ~~~~~~~~~~~~~~~~~~~
 
 To write to the local state of an account, use the :any:`App.localPut` function. The first argument
-is an integers corresponding to the account to write to, the second argument is the key to write to,
-and the third argument is the value to write. For example:
+is an integers or a byte string corresponding to the account to write to, the second argument is the
+key to write to, and the third argument is the value to write. For example:
 
 .. code-block:: python
 
-    App.localPut(Int(0), Bytes("role"), Bytes("admin")) # write a byte slice to Txn.accounts[0], the sender's account
     App.localPut(Txn.sender(), Bytes("role"), Bytes("admin")) # write a byte slice to the sender's account
-    App.localPut(Int(0), Bytes("balance"), Int(10)) # write a uint64 to Txn.accounts[0], the sender's account
     App.localPut(Txn.sender(), Bytes("balance"), Int(10)) # write a uint64 to the sender's account
-    App.localPut(Int(1), Bytes("balance"), Int(10)) # write a uint64 to Txn.accounts[1]
     App.localPut(Txn.account[1], Bytes("balance"), Int(10)) # write a uint64 to Txn.account[1]
 
 **Note:** It is only possible to write to the local state of an account if that account has opted
@@ -105,16 +100,13 @@ Reading Local State
 ~~~~~~~~~~~~~~~~~~~
 
 To read from the local state of an account, use the :any:`App.localGet` function. The first argument
-is an integer corresponding to the account to read from and the second argument is the key to read.
-For example:
+is an integer or a byte string corresponding to the account to read from and the second argument is
+the key to read. For example:
 
 .. code-block:: python
 
-    App.localGet(Int(0), Bytes("role")) # read from Txn.accounts[0], the sender's account
     App.localGet(Txn.sender(), Byte("role")) # read from the sender's account
-    App.localGet(Int(0), Bytes("balance")) # read from Txn.accounts[0], the sender's account
     App.localGet(Txn.sender(), Bytes("balance")) # read from the sender's account
-    App.localGet(Int(1), Bytes("balance")) # read from Txn.accounts[1]
     App.localGet(Txn.accounts[1], Bytes("balance")) # read from Txn.accounts[1]
 
 If you try to read from a key that does not exist in your app's global state, the integer :code:`0`
@@ -124,16 +116,13 @@ Deleting Local State
 ~~~~~~~~~~~~~~~~~~~~
 
 To delete a key from local state of an account, use the :any:`App.localDel` function. The first
-argument is an integer corresponding to the account and the second argument is the key to delete.
-For example:
+argument is an integer or a byte string corresponding to the account and the second argument is the
+key to delete. For example:
 
 .. code-block:: python
 
-    App.localDel(Int(0), Bytes("role")) # delete "role" from Txn.accounts[0], the sender's account
     App.localDel(Txn.sender(), Bytes("role")) # delete "role" from the sender's account
-    App.localDel(Int(0), Bytes("balance")) # delete "balance" from Txn.accounts[0], the sender's account
     App.localDel(Txn.sender(), Bytes("balance")) # delete "balance" from the sender's account
-    App.localDel(Int(1), Bytes("balance")) # delete "balance" from Txn.accounts[1]
     App.localDel(Txn.accounts[1], Bytes("balance")) # delete "balance" from Txn.accounts[1]
 
 If you try to delete a key that does not exist in the account's local state, nothing happens.
@@ -169,23 +158,22 @@ function.
 
 In order to use this function you need to pass in an integer that represents an application to
 read from. This integer corresponds to the index of an application in the
-:any:`Txn.applications <TxnObject.applications>` array.
-
-This means that in order to read or manipulate an external application's local state, that application
-must be present in the application call transaction's :code:`Txn.applications` array.
+:any:`Txn.applications <TxnObject.applications>` array, or since TEAL version 4, an byte string
+that represents an app id that appearing in :code:`Txn.applications` array.
 
 **Note:** The :code:`Txn.applications` array does not behave like a normal array. It's actually a
 :code:`1`-indexed array with a special value at index :code:`0`, the current application's ID.
 See :ref:`txn_special_case_arrays` for more details.
 
-Now that you have an integer that represents an application to read from, pass this as the first
-argument to :any:`App.globalGetEx`, and pass the key to read as the second argument. For example:
+Now that you have an integer or a byte string that represents an application to read from, pass
+this as the first argument to :any:`App.globalGetEx`, and pass the key to read as the second
+argument. For example:
 
 .. code-block:: python
 
     # get "status" from the global context of Txn.applications[0] (the current app)
     # if "status" has not been set, returns "none"
-    myStatus = App.globalGetEx(Int(0), Bytes("status"))
+    myStatus = App.globalGetEx(Txn.application[0], Bytes("status"))
 
     program = Seq([
         myStatus,
@@ -194,7 +182,7 @@ argument to :any:`App.globalGetEx`, and pass the key to read as the second argum
 
     # get "status" from the global context of Txn.applications[1]
     # if "status" has not been set, returns "none"
-    otherStatus = App.globalGetEx(Int(1), Bytes("status"))
+    otherStatus = App.globalGetEx(Txn.application[1], Bytes("status"))
     program = Seq([
         otherStatus,
         If(otherStatus.hasValue(), otherStatus.value(), Bytes("none"))
@@ -202,7 +190,7 @@ argument to :any:`App.globalGetEx`, and pass the key to read as the second argum
 
     # get "total supply" from the global context of Txn.applications[1]
     # if "total supply" has not been set, returns the default value of 0
-    otherSupply = App.globalGetEx(Int(1), Bytes("total supply"))
+    otherSupply = App.globalGetEx(Txn.application[1], Bytes("total supply"))
     program = Seq([
         otherSupply,
         otherSupply.value()
@@ -214,9 +202,9 @@ External Local
 To read a value from an account's local state for another application, use the :any:`App.localGetEx`
 function.
 
-The first argument is an integer corresponding to the account to read from (in the same
-format as :any:`App.localGet`), the second argument is the ID of the application to read from, and
-the third argument is the key to read.
+The first argument is an integer or a byte string corresponding to the account to read from (in the
+same format as :any:`App.localGet`), the second argument is the ID of the application to read from,
+and the third argument is the key to read.
 
 **Note:** The second argument is the actual ID of the application to read from, not an index into
 :code:`Txn.applications`. This means that you can read from any application that the account has opted
@@ -230,8 +218,7 @@ For example:
 
     # get "role" from the local state of Txn.accounts[0] (the sender) for the current app
     # if "role" has not been set, returns "none"
-    myAppSenderRole = App.localGetEx(Int(0), Int(0), Bytes("role"))
-    myAppSenderRoleDirectRef = App.localGetEx(Txn.sender(), Int(0), Bytes("role"))
+    myAppSenderRole = App.localGetEx(Txn.sender(), Int(0), Bytes("role"))
     program = Seq([
         myAppSenderRole,
         If(myAppSenderRole.hasValue(), myAppSenderRole.value(), Bytes("none"))
@@ -239,8 +226,7 @@ For example:
 
     # get "role" from the local state of Txn.accounts[1] for the current app
     # if "role" has not been set, returns "none"
-    myAppOtherAccountRole = App.localGetEx(Int(1), Int(0), Bytes("role"))
-    myAppOtherAccountRoleDirectRef = App.localGetEx(Txn.sender(), Int(0), Bytes("role"))
+    myAppOtherAccountRole = App.localGetEx(Txn.sender(), Int(0), Bytes("role"))
     program = Seq([
         myAppOtherAccountRole,
         If(myAppOtherAccountRole.hasValue(), myAppOtherAccountRole.value(), Bytes("none"))
@@ -248,8 +234,7 @@ For example:
 
     # get "role" from the local state of Txn.accounts[0] (the sender) for the app with ID 31
     # if "role" has not been set, returns "none"
-    otherAppSenderRole = App.localGetEx(Int(0), Int(31), Bytes("role"))
-    otherAppSenderRoleDirectRef = App.localGetEx(Txn.sender(), Int(31), Bytes("role"))
+    otherAppSenderRole = App.localGetEx(Txn.sender(), Int(31), Bytes("role"))
     program = Seq([
         otherAppSenderRole,
         If(otherAppSenderRole.hasValue(), otherAppSenderRole.value(), Bytes("none"))
@@ -257,8 +242,7 @@ For example:
 
     # get "role" from the local state of Txn.accounts[1] for the app with ID 31
     # if "role" has not been set, returns "none"
-    otherAppOtherAccountRole = App.localGetEx(Int(1), Int(31), Bytes("role"))
-    otherAppOtherAccountRoleDirectRef = App.localGetEx(Txn.sender(), Int(31), Bytes("role"))
+    otherAppOtherAccountRole = App.localGetEx(Txn.sender(), Int(31), Bytes("role"))
     program = Seq([
         otherAppOtherAccountRole,
         If(otherAppOtherAccountRole.hasValue(), otherAppOtherAccountRole.value(), Bytes("none"))

--- a/docs/state.rst
+++ b/docs/state.rst
@@ -90,7 +90,7 @@ third argument is the value to write. For example:
 
     App.localPut(Txn.sender(), Bytes("role"), Bytes("admin")) # write a byte slice to the sender's account
     App.localPut(Txn.sender(), Bytes("balance"), Int(10)) # write a uint64 to the sender's account
-    App.localPut(Txn.account[1], Bytes("balance"), Int(10)) # write a uint64 to Txn.account[1]
+    App.localPut(Txn.accounts[1], Bytes("balance"), Int(10)) # write a uint64 to Txn.account[1]
 
 **Note:** It is only possible to write to the local state of an account if that account has opted
 into your application. If the account has not opted in, the program will fail with an error. The
@@ -104,7 +104,7 @@ is the address of the account to read from, and the second argument is the key t
 
 .. code-block:: python
 
-    App.localGet(Txn.sender(), Byte("role")) # read from the sender's account
+    App.localGet(Txn.sender(), Bytes("role")) # read from the sender's account
     App.localGet(Txn.sender(), Bytes("balance")) # read from the sender's account
     App.localGet(Txn.accounts[1], Bytes("balance")) # read from Txn.accounts[1]
 
@@ -163,15 +163,14 @@ read from. This integer corresponds to an actual application ID that appears in 
 :code:`1`-indexed array with a special value at index :code:`0`, the current application's ID.
 See :ref:`txn_special_case_arrays` for more details.
 
-Now that you have an integer or a byte string that represents an application to read from, pass
-this as the first argument to :any:`App.globalGetEx`, and pass the key to read as the second
-argument. For example:
+Now that you have an integer that represents an application to read from, pass this as the first
+argument to :any:`App.globalGetEx`, and pass the key to read as the second argument. For example:
 
 .. code-block:: python
 
     # get "status" from the global context of Txn.applications[0] (the current app)
     # if "status" has not been set, returns "none"
-    myStatus = App.globalGetEx(Txn.application[0], Bytes("status"))
+    myStatus = App.globalGetEx(Txn.applications[0], Bytes("status"))
 
     program = Seq([
         myStatus,
@@ -180,7 +179,7 @@ argument. For example:
 
     # get "status" from the global context of Txn.applications[1]
     # if "status" has not been set, returns "none"
-    otherStatus = App.globalGetEx(Txn.application[1], Bytes("status"))
+    otherStatus = App.globalGetEx(Txn.applications[1], Bytes("status"))
     program = Seq([
         otherStatus,
         If(otherStatus.hasValue(), otherStatus.value(), Bytes("none"))
@@ -188,7 +187,7 @@ argument. For example:
 
     # get "total supply" from the global context of Txn.applications[1]
     # if "total supply" has not been set, returns the default value of 0
-    otherSupply = App.globalGetEx(Txn.application[1], Bytes("total supply"))
+    otherSupply = App.globalGetEx(Txn.applications[1], Bytes("total supply"))
     program = Seq([
         otherSupply,
         otherSupply.value()
@@ -216,7 +215,7 @@ For example:
 
     # get "role" from the local state of Txn.accounts[0] (the sender) for the current app
     # if "role" has not been set, returns "none"
-    myAppSenderRole = App.localGetEx(Txn.sender(), Int(0), Bytes("role"))
+    myAppSenderRole = App.localGetEx(Txn.accounts[0], Int(0), Bytes("role"))
     program = Seq([
         myAppSenderRole,
         If(myAppSenderRole.hasValue(), myAppSenderRole.value(), Bytes("none"))
@@ -224,7 +223,7 @@ For example:
 
     # get "role" from the local state of Txn.accounts[1] for the current app
     # if "role" has not been set, returns "none"
-    myAppOtherAccountRole = App.localGetEx(Txn.sender(), Int(0), Bytes("role"))
+    myAppOtherAccountRole = App.localGetEx(Txn.accounts[1], Int(0), Bytes("role"))
     program = Seq([
         myAppOtherAccountRole,
         If(myAppOtherAccountRole.hasValue(), myAppOtherAccountRole.value(), Bytes("none"))
@@ -232,7 +231,7 @@ For example:
 
     # get "role" from the local state of Txn.accounts[0] (the sender) for the app with ID 31
     # if "role" has not been set, returns "none"
-    otherAppSenderRole = App.localGetEx(Txn.sender(), Int(31), Bytes("role"))
+    otherAppSenderRole = App.localGetEx(Txn.accounts[0], Int(31), Bytes("role"))
     program = Seq([
         otherAppSenderRole,
         If(otherAppSenderRole.hasValue(), otherAppSenderRole.value(), Bytes("none"))
@@ -240,7 +239,7 @@ For example:
 
     # get "role" from the local state of Txn.accounts[1] for the app with ID 31
     # if "role" has not been set, returns "none"
-    otherAppOtherAccountRole = App.localGetEx(Txn.sender(), Int(31), Bytes("role"))
+    otherAppOtherAccountRole = App.localGetEx(Txn.accounts[1], Int(31), Bytes("role"))
     program = Seq([
         otherAppOtherAccountRole,
         If(otherAppOtherAccountRole.hasValue(), otherAppOtherAccountRole.value(), Bytes("none"))

--- a/docs/state.rst
+++ b/docs/state.rst
@@ -91,8 +91,11 @@ and the third argument is the value to write. For example:
 .. code-block:: python
 
     App.localPut(Int(0), Bytes("role"), Bytes("admin")) # write a byte slice to Txn.accounts[0], the sender's account
+    App.localPut(Txn.Sender(), Bytes("role"), Bytes("admin")) # write a byte slice to the sender's account
     App.localPut(Int(0), Bytes("balance"), Int(10)) # write a uint64 to Txn.accounts[0], the sender's account
+    App.localPut(Txn.Sender(), Bytes("balance"), Int(10)) # write a uint64 to the sender's account
     App.localPut(Int(1), Bytes("balance"), Int(10)) # write a uint64 to Txn.accounts[1]
+    App.localPut(Txn.account[1], Bytes("balance"), Int(10)) # write a uint64 to Txn.account[1]
 
 **Note:** It is only possible to write to the local state of an account if that account has opted
 into your application. If the account has not opted in, the program will fail with an error. The
@@ -108,8 +111,11 @@ For example:
 .. code-block:: python
 
     App.localGet(Int(0), Bytes("role")) # read from Txn.accounts[0], the sender's account
-    App.localGet(Int(0), Bytes("balance")) # read from Txn.accounts[0], the the sender's account
+    App.localGet(Txn.Sender(), Byte("role")) # read from the sender's account
+    App.localGet(Int(0), Bytes("balance")) # read from Txn.accounts[0], the sender's account
+    App.localGet(Txn.Sender(), Bytes("balance")) # read from the sender's account
     App.localGet(Int(1), Bytes("balance")) # read from Txn.accounts[1]
+    App.localGet(Txn.accounts[1], Bytes("balance")) # read from Txn.accounts[1]
 
 If you try to read from a key that does not exist in your app's global state, the integer :code:`0`
 is returned.
@@ -124,8 +130,11 @@ For example:
 .. code-block:: python
 
     App.localDel(Int(0), Bytes("role")) # delete "role" from Txn.accounts[0], the sender's account
-    App.localDel(Int(0), Bytes("balance")) # delete "balance" from Txn.accounts[0], the the sender's account
+    App.localDel(Txn.Sender(), Bytes("role")) # delete "role" from the sender's account
+    App.localDel(Int(0), Bytes("balance")) # delete "balance" from Txn.accounts[0], the sender's account
+    App.localDel(Txn.Sender(), Bytes("balance")) # delete "balance" from the sender's account
     App.localDel(Int(1), Bytes("balance")) # delete "balance" from Txn.accounts[1]
+    App.localDel(Txn.accounts[1], Bytes("balance")) # delete "balance" from Txn.accounts[1]
 
 If you try to delete a key that does not exist in the account's local state, nothing happens.
 

--- a/docs/state.rst
+++ b/docs/state.rst
@@ -91,9 +91,9 @@ and the third argument is the value to write. For example:
 .. code-block:: python
 
     App.localPut(Int(0), Bytes("role"), Bytes("admin")) # write a byte slice to Txn.accounts[0], the sender's account
-    App.localPut(Txn.Sender(), Bytes("role"), Bytes("admin")) # write a byte slice to the sender's account
+    App.localPut(Txn.sender(), Bytes("role"), Bytes("admin")) # write a byte slice to the sender's account
     App.localPut(Int(0), Bytes("balance"), Int(10)) # write a uint64 to Txn.accounts[0], the sender's account
-    App.localPut(Txn.Sender(), Bytes("balance"), Int(10)) # write a uint64 to the sender's account
+    App.localPut(Txn.sender(), Bytes("balance"), Int(10)) # write a uint64 to the sender's account
     App.localPut(Int(1), Bytes("balance"), Int(10)) # write a uint64 to Txn.accounts[1]
     App.localPut(Txn.account[1], Bytes("balance"), Int(10)) # write a uint64 to Txn.account[1]
 
@@ -111,9 +111,9 @@ For example:
 .. code-block:: python
 
     App.localGet(Int(0), Bytes("role")) # read from Txn.accounts[0], the sender's account
-    App.localGet(Txn.Sender(), Byte("role")) # read from the sender's account
+    App.localGet(Txn.sender(), Byte("role")) # read from the sender's account
     App.localGet(Int(0), Bytes("balance")) # read from Txn.accounts[0], the sender's account
-    App.localGet(Txn.Sender(), Bytes("balance")) # read from the sender's account
+    App.localGet(Txn.sender(), Bytes("balance")) # read from the sender's account
     App.localGet(Int(1), Bytes("balance")) # read from Txn.accounts[1]
     App.localGet(Txn.accounts[1], Bytes("balance")) # read from Txn.accounts[1]
 
@@ -130,9 +130,9 @@ For example:
 .. code-block:: python
 
     App.localDel(Int(0), Bytes("role")) # delete "role" from Txn.accounts[0], the sender's account
-    App.localDel(Txn.Sender(), Bytes("role")) # delete "role" from the sender's account
+    App.localDel(Txn.sender(), Bytes("role")) # delete "role" from the sender's account
     App.localDel(Int(0), Bytes("balance")) # delete "balance" from Txn.accounts[0], the sender's account
-    App.localDel(Txn.Sender(), Bytes("balance")) # delete "balance" from the sender's account
+    App.localDel(Txn.sender(), Bytes("balance")) # delete "balance" from the sender's account
     App.localDel(Int(1), Bytes("balance")) # delete "balance" from Txn.accounts[1]
     App.localDel(Txn.accounts[1], Bytes("balance")) # delete "balance" from Txn.accounts[1]
 

--- a/docs/state.rst
+++ b/docs/state.rst
@@ -71,9 +71,9 @@ Local State
 
 Local state consists of key-value pairs that are stored in a unique context for each account that
 has opted into your application. As a result, you will need to specify an account when manipulating
-local state. This is done by passing in an integer that corresponds to the index of the account in
-the :any:`Txn.accounts <TxnObject.accounts>` array (or since TEAL version 4, by passing in a byte
-string that appears in :code:`Txn.accounts` array).
+local state. This is done by passing in the address of an account. In order to read or manipulate
+an account's local state, that account must be presented in the
+:any:`Txn.accounts <TxnObject.accounts>` array.
 
 **Note:** The :code:`Txn.accounts` array does not behave like a normal array. It's actually a
 :code:`1`-indexed array with a special value at index :code:`0`, the sender's account.
@@ -83,8 +83,8 @@ Writing Local State
 ~~~~~~~~~~~~~~~~~~~
 
 To write to the local state of an account, use the :any:`App.localPut` function. The first argument
-is an integers or a byte string corresponding to the account to write to, the second argument is the
-key to write to, and the third argument is the value to write. For example:
+is the address of the account to write to, the second argument is the key to write to, and the
+third argument is the value to write. For example:
 
 .. code-block:: python
 
@@ -100,8 +100,7 @@ Reading Local State
 ~~~~~~~~~~~~~~~~~~~
 
 To read from the local state of an account, use the :any:`App.localGet` function. The first argument
-is an integer or a byte string corresponding to the account to read from and the second argument is
-the key to read. For example:
+is the address of the account to read from, and the second argument is the key to read. For example:
 
 .. code-block:: python
 
@@ -116,8 +115,8 @@ Deleting Local State
 ~~~~~~~~~~~~~~~~~~~~
 
 To delete a key from local state of an account, use the :any:`App.localDel` function. The first
-argument is an integer or a byte string corresponding to the account and the second argument is the
-key to delete. For example:
+argument is the address of the corresponding account, and the second argument is the key to delete.
+For example:
 
 .. code-block:: python
 
@@ -157,9 +156,8 @@ To read a value from the global state of another application, use the :any:`App.
 function.
 
 In order to use this function you need to pass in an integer that represents an application to
-read from. This integer corresponds to the index of an application in the
-:any:`Txn.applications <TxnObject.applications>` array, or since TEAL version 4, an byte string
-that represents an app id that appearing in :code:`Txn.applications` array.
+read from. This integer corresponds to an actual application ID that appears in the
+:any:`Txn.applications <TxnObject.applications>` array.
 
 **Note:** The :code:`Txn.applications` array does not behave like a normal array. It's actually a
 :code:`1`-indexed array with a special value at index :code:`0`, the current application's ID.
@@ -202,9 +200,9 @@ External Local
 To read a value from an account's local state for another application, use the :any:`App.localGetEx`
 function.
 
-The first argument is an integer or a byte string corresponding to the account to read from (in the
-same format as :any:`App.localGet`), the second argument is the ID of the application to read from,
-and the third argument is the key to read.
+The first argument is the address of the account to read from (in the same format as
+:any:`App.localGet`), the second argument is the ID of the application to read from, and the third
+argument is the key to read.
 
 **Note:** The second argument is the actual ID of the application to read from, not an index into
 :code:`Txn.applications`. This means that you can read from any application that the account has opted

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -144,7 +144,7 @@ class App(LeafExpr):
                 Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to bytes).
             key: The key to read from the global application state. Must evaluate to bytes.
         """
-        require_type(app.type_of(), TealType.anytype)
+        require_type(app.type_of(), TealType.uint64)
         require_type(key.type_of(), TealType.bytes)
         return MaybeValue(AppField.globalGetEx.get_op(), TealType.anytype, args=[app, key])
 

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -38,10 +38,10 @@ class AppField(Enum):
     def __init__(self, op: Op, type: TealType) -> None:
         self.op = op
         self.ret_type = type
-    
+
     def get_op(self) -> Op:
         return self.op
-    
+
     def type_of(self) -> TealType:
         return self.ret_type
 
@@ -50,7 +50,7 @@ AppField.__module__ = "pyteal"
 class App(LeafExpr):
     """An expression related to applications."""
 
-    def __init__(self, field:AppField, args) -> None:
+    def __init__(self, field: AppField, args) -> None:
         super().__init__()
         self.field = field
         self.args = args
@@ -71,7 +71,7 @@ class App(LeafExpr):
     @classmethod
     def id(cls) -> Global:
         """Get the ID of the current running application.
-        
+
         This is the same as :any:`Global.current_application_id()`.
         """
         return Global.current_application_id()
@@ -85,10 +85,10 @@ class App(LeafExpr):
                 evaluate to uint64.
             app: The ID of the application being checked. Must evaluate to uint64.
         """
-        require_type(account.type_of(), TealType.uint64)
+        require_type(account.type_of(), TealType.anytype)
         require_type(app.type_of(), TealType.uint64)
         return cls(AppField.optedIn, [account, app])
-    
+
     @classmethod
     def localGet(cls, account: Expr, key: Expr) -> 'App':
         """Read from an account's local state for the current application.
@@ -98,10 +98,10 @@ class App(LeafExpr):
                 evaluate to uint64.
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
-        require_type(account.type_of(), TealType.uint64)
+        require_type(account.type_of(), TealType.anytype)
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.localGet, [account, key])
-    
+
     @classmethod
     def localGetEx(cls, account: Expr, app: Expr, key: Expr) -> MaybeValue:
         """Read from an account's local state for an application.
@@ -112,7 +112,7 @@ class App(LeafExpr):
             app: The ID of the application being checked. Must evaluate to uint64.
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
-        require_type(account.type_of(), TealType.uint64)
+        require_type(account.type_of(), TealType.anytype)
         require_type(app.type_of(), TealType.uint64)
         require_type(key.type_of(), TealType.bytes)
         return MaybeValue(AppField.localGetEx.get_op(), TealType.anytype, args=[account, app, key])
@@ -126,7 +126,7 @@ class App(LeafExpr):
         """
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.globalGet, [key])
-    
+
     @classmethod
     def globalGetEx(cls, app: Expr, key: Expr) -> MaybeValue:
         """Read from the global state of an application.
@@ -150,11 +150,11 @@ class App(LeafExpr):
             key: The key to write in the account's local state. Must evaluate to bytes.
             value: The value to write in the account's local state. Can evaluate to any type.
         """
-        require_type(account.type_of(), TealType.uint64)
+        require_type(account.type_of(), TealType.anytype)
         require_type(key.type_of(), TealType.bytes)
         require_type(value.type_of(), TealType.anytype)
         return cls(AppField.localPut, [account, key, value])
-    
+
     @classmethod
     def globalPut(cls, key: Expr, value: Expr) -> 'App':
         """Write to the global state of the current application.
@@ -176,10 +176,10 @@ class App(LeafExpr):
                 should be deleted. Must evaluate to uint64.
             key: The key to delete from the account's local state. Must evaluate to bytes.
         """
-        require_type(account.type_of(), TealType.uint64)
+        require_type(account.type_of(), TealType.anytype)
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.localDel, [account, key])
-    
+
     @classmethod
     def globalDel(cls, key: Expr) -> 'App':
         """Delete a key from the global state of the current application.

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -135,11 +135,12 @@ class App(LeafExpr):
         """Read from the global state of an application.
 
         Args:
-            app: An index into Txn.ForeignApps that corresponds to the application to read from.
-                Must evaluate to uint64.
+            app: An index into Txn.ForeignApps that corresponds to the application to read from,
+                must be evaluated to uint64 (or, since v4, an application id that appears in
+                Txn.ForeignApps or is the CurrentApplicationID).
             key: The key to read from the global application state. Must evaluate to bytes.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app.type_of(), TealType.anytype)
         require_type(key.type_of(), TealType.bytes)
         return MaybeValue(AppField.globalGetEx.get_op(), TealType.anytype, args=[app, key])
 

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -83,8 +83,10 @@ class App(LeafExpr):
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check,
                 must be evaluated to uint64 (or, since v4, an account address that appears in
-                Txn.Accounts or is Txn.Sender).
-            app: The ID of the application being checked. Must evaluate to uint64.
+                Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
+            app: An index into Txn.ForeignApps that corresponds to the application to read from,
+                must be evaluated to uint64 (or, since v4, an application id that appears in
+                Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to bytes).
         """
         require_type(account.type_of(), TealType.anytype)
         require_type(app.type_of(), TealType.uint64)
@@ -97,7 +99,7 @@ class App(LeafExpr):
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check,
                 must be evaluated to uint64 (or, since v4, an account address that appears in
-                Txn.Accounts or is Txn.Sender).
+                Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
         require_type(account.type_of(), TealType.anytype)
@@ -111,8 +113,10 @@ class App(LeafExpr):
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check,
                 must be evaluated to uint64 (or, since v4, an account address that appears in
-                Txn.Accounts or is Txn.Sender).
-            app: The ID of the application being checked. Must evaluate to uint64.
+                Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
+            app: An index into Txn.ForeignApps that corresponds to the application to read from,
+                must be evaluated to uint64 (or, since v4, an application id that appears in
+                Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to bytes).
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
         require_type(account.type_of(), TealType.anytype)
@@ -137,7 +141,7 @@ class App(LeafExpr):
         Args:
             app: An index into Txn.ForeignApps that corresponds to the application to read from,
                 must be evaluated to uint64 (or, since v4, an application id that appears in
-                Txn.ForeignApps or is the CurrentApplicationID).
+                Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to bytes).
             key: The key to read from the global application state. Must evaluate to bytes.
         """
         require_type(app.type_of(), TealType.anytype)
@@ -151,7 +155,7 @@ class App(LeafExpr):
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check,
                 must be evaluated to uint64 (or, since v4, an account address that appears in
-                Txn.Accounts or is Txn.Sender).
+                Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
             key: The key to write in the account's local state. Must evaluate to bytes.
             value: The value to write in the account's local state. Can evaluate to any type.
         """
@@ -179,7 +183,7 @@ class App(LeafExpr):
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check,
                 must be evaluated to uint64 (or, since v4, an account address that appears in
-                Txn.Accounts or is Txn.Sender).
+                Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
             key: The key to delete from the account's local state. Must evaluate to bytes.
         """
         require_type(account.type_of(), TealType.anytype)

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -81,8 +81,9 @@ class App(LeafExpr):
         """Check if an account has opted in for an application.
 
         Args:
-            account: An index into Txn.Accounts that corresponds to the account to check. Must
-                evaluate to uint64.
+            account: An index into Txn.Accounts that corresponds to the account to check,
+                must be evaluated to uint64 (or, since v4, an account address that appears in
+                Txn.Accounts or is Txn.Sender).
             app: The ID of the application being checked. Must evaluate to uint64.
         """
         require_type(account.type_of(), TealType.anytype)
@@ -94,8 +95,9 @@ class App(LeafExpr):
         """Read from an account's local state for the current application.
 
         Args:
-            account: An index into Txn.Accounts that corresponds to the account to read from. Must
-                evaluate to uint64.
+            account: An index into Txn.Accounts that corresponds to the account to check,
+                must be evaluated to uint64 (or, since v4, an account address that appears in
+                Txn.Accounts or is Txn.Sender).
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
         require_type(account.type_of(), TealType.anytype)
@@ -107,8 +109,9 @@ class App(LeafExpr):
         """Read from an account's local state for an application.
 
         Args:
-            account: An index into Txn.Accounts that corresponds to the account to read from. Must
-                evaluate to uint64.
+            account: An index into Txn.Accounts that corresponds to the account to check,
+                must be evaluated to uint64 (or, since v4, an account address that appears in
+                Txn.Accounts or is Txn.Sender).
             app: The ID of the application being checked. Must evaluate to uint64.
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
@@ -145,8 +148,9 @@ class App(LeafExpr):
         """Write to an account's local state for the current application.
 
         Args:
-            account: An index into Txn.Accounts that corresponds to the account to write to. Must
-                evaluate to uint64.
+            account: An index into Txn.Accounts that corresponds to the account to check,
+                must be evaluated to uint64 (or, since v4, an account address that appears in
+                Txn.Accounts or is Txn.Sender).
             key: The key to write in the account's local state. Must evaluate to bytes.
             value: The value to write in the account's local state. Can evaluate to any type.
         """
@@ -172,8 +176,9 @@ class App(LeafExpr):
         """Delete a key from an account's local state for the current application.
 
         Args:
-            account: An index into Txn.Accounts that corresponds to the account from which the key
-                should be deleted. Must evaluate to uint64.
+            account: An index into Txn.Accounts that corresponds to the account to check,
+                must be evaluated to uint64 (or, since v4, an account address that appears in
+                Txn.Accounts or is Txn.Sender).
             key: The key to delete from the account's local state. Must evaluate to bytes.
         """
         require_type(account.type_of(), TealType.anytype)

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -41,40 +41,81 @@ def test_opted_in():
     args = [Int(1), Int(12)]
     expr = App.optedIn(args[0], args[1])
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 1),
         TealOp(args[1], Op.int, 12),
         TealOp(expr, Op.app_opted_in)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
+
+def test_opted_in_direct_ref():
+    args = [Bytes("sender address"), Int(100)]
+    expr = App.optedIn(args[0], args[1])
+    assert expr.type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.byte, "\"sender address\""),
+        TealOp(args[1], Op.int, 100),
+        TealOp(expr, Op.app_opted_in)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    assert actual == expected
+
+def test_opted_in_invalid():
+    with pytest.raises(TealTypeError):
+        App.optedIn(Bytes("sender"), Bytes("100"))
+
+    with pytest.raises(TealTypeError):
+        App.optedIn(Int(123456), Bytes("364"))
 
 def test_local_get():
     args = [Int(0), Bytes("key")]
     expr = App.localGet(args[0], args[1])
     assert expr.type_of() == TealType.anytype
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.byte, "\"key\""),
         TealOp(expr, Op.app_local_get)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
+    assert actual == expected
+
+def test_local_get_direct_ref():
+    args = [Txn.sender(), Bytes("key")]
+    expr = App.localGet(args[0], args[1])
+    assert expr.type_of() == TealType.anytype
+
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.txn, "Sender"),
+        TealOp(args[1], Op.byte, "\"key\""),
+        TealOp(expr, Op.app_local_get)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
     assert actual == expected
 
 def test_local_get_invalid():
     with pytest.raises(TealTypeError):
-        App.localGet(Txn.sender(), Bytes("key"))
-    
+        App.localGet(Txn.sender(), Int(1337))
+
     with pytest.raises(TealTypeError):
         App.localGet(Int(0), Int(1))
 
@@ -83,7 +124,7 @@ def test_local_get_ex():
     expr = App.localGetEx(args[0], args[1], args[2])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.anytype
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.int, 6),
@@ -92,38 +133,60 @@ def test_local_get_ex():
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+def test_local_get_ex_direct_ref():
+    args = [Txn.sender(), Int(6), Bytes("key")]
+    expr = App.localGetEx(args[0], args[1], args[2])
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.anytype
+
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.txn, "Sender"),
+        TealOp(args[1], Op.int, 6),
+        TealOp(args[2], Op.byte, "\"key\""),
+        TealOp(expr, Op.app_local_get_ex),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 def test_local_get_ex_invalid():
     with pytest.raises(TealTypeError):
-        App.localGetEx(Txn.sender(), Int(0), Bytes("key"))
-    
+        App.localGetEx(Txn.sender(), Int(0), Int(0x123456))
+
     with pytest.raises(TealTypeError):
         App.localGetEx(Int(0), Bytes("app"), Bytes("key"))
 
     with pytest.raises(TealTypeError):
-        App.localGetEx(Int(0), Int(0), Int(1))
+        App.localGetEx(Txn.sender(), Int(0), Int(1))
 
 def test_global_get():
     arg = Bytes("key")
     expr = App.globalGet(arg)
     assert expr.type_of() == TealType.anytype
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.byte, "\"key\""),
         TealOp(expr, Op.app_global_get)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_global_get_invalid():
@@ -135,7 +198,7 @@ def test_global_get_ex():
     expr = App.globalGetEx(args[0], args[1])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.anytype
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 6),
         TealOp(args[1], Op.byte, "\"key\""),
@@ -143,11 +206,11 @@ def test_global_get_ex():
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -162,27 +225,45 @@ def test_local_put():
     args = [Int(0), Bytes("key"), Int(5)]
     expr = App.localPut(args[0], args[1], args[2])
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.byte, "\"key\""),
         TealOp(args[2], Op.int, 5),
         TealOp(expr, Op.app_local_put)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
+    assert actual == expected
+
+def test_local_put_direct_ref():
+    args = [Txn.sender(), Bytes("key"), Int(5)]
+    expr = App.localPut(args[0], args[1], args[2])
+    assert expr.type_of() == TealType.none
+
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.txn, "Sender"),
+        TealOp(args[1], Op.byte, "\"key\""),
+        TealOp(args[2], Op.int, 5),
+        TealOp(expr, Op.app_local_put)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
     assert actual == expected
 
 def test_local_put_invalid():
     with pytest.raises(TealTypeError):
-        App.localPut(Txn.sender(), Bytes("key"), Int(5))
-    
+        App.localPut(Txn.sender(), Int(55), Int(5))
+
     with pytest.raises(TealTypeError):
         App.localPut(Int(1), Int(0), Int(5))
-    
+
     with pytest.raises(TealTypeError):
         App.localPut(Int(1), Bytes("key"), Pop(Int(1)))
 
@@ -190,23 +271,23 @@ def test_global_put():
     args = [Bytes("key"), Int(5)]
     expr = App.globalPut(args[0], args[1])
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.byte, "\"key\""),
         TealOp(args[1], Op.int, 5),
         TealOp(expr, Op.app_global_put)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_global_put_invalid():
     with pytest.raises(TealTypeError):
         App.globalPut(Int(0), Int(5))
-    
+
     with pytest.raises(TealTypeError):
         App.globalPut(Bytes("key"), Pop(Int(1)))
 
@@ -214,23 +295,40 @@ def test_local_del():
     args = [Int(0), Bytes("key")]
     expr = App.localDel(args[0], args[1])
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.byte, "\"key\""),
         TealOp(expr, Op.app_local_del)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
+    assert actual == expected
+
+def test_local_del_direct_ref():
+    args = [Txn.sender(), Bytes("key")]
+    expr = App.localDel(args[0], args[1])
+    assert expr.type_of() == TealType.none
+
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.txn, "Sender"),
+        TealOp(args[1], Op.byte, "\"key\""),
+        TealOp(expr, Op.app_local_del)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
     assert actual == expected
 
 def test_local_del_invalid():
     with pytest.raises(TealTypeError):
-        App.localDel(Txn.sender(), Bytes("key"))
-    
+        App.localDel(Txn.sender(), Int(123))
+
     with pytest.raises(TealTypeError):
         App.localDel(Int(1), Int(2))
 
@@ -238,16 +336,16 @@ def test_global_del():
     arg = Bytes("key")
     expr = App.globalDel(arg)
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.byte, "\"key\""),
         TealOp(expr, Op.app_global_del)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_global_del_invalid():

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -143,21 +143,21 @@ def test_local_get_ex():
         assert actual == expected
 
 def test_local_get_ex_direct_ref():
-    args = [Txn.sender(), Int(6), Bytes("key")]
+    args = [Txn.sender(), Txn.applications[12], Bytes("key")]
     expr = App.localGetEx(args[0], args[1], args[2])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.anytype
 
     expected = TealSimpleBlock([
         TealOp(args[0], Op.txn, "Sender"),
-        TealOp(args[1], Op.int, 6),
+        TealOp(args[1], Op.txna, "Applications", 12),
         TealOp(args[2], Op.byte, "\"key\""),
         TealOp(expr, Op.app_local_get_ex),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal4Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -170,9 +170,6 @@ def test_local_get_ex_invalid():
 
     with pytest.raises(TealTypeError):
         App.localGetEx(Int(0), Bytes("app"), Bytes("key"))
-
-    with pytest.raises(TealTypeError):
-        App.localGetEx(Txn.sender(), Int(0), Int(1))
 
 def test_global_get():
     arg = Bytes("key")

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -143,21 +143,21 @@ def test_local_get_ex():
         assert actual == expected
 
 def test_local_get_ex_direct_ref():
-    args = [Txn.sender(), Txn.applications[12], Bytes("key")]
+    args = [Txn.sender(), Int(6), Bytes("key")]
     expr = App.localGetEx(args[0], args[1], args[2])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.anytype
 
     expected = TealSimpleBlock([
         TealOp(args[0], Op.txn, "Sender"),
-        TealOp(args[1], Op.txna, "Applications", 12),
+        TealOp(args[1], Op.int, 6),
         TealOp(args[2], Op.byte, "\"key\""),
         TealOp(expr, Op.app_local_get_ex),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(teal4Options)
+    actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -5,7 +5,7 @@ from .. import *
 from .. import CompileOptions
 
 options = CompileOptions()
-teal4Options = CompileOptions(version=3)
+teal4Options = CompileOptions(version=4)
 
 def test_on_complete():
     assert OnComplete.NoOp.__teal__(options)[0] == TealSimpleBlock([

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -15,8 +15,9 @@ class AssetHolding:
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check,
                 must be evaluated to uint64 (or, since v4, an account address that appears in
-                Txn.Accounts or is Txn.Sender).
-            asset: The ID of the asset to get. Must evaluate to uint64.
+                Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
+            asset: The ID of the asset to get, must be evaluated to uint64 (or, since v4,
+                a Txn.ForeignAssets offset).
         """
         require_type(account.type_of(), TealType.anytype)
         require_type(asset.type_of(), TealType.uint64)
@@ -31,8 +32,9 @@ class AssetHolding:
         Args:
             account: An index into Txn.Accounts that corresponds to the account to check,
                 must be evaluated to uint64 (or, since v4, an account address that appears in
-                Txn.Accounts or is Txn.Sender).
-            asset: The ID of the asset to check. Must evaluate to uint64.
+                Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
+            asset: The ID of the asset to get, must be evaluated to uint64 (or, since v4,
+                a Txn.ForeignAssets offset).
         """
         require_type(account.type_of(), TealType.anytype)
         require_type(asset.type_of(), TealType.uint64)
@@ -47,10 +49,11 @@ class AssetParam:
         """Get the total number of units of an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetTotal"], args=[asset])
 
     @classmethod
@@ -58,10 +61,11 @@ class AssetParam:
         """Get the number of decimals for an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDecimals"], args=[asset])
 
     @classmethod
@@ -69,10 +73,11 @@ class AssetParam:
         """Check if an asset is frozen by default.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDefaultFrozen"], args=[asset])
 
     @classmethod
@@ -80,10 +85,11 @@ class AssetParam:
         """Get the unit name of an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetUnitName"], args=[asset])
 
     @classmethod
@@ -91,10 +97,11 @@ class AssetParam:
         """Get the name of an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetName"], args=[asset])
 
     @classmethod
@@ -102,10 +109,11 @@ class AssetParam:
         """Get the URL of an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetURL"], args=[asset])
 
     @classmethod
@@ -115,10 +123,11 @@ class AssetParam:
         If set, this will be 32 bytes long.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetMetadataHash"], args=[asset])
 
     @classmethod
@@ -126,10 +135,11 @@ class AssetParam:
         """Get the manager address for an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetManager"], args=[asset])
 
     @classmethod
@@ -137,10 +147,11 @@ class AssetParam:
         """Get the reserve address for an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetReserve"], args=[asset])
 
     @classmethod
@@ -148,10 +159,11 @@ class AssetParam:
         """Get the freeze address for an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetFreeze"], args=[asset])
 
     @classmethod
@@ -159,10 +171,11 @@ class AssetParam:
         """Get the clawback address for an asset.
 
         Args:
-            asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
-                evaluate to uint64.
+            asset: An index into Txn.ForeignAssets that corresponds to the asset to check,
+                must be evaluated to uint64 (or since v4, an asset ID that appears in
+                Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.anytype)
+        require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetClawback"], args=[asset])
 
 AssetParam.__module__ = "pyteal"

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -18,7 +18,6 @@ class AssetHolding:
                 Txn.Accounts or is Txn.Sender).
             asset: The ID of the asset to get. Must evaluate to uint64.
         """
-        # TODO need to write test function for Version 4
         require_type(account.type_of(), TealType.anytype)
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetBalance"], args=[account, asset])
@@ -35,7 +34,6 @@ class AssetHolding:
                 Txn.Accounts or is Txn.Sender).
             asset: The ID of the asset to check. Must evaluate to uint64.
         """
-        # TODO need to write test function for Version 4
         require_type(account.type_of(), TealType.anytype)
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetFrozen"], args=[account, asset])

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -50,7 +50,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetTotal"], args=[asset])
 
     @classmethod
@@ -61,7 +61,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDecimals"], args=[asset])
 
     @classmethod
@@ -72,7 +72,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDefaultFrozen"], args=[asset])
 
     @classmethod
@@ -83,7 +83,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetUnitName"], args=[asset])
 
     @classmethod
@@ -94,7 +94,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetName"], args=[asset])
 
     @classmethod
@@ -105,7 +105,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetURL"], args=[asset])
 
     @classmethod
@@ -118,7 +118,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetMetadataHash"], args=[asset])
 
     @classmethod
@@ -129,7 +129,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetManager"], args=[asset])
 
     @classmethod
@@ -140,7 +140,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetReserve"], args=[asset])
 
     @classmethod
@@ -151,7 +151,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetFreeze"], args=[asset])
 
     @classmethod
@@ -162,7 +162,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset.type_of(), TealType.anytype)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetClawback"], args=[asset])
 
 AssetParam.__module__ = "pyteal"

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -7,7 +7,7 @@ from .leafexpr import LeafExpr
 from .maybe import MaybeValue
 
 class AssetHolding:
-    
+
     @classmethod
     def balance(cls, account: Expr, asset: Expr) -> MaybeValue:
         """Get the amount of an asset held by an account.
@@ -17,10 +17,11 @@ class AssetHolding:
                 evaluate to uint64.
             asset: The ID of the asset to get. Must evaluate to uint64.
         """
-        require_type(account.type_of(), TealType.uint64)
+        # TODO need to write test function for Version 4
+        require_type(account.type_of(), TealType.anytype)
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetBalance"], args=[account, asset])
-    
+
     @classmethod
     def frozen(cls, account: Expr, asset: Expr) -> MaybeValue:
         """Check if an asset is frozen for an account.
@@ -32,7 +33,8 @@ class AssetHolding:
                 evaluate to uint64.
             asset: The ID of the asset to check. Must evaluate to uint64.
         """
-        require_type(account.type_of(), TealType.uint64)
+        # TODO need to write test function for Version 4
+        require_type(account.type_of(), TealType.anytype)
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_holding_get, TealType.uint64, immediate_args=["AssetFrozen"], args=[account, asset])
 
@@ -50,7 +52,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetTotal"], args=[asset])
-    
+
     @classmethod
     def decimals(cls, asset: Expr) -> MaybeValue:
         """Get the number of decimals for an asset.
@@ -61,7 +63,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDecimals"], args=[asset])
-    
+
     @classmethod
     def defaultFrozen(cls, asset: Expr) -> MaybeValue:
         """Check if an asset is frozen by default.
@@ -72,7 +74,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.uint64, immediate_args=["AssetDefaultFrozen"], args=[asset])
-    
+
     @classmethod
     def unitName(cls, asset: Expr) -> MaybeValue:
         """Get the unit name of an asset.
@@ -83,7 +85,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetUnitName"], args=[asset])
-    
+
     @classmethod
     def name(cls, asset: Expr) -> MaybeValue:
         """Get the name of an asset.
@@ -94,7 +96,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetName"], args=[asset])
-    
+
     @classmethod
     def url(cls, asset: Expr) -> MaybeValue:
         """Get the URL of an asset.
@@ -105,7 +107,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetURL"], args=[asset])
-    
+
     @classmethod
     def metadataHash(cls, asset: Expr) -> MaybeValue:
         """Get the arbitrary commitment for an asset.
@@ -118,7 +120,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetMetadataHash"], args=[asset])
-    
+
     @classmethod
     def manager(cls, asset: Expr) -> MaybeValue:
         """Get the manager address for an asset.
@@ -129,7 +131,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetManager"], args=[asset])
-    
+
     @classmethod
     def reserve(cls, asset: Expr) -> MaybeValue:
         """Get the reserve address for an asset.
@@ -140,7 +142,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetReserve"], args=[asset])
-    
+
     @classmethod
     def freeze(cls, asset: Expr) -> MaybeValue:
         """Get the freeze address for an asset.
@@ -151,7 +153,7 @@ class AssetParam:
         """
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(Op.asset_params_get, TealType.bytes, immediate_args=["AssetFreeze"], args=[asset])
-    
+
     @classmethod
     def clawback(cls, asset: Expr) -> MaybeValue:
         """Get the clawback address for an asset.

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -13,8 +13,9 @@ class AssetHolding:
         """Get the amount of an asset held by an account.
 
         Args:
-            account: An index into Txn.Accounts that corresponds to the account to check. Must
-                evaluate to uint64.
+            account: An index into Txn.Accounts that corresponds to the account to check,
+                must be evaluated to uint64 (or, since v4, an account address that appears in
+                Txn.Accounts or is Txn.Sender).
             asset: The ID of the asset to get. Must evaluate to uint64.
         """
         # TODO need to write test function for Version 4
@@ -29,8 +30,9 @@ class AssetHolding:
         A value of 1 indicates frozen and 0 indicates not frozen.
 
         Args:
-            account: An index into Txn.Accounts that corresponds to the account to check. Must
-                evaluate to uint64.
+            account: An index into Txn.Accounts that corresponds to the account to check,
+                must be evaluated to uint64 (or, since v4, an account address that appears in
+                Txn.Accounts or is Txn.Sender).
             asset: The ID of the asset to check. Must evaluate to uint64.
         """
         # TODO need to write test function for Version 4

--- a/pyteal/ast/asset_test.py
+++ b/pyteal/ast/asset_test.py
@@ -4,7 +4,7 @@ from .. import *
 # this is not necessary but mypy complains if it's not included
 from .. import CompileOptions
 
-options = CompileOptions()
+teal2Options = CompileOptions()
 teal4Options = CompileOptions(version=4)
 
 def test_asset_holding_balance():
@@ -21,7 +21,7 @@ def test_asset_holding_balance():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -29,20 +29,20 @@ def test_asset_holding_balance():
         assert actual == expected
 
 def test_asset_holding_balance_direct_ref():
-    args = [Txn.sender(), Int(17)]
+    args = [Txn.sender(), Txn.assets[17]]
     expr = AssetHolding.balance(args[0], args[1])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
 
     expected = TealSimpleBlock([
         TealOp(args[0], Op.txn, "Sender"),
-        TealOp(args[1], Op.int, 17),
+        TealOp(args[1], Op.txna, "Assets", 17),
         TealOp(expr, Op.asset_holding_get, "AssetBalance"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal4Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -70,7 +70,7 @@ def test_asset_holding_frozen():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -78,20 +78,20 @@ def test_asset_holding_frozen():
         assert actual == expected
 
 def test_asset_holding_frozen_direct_ref():
-    args = [Txn.sender(), Int(17)]
+    args = [Txn.sender(), Txn.assets[17]]
     expr = AssetHolding.frozen(args[0], args[1])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
 
     expected = TealSimpleBlock([
         TealOp(args[0], Op.txn, "Sender"),
-        TealOp(args[1], Op.int, 17),
+        TealOp(args[1], Op.txna, "Assets", 17),
         TealOp(expr, Op.asset_holding_get, "AssetFrozen"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal4Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -118,7 +118,7 @@ def test_asset_param_total():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -147,7 +147,7 @@ def test_asset_param_total_direct_ref():
 
 def test_asset_param_total_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.total(AssetParam.total(Txn.assets[0]))
+        AssetParam.total(Txn.sender())
 
 def test_asset_param_decimals():
     arg = Int(0)
@@ -162,7 +162,7 @@ def test_asset_param_decimals():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -191,7 +191,7 @@ def test_asset_param_decimals_direct_ref():
 
 def test_asset_param_decimals_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.decimals(AssetParam.decimals(Txn.assets[0]))
+        AssetParam.decimals(Txn.sender())
 
 def test_asset_param_default_frozen():
     arg = Int(0)
@@ -206,7 +206,7 @@ def test_asset_param_default_frozen():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -235,7 +235,7 @@ def test_asset_param_default_frozen_direct_ref():
 
 def test_asset_param_default_frozen_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.defaultFrozen(AssetParam.defaultFrozen(Txn.assets[0]))
+        AssetParam.defaultFrozen(Txn.sender())
 
 def test_asset_param_unit_name():
     arg = Int(0)
@@ -250,7 +250,7 @@ def test_asset_param_unit_name():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -279,7 +279,7 @@ def test_asset_param_unit_name_direct_ref():
 
 def test_asset_param_unit_name_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.unitName(AssetParam.unitName(Txn.assets[0]))
+        AssetParam.unitName(Txn.sender())
 
 def test_asset_param_name():
     arg = Int(0)
@@ -294,7 +294,7 @@ def test_asset_param_name():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -323,7 +323,7 @@ def test_asset_param_name_direct_ref():
 
 def test_asset_param_name_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.name(AssetParam.name(Txn.assets[0]))
+        AssetParam.name(Txn.sender())
 
 def test_asset_param_url():
     arg = Int(0)
@@ -338,7 +338,7 @@ def test_asset_param_url():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -367,7 +367,7 @@ def test_asset_param_url_direct_ref():
 
 def test_asset_param_url_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.url(AssetParam.url(Txn.assets[0]))
+        AssetParam.url(Txn.sender())
 
 def test_asset_param_metadata_hash():
     arg = Int(0)
@@ -382,7 +382,7 @@ def test_asset_param_metadata_hash():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -411,7 +411,7 @@ def test_asset_param_metadata_hash_direct_ref():
 
 def test_asset_param_metadata_hash_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.metadataHash(AssetParam.metadataHash(Txn.assets[0]))
+        AssetParam.metadataHash(Txn.sender())
 
 def test_asset_param_manager():
     arg = Int(0)
@@ -426,7 +426,7 @@ def test_asset_param_manager():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -455,7 +455,7 @@ def test_asset_param_manager_direct_ref():
 
 def test_asset_param_manager_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.manager(AssetParam.manager(Txn.assets[0]))
+        AssetParam.manager(Txn.sender())
 
 def test_asset_param_reserve():
     arg = Int(2)
@@ -470,7 +470,7 @@ def test_asset_param_reserve():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -499,7 +499,7 @@ def test_asset_param_reserve_direct_ref():
 
 def test_asset_param_reserve_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.reserve(AssetParam.reserve(Txn.assets[0]))
+        AssetParam.reserve(Txn.sender())
 
 def test_asset_param_freeze():
     arg = Int(0)
@@ -514,7 +514,7 @@ def test_asset_param_freeze():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -543,7 +543,7 @@ def test_asset_param_freeze_direct_ref():
 
 def test_asset_param_freeze_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.freeze(AssetParam.freeze(Txn.assets[0]))
+        AssetParam.freeze(Txn.sender())
 
 def test_asset_param_clawback():
     arg = Int(1)
@@ -558,7 +558,7 @@ def test_asset_param_clawback():
         TealOp(None, Op.store, expr.slotValue)
     ])
 
-    actual, _ = expr.__teal__(options)
+    actual, _ = expr.__teal__(teal2Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
 
@@ -587,4 +587,4 @@ def test_asset_param_clawback_direct_ref():
 
 def test_asset_param_clawback_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.clawback(AssetParam.clawback(Txn.assets[0]))
+        AssetParam.clawback(Txn.sender())

--- a/pyteal/ast/asset_test.py
+++ b/pyteal/ast/asset_test.py
@@ -11,7 +11,7 @@ def test_asset_holding_balance():
     expr = AssetHolding.balance(args[0], args[1])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.int, 17),
@@ -19,18 +19,39 @@ def test_asset_holding_balance():
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+def test_asset_holding_balance_direct_ref():
+    args = [Txn.sender(), Int(17)]
+    expr = AssetHolding.balance(args[0], args[1])
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.txn, "Sender"),
+        TealOp(args[1], Op.int, 17),
+        TealOp(expr, Op.asset_holding_get, "AssetBalance"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 def test_asset_holding_balance_invalid():
     with pytest.raises(TealTypeError):
-        AssetHolding.balance(Txn.sender(), Int(17))
-    
+        AssetHolding.balance(Txn.sender(), Bytes("100"))
+
     with pytest.raises(TealTypeError):
         AssetHolding.balance(Int(0), Txn.receiver())
 
@@ -39,7 +60,7 @@ def test_asset_holding_frozen():
     expr = AssetHolding.frozen(args[0], args[1])
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(args[0], Op.int, 0),
         TealOp(args[1], Op.int, 17),
@@ -47,18 +68,39 @@ def test_asset_holding_frozen():
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+def test_asset_holding_frozen_direct_ref():
+    args = [Txn.sender(), Int(17)]
+    expr = AssetHolding.frozen(args[0], args[1])
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(args[0], Op.txn, "Sender"),
+        TealOp(args[1], Op.int, 17),
+        TealOp(expr, Op.asset_holding_get, "AssetFrozen"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 def test_asset_holding_frozen_invalid():
     with pytest.raises(TealTypeError):
-        AssetHolding.frozen(Txn.sender(), Int(17))
-    
+        AssetHolding.frozen(Txn.sender(), Bytes("17"))
+
     with pytest.raises(TealTypeError):
         AssetHolding.frozen(Int(0), Txn.receiver())
 
@@ -67,18 +109,18 @@ def test_asset_param_total():
     expr = AssetParam.total(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetTotal"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -91,18 +133,18 @@ def test_asset_param_decimals():
     expr = AssetParam.decimals(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetDecimals"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -115,18 +157,18 @@ def test_asset_param_default_frozen():
     expr = AssetParam.defaultFrozen(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetDefaultFrozen"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -139,18 +181,18 @@ def test_asset_param_unit_name():
     expr = AssetParam.unitName(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetUnitName"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -163,18 +205,18 @@ def test_asset_param_name():
     expr = AssetParam.name(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetName"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -187,18 +229,18 @@ def test_asset_param_url():
     expr = AssetParam.url(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetURL"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -211,18 +253,18 @@ def test_asset_param_metadata_hash():
     expr = AssetParam.metadataHash(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetMetadataHash"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -235,18 +277,18 @@ def test_asset_param_manager():
     expr = AssetParam.manager(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetManager"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -259,18 +301,18 @@ def test_asset_param_reserve():
     expr = AssetParam.reserve(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 2),
         TealOp(expr, Op.asset_params_get, "AssetReserve"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -283,18 +325,18 @@ def test_asset_param_freeze():
     expr = AssetParam.freeze(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.asset_params_get, "AssetFreeze"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
@@ -307,18 +349,18 @@ def test_asset_param_clawback():
     expr = AssetParam.clawback(arg)
     assert expr.type_of() == TealType.none
     assert expr.value().type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 1),
         TealOp(expr, Op.asset_params_get, "AssetClawback"),
         TealOp(None, Op.store, expr.slotOk),
         TealOp(None, Op.store, expr.slotValue)
     ])
-    
+
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 

--- a/pyteal/ast/asset_test.py
+++ b/pyteal/ast/asset_test.py
@@ -5,6 +5,7 @@ from .. import *
 from .. import CompileOptions
 
 options = CompileOptions()
+teal4Options = CompileOptions(version=4)
 
 def test_asset_holding_balance():
     args = Int(0), Int(17)
@@ -124,9 +125,29 @@ def test_asset_param_total():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_total_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.total(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetTotal"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_total_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.total(Txn.sender())
+        AssetParam.total(AssetParam.total(Txn.assets[0]))
 
 def test_asset_param_decimals():
     arg = Int(0)
@@ -148,9 +169,29 @@ def test_asset_param_decimals():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_decimals_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.decimals(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetDecimals"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_decimals_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.decimals(Txn.sender())
+        AssetParam.decimals(AssetParam.decimals(Txn.assets[0]))
 
 def test_asset_param_default_frozen():
     arg = Int(0)
@@ -172,9 +213,29 @@ def test_asset_param_default_frozen():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_default_frozen_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.defaultFrozen(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetDefaultFrozen"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_default_frozen_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.defaultFrozen(Txn.sender())
+        AssetParam.defaultFrozen(AssetParam.defaultFrozen(Txn.assets[0]))
 
 def test_asset_param_unit_name():
     arg = Int(0)
@@ -196,9 +257,29 @@ def test_asset_param_unit_name():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_unit_name_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.unitName(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetUnitName"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_unit_name_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.unitName(Txn.sender())
+        AssetParam.unitName(AssetParam.unitName(Txn.assets[0]))
 
 def test_asset_param_name():
     arg = Int(0)
@@ -220,9 +301,29 @@ def test_asset_param_name():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_name_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.name(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetName"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_name_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.name(Txn.sender())
+        AssetParam.name(AssetParam.name(Txn.assets[0]))
 
 def test_asset_param_url():
     arg = Int(0)
@@ -244,9 +345,29 @@ def test_asset_param_url():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_url_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.url(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetURL"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_url_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.url(Txn.sender())
+        AssetParam.url(AssetParam.url(Txn.assets[0]))
 
 def test_asset_param_metadata_hash():
     arg = Int(0)
@@ -268,9 +389,29 @@ def test_asset_param_metadata_hash():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_metadata_hash_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.metadataHash(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetMetadataHash"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_metadata_hash_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.metadataHash(Txn.sender())
+        AssetParam.metadataHash(AssetParam.metadataHash(Txn.assets[0]))
 
 def test_asset_param_manager():
     arg = Int(0)
@@ -292,9 +433,29 @@ def test_asset_param_manager():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_manager_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.manager(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetManager"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_manager_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.manager(Txn.sender())
+        AssetParam.manager(AssetParam.manager(Txn.assets[0]))
 
 def test_asset_param_reserve():
     arg = Int(2)
@@ -316,9 +477,29 @@ def test_asset_param_reserve():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_reserve_direct_ref():
+    arg = Txn.assets[2]
+    expr = AssetParam.reserve(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 2),
+        TealOp(expr, Op.asset_params_get, "AssetReserve"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_reserve_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.reserve(Txn.sender())
+        AssetParam.reserve(AssetParam.reserve(Txn.assets[0]))
 
 def test_asset_param_freeze():
     arg = Int(0)
@@ -340,9 +521,29 @@ def test_asset_param_freeze():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_freeze_direct_ref():
+    arg = Txn.assets[0]
+    expr = AssetParam.freeze(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 0),
+        TealOp(expr, Op.asset_params_get, "AssetFreeze"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_freeze_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.freeze(Txn.sender())
+        AssetParam.freeze(AssetParam.freeze(Txn.assets[0]))
 
 def test_asset_param_clawback():
     arg = Int(1)
@@ -364,6 +565,26 @@ def test_asset_param_clawback():
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+def test_asset_param_clawback_direct_ref():
+    arg = Txn.assets[1]
+    expr = AssetParam.clawback(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txna, "Assets", 1),
+        TealOp(expr, Op.asset_params_get, "AssetClawback"),
+        TealOp(None, Op.store, expr.slotOk),
+        TealOp(None, Op.store, expr.slotValue)
+    ])
+
+    actual, _ = expr.__teal__(teal4Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
 def test_asset_param_clawback_invalid():
     with pytest.raises(TealTypeError):
-        AssetParam.clawback(Txn.sender())
+        AssetParam.clawback(AssetParam.clawback(Txn.assets[0]))

--- a/pyteal/ast/global_.py
+++ b/pyteal/ast/global_.py
@@ -26,7 +26,7 @@ class GlobalField(Enum):
         self.arg_name = name
         self.ret_type = type
         self.min_version = min_version
-    
+
     def type_of(self) -> TealType:
         return self.ret_type
 
@@ -44,10 +44,10 @@ class Global(LeafExpr):
 
         op = TealOp(self, Op.global_, self.field.arg_name)
         return TealBlock.FromOp(options, op)
-         
+
     def __str__(self):
         return "(Global {})".format(self.field.arg_name)
-    
+
     def type_of(self):
         return self.field.type_of()
 
@@ -74,7 +74,7 @@ class Global(LeafExpr):
     @classmethod
     def group_size(cls) -> 'Global':
         """Get the number of transactions in this atomic transaction group.
-        
+
         This will be at least 1.
         """
         return cls(GlobalField.group_size)
@@ -83,30 +83,30 @@ class Global(LeafExpr):
     def logic_sig_version(cls) -> 'Global':
         """Get the maximum supported TEAL version."""
         return cls(GlobalField.logic_sig_version)
-    
+
     @classmethod
     def round(cls) -> 'Global':
         """Get the current round number."""
         return cls(GlobalField.round)
-    
+
     @classmethod
     def latest_timestamp(cls) -> 'Global':
         """Get the latest confirmed block UNIX timestamp.
-        
+
         Fails if negative."""
         return cls(GlobalField.latest_timestamp)
-    
+
     @classmethod
     def current_application_id(cls) -> 'Global':
         """Get the ID of the current application executing.
-        
+
         Fails if no application is executing."""
         return cls(GlobalField.current_app_id)
-    
+
     @classmethod
     def creator_address(cls) -> 'Global':
         """Address of the creator of the current application.
-        
+
         Fails if no such application is executing. Requires TEAL version 3 or higher."""
         return cls(GlobalField.creator_address)
 

--- a/pyteal/ast/global_test.py
+++ b/pyteal/ast/global_test.py
@@ -112,7 +112,7 @@ def test_global_current_application_id():
     ])
 
     actual, _ = expr.__teal__(teal2Options)
-    
+
     assert actual == expected
 
 def test_global_creator_address():
@@ -124,7 +124,7 @@ def test_global_creator_address():
     ])
 
     actual, _ = expr.__teal__(teal3Options)
-    
+
     assert actual == expected
 
     with pytest.raises(TealInputError):

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -97,8 +97,9 @@ def Return(arg: Expr) -> UnaryExpr:
 def Balance(account: Expr) -> UnaryExpr:
     """Get the balance of a user in microAlgos.
 
-    Argument must be an index into Txn.Accounts that corresponds to the account to read from. It
-    must evaluate to uint64.
+    Argument must be an index into Txn.Accounts that corresponds to the account to read from,
+    must be evaluated to uint64 (or, since v4, an account address that appears in Txn.Accounts
+    or is Txn.Sender).
 
     This operation is only permitted in application mode.
     """
@@ -109,8 +110,9 @@ def MinBalance(account: Expr) -> UnaryExpr:
 
     For more information about minimum balances, see: https://developer.algorand.org/docs/features/accounts/#minimum-balance
 
-    Argument must be an index into Txn.Accounts that corresponds to the account to read from. It
-    must evaluate to uint64.
+    Argument must be an index into Txn.Accounts that corresponds to the account to read from,
+    must be evaluated to uint64 (or, since v4, an account address that appears in Txn.Accounts
+    or is Txn.Sender).
 
     Requires TEAL version 3 or higher. This operation is only permitted in application mode.
     """

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -102,7 +102,7 @@ def Balance(account: Expr) -> UnaryExpr:
 
     This operation is only permitted in application mode.
     """
-    return UnaryExpr(Op.balance, TealType.uint64, TealType.uint64, account)
+    return UnaryExpr(Op.balance, TealType.anytype, TealType.uint64, account)
 
 def MinBalance(account: Expr) -> UnaryExpr:
     """Get the minimum balance of a user in microAlgos.

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -46,7 +46,7 @@ def BitLen(arg: Expr) -> UnaryExpr:
     If the argument is 0, 0 will be returned.
 
     If the argument is a byte array, it is interpreted as a big-endian unsigned integer.
-    
+
     Requires TEAL version 4 or higher.
     """
     return UnaryExpr(Op.bitlen, TealType.anytype, TealType.uint64, arg)
@@ -72,14 +72,14 @@ def Not(arg: Expr) -> UnaryExpr:
 
 def BitwiseNot(arg: Expr) -> UnaryExpr:
     """Get the bitwise inverse of a uint64.
-    
+
     Produces ~arg.
     """
     return UnaryExpr(Op.bitwise_not, TealType.uint64, TealType.uint64, arg)
 
 def Sqrt(arg: Expr) -> UnaryExpr:
     """Get the integer square root of a uint64.
-    
+
     This will return the largest integer X such that X^2 <= arg.
 
     Requires TEAL version 4 or higher.
@@ -114,11 +114,11 @@ def MinBalance(account: Expr) -> UnaryExpr:
 
     Requires TEAL version 3 or higher. This operation is only permitted in application mode.
     """
-    return UnaryExpr(Op.min_balance, TealType.uint64, TealType.uint64, account)
+    return UnaryExpr(Op.min_balance, TealType.anytype, TealType.uint64, account)
 
 def BytesNot(arg: Expr) -> UnaryExpr:
     """Get the bitwise inverse of bytes.
-    
+
     Produces ~arg.
     Argument must not exceed 64 bytes.
 
@@ -129,8 +129,8 @@ def BytesNot(arg: Expr) -> UnaryExpr:
 def BytesZero(arg: Expr) -> UnaryExpr:
     """Get a byte-array of a specified length, containing all zero bytes.
 
-    Argument must evaluate to uint64. 
+    Argument must evaluate to uint64.
 
-    Requires TEAL version 4 or higher.    
+    Requires TEAL version 4 or higher.
     """
     return UnaryExpr(Op.bzero, TealType.uint64, TealType.bytes, arg)

--- a/pyteal/ast/unaryexpr_test.py
+++ b/pyteal/ast/unaryexpr_test.py
@@ -12,7 +12,7 @@ def test_btoi():
     arg = Arg(1)
     expr = Btoi(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.arg, 1),
         TealOp(expr, Op.btoi)
@@ -32,7 +32,7 @@ def test_itob():
     arg = Int(1)
     expr = Itob(arg)
     assert expr.type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 1),
         TealOp(expr, Op.itob)
@@ -52,7 +52,7 @@ def test_len():
     arg = Txn.receiver()
     expr = Len(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.txn, "Receiver"),
         TealOp(expr, Op.len)
@@ -72,7 +72,7 @@ def test_bitlen_int():
     arg = Int(7)
     expr = BitLen(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 7),
         TealOp(expr, Op.bitlen)
@@ -88,7 +88,7 @@ def test_bitlen_bytes():
     arg = Txn.receiver()
     expr = BitLen(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.txn, "Receiver"),
         TealOp(expr, Op.bitlen)
@@ -104,7 +104,7 @@ def test_sha256():
     arg = Arg(0)
     expr = Sha256(arg)
     assert expr.type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.arg, 0),
         TealOp(expr, Op.sha256)
@@ -124,7 +124,7 @@ def test_sha512_256():
     arg = Arg(0)
     expr = Sha512_256(arg)
     assert expr.type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.arg, 0),
         TealOp(expr, Op.sha512_256)
@@ -144,7 +144,7 @@ def test_keccak256():
     arg = Arg(0)
     expr = Keccak256(arg)
     assert expr.type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.arg, 0),
         TealOp(expr, Op.keccak256)
@@ -164,7 +164,7 @@ def test_not():
     arg = Int(1)
     expr = Not(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 1),
         TealOp(expr, Op.logic_not)
@@ -184,7 +184,7 @@ def test_bitwise_not():
     arg = Int(2)
     expr = BitwiseNot(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 2),
         TealOp(expr, Op.bitwise_not)
@@ -200,7 +200,7 @@ def test_bitwise_not_overload():
     arg = Int(10)
     expr = ~arg
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 10),
         TealOp(expr, Op.bitwise_not)
@@ -220,7 +220,7 @@ def test_sqrt():
     arg = Int(4)
     expr = Sqrt(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 4),
         TealOp(expr, Op.sqrt)
@@ -240,7 +240,7 @@ def test_pop():
     arg_int = Int(3)
     expr_int = Pop(arg_int)
     assert expr_int.type_of() == TealType.none
-    
+
     expected_int = TealSimpleBlock([
         TealOp(arg_int, Op.int, 3),
         TealOp(expr_int, Op.pop)
@@ -249,7 +249,7 @@ def test_pop():
     actual_int, _ = expr_int.__teal__(teal2Options)
     actual_int.addIncoming()
     actual_int = TealBlock.NormalizeBlocks(actual_int)
-    
+
     assert actual_int == expected_int
 
     arg_bytes = Txn.receiver()
@@ -276,7 +276,7 @@ def test_return():
     arg = Int(1)
     expr = Return(arg)
     assert expr.type_of() == TealType.none
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 1),
         TealOp(expr, Op.return_)
@@ -296,7 +296,7 @@ def test_balance():
     arg = Int(0)
     expr = Balance(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.balance)
@@ -316,7 +316,7 @@ def test_min_balance():
     arg = Int(0)
     expr = MinBalance(arg)
     assert expr.type_of() == TealType.uint64
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 0),
         TealOp(expr, Op.min_balance)
@@ -328,15 +328,33 @@ def test_min_balance():
 
     assert actual == expected
 
+def test_min_balance_direct_ref():
+    arg = Txn.sender()
+    expr = MinBalance(arg)
+    assert expr.type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txn, "Sender"),
+        TealOp(expr, Op.min_balance)
+    ])
+
+    actual, _ = expr.__teal__(teal3Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    assert actual == expected
+
 def test_min_balance_invalid():
     with pytest.raises(TealTypeError):
-        MinBalance(Txn.receiver())
+        args = [Txn.sender(), Int(17)]
+        expr = AssetHolding.balance(args[0], args[1])
+        MinBalance(expr)
 
 def test_b_not():
     arg = Bytes("base16", "0xFFFFFFFFFFFFFFFFFF")
     expr = BytesNot(arg)
     assert expr.type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.byte, "0xFFFFFFFFFFFFFFFFFF"),
         TealOp(expr, Op.b_not)
@@ -345,7 +363,7 @@ def test_b_not():
     actual, _ = expr.__teal__(teal4Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_b_not_invalid():
@@ -356,7 +374,7 @@ def test_b_zero():
     arg = Int(8)
     expr = BytesZero(arg)
     assert expr.type_of() == TealType.bytes
-    
+
     expected = TealSimpleBlock([
         TealOp(arg, Op.int, 8),
         TealOp(expr, Op.bzero)
@@ -365,7 +383,7 @@ def test_b_zero():
     actual, _ = expr.__teal__(teal4Options)
     actual.addIncoming()
     actual = TealBlock.NormalizeBlocks(actual)
-    
+
     assert actual == expected
 
 def test_b_zero_invalid():

--- a/pyteal/ast/unaryexpr_test.py
+++ b/pyteal/ast/unaryexpr_test.py
@@ -308,9 +308,27 @@ def test_balance():
 
     assert actual == expected
 
+def test_balance_direct_ref():
+    arg = Txn.sender()
+    expr = Balance(arg)
+    assert expr.type_of() == TealType.uint64
+
+    expected = TealSimpleBlock([
+        TealOp(arg, Op.txn, "Sender"),
+        TealOp(expr, Op.balance)
+    ])
+
+    actual, _ = expr.__teal__(teal2Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    assert actual == expected
+
 def test_balance_invalid():
     with pytest.raises(TealTypeError):
-        Balance(Txn.receiver())
+        args = [Txn.sender(), Int(17)]
+        expr = AssetHolding.balance(args[0], args[1])
+        MinBalance(expr)
 
 def test_min_balance():
     arg = Int(0)


### PR DESCRIPTION
This PR adds supports on direct reference for foreign app/account/asset, corresponding to the PR [#2264](https://github.com/algorand/go-algorand/pull/2264) in `go-algorand`.

Minor changes are applied to the following components:
- `AssetParam`: add support for passing asset id in `Txn.assets`.
- `AssetHolding`: add support for passing account address in `Txn.Accounts` or is `Txn.Sender`.
- `MinBalance, Balance` in `unaryexp.py`: add support for passing account address.
- `App`:
  - `optedIn, localGet, localGetEx, localPut, localDel`: add support for passing account address.
  - `globalGetEx`: add support for passing application id in `Txn.applications`.

Corresponding documents and test cases are modified.