### PR TITLE
Align Seq with rest of the API

### DIFF
--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -1,4 +1,4 @@
-from typing import List, cast, TYPE_CHECKING
+from typing import List, cast, TYPE_CHECKING, overload
 
 from ..types import TealType, require_type
 from ..errors import TealInputError
@@ -11,7 +11,15 @@ if TYPE_CHECKING:
 class Seq(Expr):
     """A control flow expression to represent a sequence of expressions."""
     
+    @overload
+    def __init__(self, *exprs: Expr):
+        ...
+
+    @overload
     def __init__(self, exprs: List[Expr]):
+        ...
+
+    def __init__(self, *exprs):
         """Create a new Seq expression.
 
         The new Seq expression will take on the return value of the final expression in the sequence.
@@ -29,6 +37,10 @@ class Seq(Expr):
                 ])
         """
         super().__init__()
+
+        # Handle case where a list of expressions is provided
+        if len(exprs) == 1 and isinstance(exprs[0], list):
+            exprs = exprs[0]
         
         if len(exprs) == 0:
             raise TealInputError("Seq requires children.")

--- a/pyteal/ast/seq_test.py
+++ b/pyteal/ast/seq_test.py
@@ -72,3 +72,17 @@ def test_seq_invalid():
     
     with pytest.raises(TealTypeError):
         Seq([Seq([Pop(Int(1)), Int(2)]), Int(3)])
+
+def test_seq_overloads_equivalence():
+    items = [
+        App.localPut(Int(0), Bytes("key1"), Int(1)),
+        App.localPut(Int(1), Bytes("key2"), Bytes("value2")),
+        Pop(Bytes("end"))
+    ]
+    expr1 = Seq(items)
+    expr2 = Seq(*items)
+
+    expected = expr1.__teal__(options)
+    actual = expr2.__teal__(options)
+
+    assert actual == expected


### PR DESCRIPTION
It doesn't make sense for Seq to have a different API than all of the other operations.
This change allows to write
```
Seq(
    expr1,
    expr2
)
```
directly without needlessly wrapping the arguments in an array. This is especially convenient in repositories that use black to format source code. Before this patch the formatted code has too much indentation in a simple Seq:
```
Seq(
    [
        expr1,
        expr2,
    ]
)
```
This change doesn't break backwards compatibility.