### PR TITLE
Fix NaryExpr __str__ method

### DIFF
--- a/pyteal/ast/naryexpr.py
+++ b/pyteal/ast/naryexpr.py
@@ -48,7 +48,7 @@ class NaryExpr(Expr):
         return start, end
 
     def __str__(self):
-        ret_str = ("(" + str(self.op),)
+        ret_str = "(" + str(self.op)
         for a in self.args:
             ret_str += " " + a.__str__()
         ret_str += ")"


### PR DESCRIPTION
Remove the comma causing the result to be a tuple and therefore rendering the __str__ method unusable