### PR TITLE
`SafeRatio` -> `WideRatio`

### DIFF
--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -92,7 +92,7 @@ from .ternaryexpr import Ed25519Verify, Substring, Extract, SetBit, SetByte
 
 # more ops
 from .naryexpr import NaryExpr, And, Or, Concat
-from .safemath import SafeRatio
+from .widemath import WideRatio
 
 # control flow
 from .if_ import If
@@ -195,7 +195,7 @@ __all__ = [
     "And",
     "Or",
     "Concat",
-    "SafeRatio",
+    "WideRatio",
     "If",
     "Cond",
     "Seq",

--- a/pyteal/ast/widemath.py
+++ b/pyteal/ast/widemath.py
@@ -74,7 +74,7 @@ def multiplyFactors(
     return start, end
 
 
-class SafeRatio(Expr):
+class WideRatio(Expr):
     """A class used to calculate expressions of the form :code:`(N_1 * N_2 * N_3 * ...) / (D_1 * D_2 * D_3 * ...)`
 
     Use this class if all inputs to the expression are uint64s, the output fits in a uint64, and all
@@ -84,7 +84,7 @@ class SafeRatio(Expr):
     def __init__(
         self, numeratorFactors: List[Expr], denominatorFactors: List[Expr]
     ) -> None:
-        """Create a new SafeRatio expression with the given numerator and denominator factors.
+        """Create a new WideRatio expression with the given numerator and denominator factors.
 
         This will calculate :code:`(N_1 * N_2 * N_3 * ...) / (D_1 * D_2 * D_3 * ...)`, where each
         :code:`N_i` represents an element in :code:`numeratorFactors` and each :code:`D_i`
@@ -114,7 +114,7 @@ class SafeRatio(Expr):
     def __teal__(self, options: "CompileOptions"):
         if options.version < Op.cover.min_version:
             raise TealCompileError(
-                "SafeRatio requires TEAL version {} or higher".format(
+                "WideRatio requires TEAL version {} or higher".format(
                     Op.cover.min_version
                 ),
                 self,
@@ -140,7 +140,7 @@ class SafeRatio(Expr):
         return numStart, combine
 
     def __str__(self):
-        ret_str = "(SafeRatio (*"
+        ret_str = "(WideRatio (*"
         for f in self.numeratorFactors:
             ret_str += " " + str(f)
         ret_str += ") (*"
@@ -156,4 +156,4 @@ class SafeRatio(Expr):
         return False
 
 
-SafeRatio.__module__ = "pyteal"
+WideRatio.__module__ = "pyteal"

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -1339,10 +1339,10 @@ retsub
     assert actual == expected
 
 
-def test_compile_safe_ratio():
+def test_compile_wide_ratio():
     cases = (
         (
-            SafeRatio([Int(2), Int(100)], [Int(5)]),
+            WideRatio([Int(2), Int(100)], [Int(5)]),
             """#pragma version 5
 int 2
 int 100
@@ -1359,7 +1359,7 @@ return
 """,
         ),
         (
-            SafeRatio([Int(2), Int(100)], [Int(10), Int(5)]),
+            WideRatio([Int(2), Int(100)], [Int(10), Int(5)]),
             """#pragma version 5
 int 2
 int 100
@@ -1377,7 +1377,7 @@ return
 """,
         ),
         (
-            SafeRatio([Int(2), Int(100), Int(3)], [Int(10), Int(5)]),
+            WideRatio([Int(2), Int(100), Int(3)], [Int(10), Int(5)]),
             """#pragma version 5
 int 2
 int 100
@@ -1404,7 +1404,7 @@ return
 """,
         ),
         (
-            SafeRatio([Int(2), Int(100), Int(3)], [Int(10), Int(5), Int(6)]),
+            WideRatio([Int(2), Int(100), Int(3)], [Int(10), Int(5), Int(6)]),
             """#pragma version 5
 int 2
 int 100
@@ -1440,7 +1440,7 @@ return
 """,
         ),
         (
-            SafeRatio([Int(2), Int(100), Int(3), Int(4)], [Int(10), Int(5), Int(6)]),
+            WideRatio([Int(2), Int(100), Int(3), Int(4)], [Int(10), Int(5), Int(6)]),
             """#pragma version 5
 int 2
 int 100


### PR DESCRIPTION
Rename `SafeRatio` to `WideRatio`. "Safe" is a bit of misnomer, since normal math will still error if an overflow happens, so it's never unsafe. Rather, this expression just gives you more room until an overflow can happen.