### PR TITLE
Add missing field to `AppParam`

### DIFF
--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -341,5 +341,18 @@ class AppParam:
             Op.app_params_get, TealType.bytes, immediate_args=["AppCreator"], args=[app]
         )
 
+    @classmethod
+    def address(cls, app: Expr) -> MaybeValue:
+        """Get the escrow address for the application.
+
+        Args:
+            app: An index into Txn.ForeignApps that correspond to the application to check.
+                Must evaluate to uint64.
+        """
+        require_type(app.type_of(), TealType.uint64)
+        return MaybeValue(
+            Op.app_params_get, TealType.bytes, immediate_args=["AppAddress"], args=[app]
+        )
+
 
 AppParam.__module__ = "pyteal"

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -649,3 +649,31 @@ def test_app_param_creator_valid():
 def test_app_param_creator_invalid():
     with pytest.raises(TealTypeError):
         AppParam.creator(Txn.sender())
+
+
+def test_app_param_address_valid():
+    arg = Int(1)
+    expr = AppParam.address(arg)
+    assert expr.type_of() == TealType.none
+    assert expr.value().type_of() == TealType.bytes
+
+    expected = TealSimpleBlock(
+        [
+            TealOp(arg, Op.int, 1),
+            TealOp(expr, Op.app_params_get, "AppAddress"),
+            TealOp(None, Op.store, expr.slotOk),
+            TealOp(None, Op.store, expr.slotValue),
+        ]
+    )
+
+    actual, _ = expr.__teal__(teal5Options)
+    actual.addIncoming()
+    actual = TealBlock.NormalizeBlocks(actual)
+
+    with TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+
+def test_app_param_address_invalid():
+    with pytest.raises(TealTypeError):
+        AppParam.address(Txn.sender())


### PR DESCRIPTION
`AppParam.address()` gets the escrow address for an application.