### PR TITLE
v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.9.1
+
+## Added
+* Documentation for exponent operator ([#134](https://github.com/algorand/pyteal/pull/134))
+* Documentation for using `Seq` with lists ([#135](https://github.com/algorand/pyteal/pull/135))
+
+## Fixed
+* Fixed use of wildcard import in Pylance ([#133](https://github.com/algorand/pyteal/pull/133))
+
 # 0.9.0
 
 ## Added

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyteal",
-    version="0.9.0",
+    version="0.9.1",
     author="Algorand",
     author_email="pypiservice@algorand.com",
     description="Algorand Smart Contracts in Python",


### PR DESCRIPTION
## Added
* Documentation for exponent operator ([#134](https://github.com/algorand/pyteal/pull/134))
* Documentation for using `Seq` with lists ([#135](https://github.com/algorand/pyteal/pull/135))

## Fixed
* Fixed use of wildcard import in Pylance ([#133](https://github.com/algorand/pyteal/pull/133))