### PR TITLE
Include pyi files in build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    package_data={"pyteal": ["*.pyi"]},
     python_requires=">=3.6",
 )


### PR DESCRIPTION
Include the new `__init__.pyi` file in this package's distribution file.