### PR TITLE
up max teal version

### DIFF
--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -22,7 +22,7 @@ from .subroutines import (
 )
 from .constants import createConstantBlocks
 
-MAX_TEAL_VERSION = 5
+MAX_TEAL_VERSION = 6
 MIN_TEAL_VERSION = 2
 DEFAULT_TEAL_VERSION = MIN_TEAL_VERSION
 

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -134,7 +134,7 @@ def test_compile_version_invalid():
         compileTeal(expr, Mode.Signature, version=1)  # too small
 
     with pytest.raises(TealInputError):
-        compileTeal(expr, Mode.Signature, version=6)  # too large
+        compileTeal(expr, Mode.Signature, version=MAX_TEAL_VERSION+1)  # too large
 
     with pytest.raises(TealInputError):
         compileTeal(expr, Mode.Signature, version=2.0)  # decimal

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -134,7 +134,7 @@ def test_compile_version_invalid():
         compileTeal(expr, Mode.Signature, version=1)  # too small
 
     with pytest.raises(TealInputError):
-        compileTeal(expr, Mode.Signature, version=MAX_TEAL_VERSION+1)  # too large
+        compileTeal(expr, Mode.Signature, version=MAX_TEAL_VERSION + 1)  # too large
 
     with pytest.raises(TealInputError):
         compileTeal(expr, Mode.Signature, version=2.0)  # decimal

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -195,6 +195,17 @@ return
     assert actual == expected
 
 
+def test_compile_version_6():
+    expr = Int(1)
+    expected = """
+#pragma version 6
+int 1
+return
+""".strip()
+    actual = compileTeal(expr, Mode.Signature, version=6)
+    assert actual == expected
+
+
 def test_slot_load_before_store():
 
     program = AssetHolding.balance(Int(0), Int(0)).value()

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -134,7 +134,7 @@ def test_compile_version_invalid():
         compileTeal(expr, Mode.Signature, version=1)  # too small
 
     with pytest.raises(TealInputError):
-        compileTeal(expr, Mode.Signature, version=MAX_TEAL_VERSION + 1)  # too large
+        compileTeal(expr, Mode.Signature, version=7)  # too large
 
     with pytest.raises(TealInputError):
         compileTeal(expr, Mode.Signature, version=2.0)  # decimal


### PR DESCRIPTION
Just upping the max version allowed so if folks are interested in toying around they can. 

Generally I think we should try to do this for future versions as soon as a new teal version hits master/feature branches of go-algorand, even if we haven't defined the new ops yet

Optionally I can target some new feature branch here instead of trying to merge to master