### PR TITLE
Formatting subroutines with name and newline

### DIFF
--- a/examples/signature/dutch_auction.teal
+++ b/examples/signature/dutch_auction.teal
@@ -12,6 +12,7 @@ int 1
 ==
 bnz main_l4
 err
+
 main_l4:
 txn RekeyTo
 global ZeroAddress
@@ -51,6 +52,7 @@ int TMPL_ASSET_A
 ||
 &&
 b main_l7
+
 main_l5:
 gtxn 0 RekeyTo
 global ZeroAddress
@@ -157,6 +159,7 @@ gtxn 3 Receiver
 ==
 &&
 b main_l7
+
 main_l6:
 gtxn 0 RekeyTo
 global ZeroAddress
@@ -297,5 +300,6 @@ gtxn 3 Receiver
 gtxn 4 Receiver
 ==
 &&
+
 main_l7:
 return

--- a/examples/signature/dutch_auction.teal
+++ b/examples/signature/dutch_auction.teal
@@ -12,7 +12,6 @@ int 1
 ==
 bnz main_l4
 err
-
 main_l4:
 txn RekeyTo
 global ZeroAddress
@@ -52,7 +51,6 @@ int TMPL_ASSET_A
 ||
 &&
 b main_l7
-
 main_l5:
 gtxn 0 RekeyTo
 global ZeroAddress
@@ -159,7 +157,6 @@ gtxn 3 Receiver
 ==
 &&
 b main_l7
-
 main_l6:
 gtxn 0 RekeyTo
 global ZeroAddress
@@ -300,6 +297,5 @@ gtxn 3 Receiver
 gtxn 4 Receiver
 ==
 &&
-
 main_l7:
 return

--- a/examples/signature/split.teal
+++ b/examples/signature/split.teal
@@ -30,7 +30,6 @@ int 3000
 >
 &&
 b main_l3
-
 main_l2:
 gtxn 0 Sender
 gtxn 1 Sender
@@ -61,7 +60,6 @@ gtxn 0 Amount
 int 1000
 ==
 &&
-
 main_l3:
 &&
 return

--- a/examples/signature/split.teal
+++ b/examples/signature/split.teal
@@ -30,6 +30,7 @@ int 3000
 >
 &&
 b main_l3
+
 main_l2:
 gtxn 0 Sender
 gtxn 1 Sender
@@ -60,6 +61,7 @@ gtxn 0 Amount
 int 1000
 ==
 &&
+
 main_l3:
 &&
 return

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -826,13 +826,13 @@ global CreatorAddress
 ==
 bz main_l2
 txna ApplicationArgs 0
-callsub sub0
+callsub storeValue_0
 main_l2:
 int 1
 return
 
 // storeValue
-sub0:
+storeValue_0:
 store 0
 byte "key"
 load 0
@@ -868,7 +868,7 @@ global CreatorAddress
 ==
 bnz main_l3
 main_l1:
-callsub sub1
+callsub getValue_1
 byte "fail"
 ==
 bz main_l4
@@ -876,14 +876,14 @@ int 0
 return
 main_l3:
 txna ApplicationArgs 0
-callsub sub0
+callsub storeValue_0
 b main_l1
 main_l4:
 int 1
 return
 
 // storeValue
-sub0:
+storeValue_0:
 store 0
 byte "key"
 load 0
@@ -891,7 +891,7 @@ app_global_put
 retsub
 
 // getValue
-sub1:
+getValue_1:
 byte "key"
 app_global_get
 retsub
@@ -919,13 +919,13 @@ int 3
 int 4
 int 5
 int 6
-callsub sub0
+callsub calculateSum_0
 int 21
 ==
 return
 
 // calculateSum
-sub0:
+calculateSum_0:
 store 5
 store 4
 store 3
@@ -964,37 +964,37 @@ def test_compile_subroutine_recursive():
 
     expected = """#pragma version 4
 int 6
-callsub sub0
+callsub isEven_0
 return
 
 // isEven
-sub0:
+isEven_0:
 store 0
 load 0
 int 0
 ==
-bnz sub0_l4
+bnz isEven_0_l4
 load 0
 int 1
 ==
-bnz sub0_l3
+bnz isEven_0_l3
 load 0
 int 2
 -
 load 0
 dig 1
-callsub sub0
+callsub isEven_0
 swap
 store 0
 swap
 pop
-b sub0_l5
-sub0_l3:
+b isEven_0_l5
+isEven_0_l3:
 int 0
-b sub0_l5
-sub0_l4:
+b isEven_0_l5
+isEven_0_l4:
 int 1
-sub0_l5:
+isEven_0_l5:
 retsub
     """.strip()
     actual = compileTeal(program, Mode.Application, version=4, assembleConstants=False)
@@ -1016,35 +1016,35 @@ def test_compile_subroutine_recursive_5():
 
     expected = """#pragma version 5
 int 6
-callsub sub0
+callsub isEven_0
 return
 
 // isEven
-sub0:
+isEven_0:
 store 0
 load 0
 int 0
 ==
-bnz sub0_l4
+bnz isEven_0_l4
 load 0
 int 1
 ==
-bnz sub0_l3
+bnz isEven_0_l3
 load 0
 int 2
 -
 load 0
 swap
-callsub sub0
+callsub isEven_0
 swap
 store 0
-b sub0_l5
-sub0_l3:
+b isEven_0_l5
+isEven_0_l3:
 int 0
-b sub0_l5
-sub0_l4:
+b isEven_0_l5
+isEven_0_l4:
 int 1
-sub0_l5:
+isEven_0_l5:
 retsub
     """.strip()
     actual = compileTeal(program, Mode.Application, version=5, assembleConstants=False)
@@ -1065,17 +1065,17 @@ def test_compile_subroutine_recursive_multiple_args():
     expected = """#pragma version 4
 int 3
 int 5
-callsub sub0
+callsub multiplyByAdding_0
 return
 
 // multiplyByAdding
-sub0:
+multiplyByAdding_0:
 store 1
 store 0
 load 0
 int 0
 ==
-bnz sub0_l2
+bnz multiplyByAdding_0_l2
 load 1
 load 0
 int 1
@@ -1085,7 +1085,7 @@ load 0
 load 1
 dig 3
 dig 3
-callsub sub0
+callsub multiplyByAdding_0
 store 0
 store 1
 load 0
@@ -1097,7 +1097,7 @@ swap
 pop
 +
 retsub
-sub0_l2:
+multiplyByAdding_0_l2:
 int 0
 retsub
     """.strip()
@@ -1119,17 +1119,17 @@ def test_compile_subroutine_recursive_multiple_args_5():
     expected = """#pragma version 5
 int 3
 int 5
-callsub sub0
+callsub multiplyByAdding_0
 return
 
 // multiplyByAdding
-sub0:
+multiplyByAdding_0:
 store 1
 store 0
 load 0
 int 0
 ==
-bnz sub0_l2
+bnz multiplyByAdding_0_l2
 load 1
 load 0
 int 1
@@ -1139,13 +1139,13 @@ load 0
 load 1
 uncover 3
 uncover 3
-callsub sub0
+callsub multiplyByAdding_0
 cover 2
 store 1
 store 0
 +
 retsub
-sub0_l2:
+multiplyByAdding_0_l2:
 int 0
 retsub
     """.strip()
@@ -1166,55 +1166,55 @@ def test_compile_subroutine_mutually_recursive():
 
     expected = """#pragma version 4
 int 6
-callsub sub0
+callsub isEven_0
 return
 
 // isEven
-sub0:
+isEven_0:
 store 0
 load 0
 int 0
 ==
-bnz sub0_l2
+bnz isEven_0_l2
 load 0
 int 1
 -
 load 0
 dig 1
-callsub sub1
+callsub isOdd_1
 swap
 store 0
 swap
 pop
 !
-b sub0_l3
-sub0_l2:
+b isEven_0_l3
+isEven_0_l2:
 int 1
-sub0_l3:
+isEven_0_l3:
 retsub
 
 // isOdd
-sub1:
+isOdd_1:
 store 1
 load 1
 int 0
 ==
-bnz sub1_l2
+bnz isOdd_1_l2
 load 1
 int 1
 -
 load 1
 dig 1
-callsub sub0
+callsub isEven_0
 swap
 store 1
 swap
 pop
 !
-b sub1_l3
-sub1_l2:
+b isOdd_1_l3
+isOdd_1_l2:
 int 0
-sub1_l3:
+isOdd_1_l3:
 retsub
     """.strip()
     actual = compileTeal(program, Mode.Application, version=4, assembleConstants=False)
@@ -1234,51 +1234,51 @@ def test_compile_subroutine_mutually_recursive_5():
 
     expected = """#pragma version 5
 int 6
-callsub sub0
+callsub isEven_0
 return
 
 // isEven
-sub0:
+isEven_0:
 store 0
 load 0
 int 0
 ==
-bnz sub0_l2
+bnz isEven_0_l2
 load 0
 int 1
 -
 load 0
 swap
-callsub sub1
+callsub isOdd_1
 swap
 store 0
 !
-b sub0_l3
-sub0_l2:
+b isEven_0_l3
+isEven_0_l2:
 int 1
-sub0_l3:
+isEven_0_l3:
 retsub
 
 // isOdd
-sub1:
+isOdd_1:
 store 1
 load 1
 int 0
 ==
-bnz sub1_l2
+bnz isOdd_1_l2
 load 1
 int 1
 -
 load 1
 swap
-callsub sub0
+callsub isEven_0
 swap
 store 1
 !
-b sub1_l3
-sub1_l2:
+b isOdd_1_l3
+isOdd_1_l2:
 int 0
-sub1_l3:
+isOdd_1_l3:
 retsub
     """.strip()
     actual = compileTeal(program, Mode.Application, version=5, assembleConstants=False)
@@ -1297,20 +1297,20 @@ def test_compile_loop_in_subroutine():
 
     expected = """#pragma version 4
 byte "value"
-callsub sub0
+callsub setState_0
 int 1
 return
 
 // setState
-sub0:
+setState_0:
 store 0
 int 0
 store 1
-sub0_l1:
+setState_0_l1:
 load 1
 int 10
 <
-bz sub0_l3
+bz setState_0_l3
 load 1
 itob
 load 0
@@ -1319,8 +1319,8 @@ load 1
 int 1
 +
 store 1
-b sub0_l1
-sub0_l3:
+b setState_0_l1
+setState_0_l3:
 retsub
     """.strip()
     actual = compileTeal(program, Mode.Application, version=4, assembleConstants=False)
@@ -1361,13 +1361,13 @@ concat
 intc_0 // 1
 intc_0 // 1
 pushint 3 // 3
-callsub sub0
+callsub storeValue_0
 main_l2:
 intc_0 // 1
 return
 
 // storeValue
-sub0:
+storeValue_0:
 store 3
 store 2
 store 1

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -51,10 +51,8 @@ int 1
 bnz main_l2
 int 3
 b main_l3
-
 main_l2:
 int 2
-
 main_l3:
 return
 """.strip()
@@ -76,14 +74,11 @@ int 3
 bnz main_l3
 int 5
 b main_l5
-
 main_l3:
 int 4
 b main_l5
-
 main_l4:
 int 2
-
 main_l5:
 return
 """.strip()
@@ -107,7 +102,6 @@ txn ApplicationID
 int 0
 ==
 bnz main_l1
-
 main_l1:
 int 1
 return
@@ -342,7 +336,6 @@ def test_compile_while():
     #pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 2
@@ -353,7 +346,6 @@ int 1
 +
 store 0
 b main_l1
-
 main_l3:
 int 1
 return
@@ -384,7 +376,6 @@ return
     expected = """#pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 2
@@ -392,7 +383,6 @@ int 2
 bz main_l6
 int 0
 store 1
-
 main_l3:
 load 1
 int 5
@@ -403,14 +393,12 @@ int 1
 +
 store 0
 b main_l1
-
 main_l5:
 load 1
 int 1
 +
 store 1
 b main_l3
-
 main_l6:
 int 1
 return
@@ -431,11 +419,9 @@ def test_compile_for():
         ]
     )
 
-    expected = """
-    #pragma version 4
+    expected = """#pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 10
@@ -452,7 +438,6 @@ int 1
 +
 store 0
 b main_l1
-
 main_l3:
 int 1
 return
@@ -480,11 +465,9 @@ return
         ]
     )
 
-    expected = """
-        #pragma version 4
+    expected = """#pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 10
@@ -492,7 +475,6 @@ int 10
 bz main_l6
 int 0
 store 1
-
 main_l3:
 load 1
 int 4
@@ -503,7 +485,6 @@ int 1
 +
 store 0
 b main_l1
-
 main_l5:
 load 1
 itob
@@ -516,11 +497,10 @@ int 2
 +
 store 1
 b main_l3
-
 main_l6:
 int 1
 return
-        """.strip()
+    """.strip()
     actual = compileTeal(program, Mode.Application, version=4, assembleConstants=False)
     assert expected == actual
 
@@ -542,7 +522,6 @@ def test_compile_break():
     expected = """#pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 3
@@ -557,7 +536,6 @@ int 1
 +
 store 0
 b main_l1
-
 main_l4:
 int 1
 return
@@ -584,7 +562,6 @@ return
     expected = """#pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 10
@@ -605,7 +582,6 @@ int 1
 +
 store 0
 b main_l1
-
 main_l4:
 int 1
 return
@@ -630,13 +606,11 @@ def test_compile_continue():
     expected = """#pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 3
 <
 bz main_l4
-
 main_l2:
 load 0
 int 2
@@ -647,7 +621,6 @@ int 1
 +
 store 0
 b main_l1
-
 main_l4:
 int 1
 return
@@ -674,7 +647,6 @@ return
     expected = """#pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 10
@@ -690,14 +662,12 @@ load 0
 int 2
 *
 app_global_put
-
 main_l4:
 load 0
 int 1
 +
 store 0
 b main_l1
-
 main_l5:
 int 1
 return
@@ -731,7 +701,6 @@ load 0
 int 10
 <
 bz main_l2
-
 main_l1:
 load 0
 int 1
@@ -741,7 +710,6 @@ load 0
 int 4
 <
 bnz main_l1
-
 main_l2:
 int 1
 return
@@ -777,25 +745,21 @@ return
     expected = """#pragma version 4
 int 0
 store 0
-
 main_l1:
 load 0
 int 10
 <
 bz main_l8
-
 main_l2:
 load 0
 int 8
 ==
 bnz main_l8
-
 main_l3:
 load 0
 int 6
 <
 bnz main_l6
-
 main_l4:
 load 0
 int 5
@@ -806,7 +770,6 @@ int 1
 +
 store 0
 b main_l1
-
 main_l6:
 load 0
 int 3
@@ -817,7 +780,6 @@ int 1
 +
 store 0
 b main_l3
-
 main_l8:
 int 1
 return
@@ -865,12 +827,12 @@ global CreatorAddress
 bz main_l2
 txna ApplicationArgs 0
 callsub sub0
-
 main_l2:
 int 1
 return
 
-sub0: // storeValue
+// storeValue
+sub0:
 store 0
 byte "key"
 load 0
@@ -905,7 +867,6 @@ txn Sender
 global CreatorAddress
 ==
 bnz main_l3
-
 main_l1:
 callsub sub1
 byte "fail"
@@ -913,24 +874,24 @@ byte "fail"
 bz main_l4
 int 0
 return
-
 main_l3:
 txna ApplicationArgs 0
 callsub sub0
 b main_l1
-
 main_l4:
 int 1
 return
 
-sub0: // storeValue
+// storeValue
+sub0:
 store 0
 byte "key"
 load 0
 app_global_put
 retsub
 
-sub1: // getValue
+// getValue
+sub1:
 byte "key"
 app_global_get
 retsub
@@ -963,7 +924,8 @@ int 21
 ==
 return
 
-sub0: // calculateSum
+// calculateSum
+sub0:
 store 5
 store 4
 store 3
@@ -1005,7 +967,8 @@ int 6
 callsub sub0
 return
 
-sub0: // isEven
+// isEven
+sub0:
 store 0
 load 0
 int 0
@@ -1026,14 +989,11 @@ store 0
 swap
 pop
 b sub0_l5
-
 sub0_l3:
 int 0
 b sub0_l5
-
 sub0_l4:
 int 1
-
 sub0_l5:
 retsub
     """.strip()
@@ -1059,7 +1019,8 @@ int 6
 callsub sub0
 return
 
-sub0: // isEven
+// isEven
+sub0:
 store 0
 load 0
 int 0
@@ -1078,14 +1039,11 @@ callsub sub0
 swap
 store 0
 b sub0_l5
-
 sub0_l3:
 int 0
 b sub0_l5
-
 sub0_l4:
 int 1
-
 sub0_l5:
 retsub
     """.strip()
@@ -1110,7 +1068,8 @@ int 5
 callsub sub0
 return
 
-sub0: // multiplyByAdding
+// multiplyByAdding
+sub0:
 store 1
 store 0
 load 0
@@ -1138,7 +1097,6 @@ swap
 pop
 +
 retsub
-
 sub0_l2:
 int 0
 retsub
@@ -1164,7 +1122,8 @@ int 5
 callsub sub0
 return
 
-sub0: // multiplyByAdding
+// multiplyByAdding
+sub0:
 store 1
 store 0
 load 0
@@ -1186,7 +1145,6 @@ store 1
 store 0
 +
 retsub
-
 sub0_l2:
 int 0
 retsub
@@ -1211,7 +1169,8 @@ int 6
 callsub sub0
 return
 
-sub0: // isEven
+// isEven
+sub0:
 store 0
 load 0
 int 0
@@ -1229,14 +1188,13 @@ swap
 pop
 !
 b sub0_l3
-
 sub0_l2:
 int 1
-
 sub0_l3:
 retsub
 
-sub1: // isOdd
+// isOdd
+sub1:
 store 1
 load 1
 int 0
@@ -1254,10 +1212,8 @@ swap
 pop
 !
 b sub1_l3
-
 sub1_l2:
 int 0
-
 sub1_l3:
 retsub
     """.strip()
@@ -1281,7 +1237,8 @@ int 6
 callsub sub0
 return
 
-sub0: // isEven
+// isEven
+sub0:
 store 0
 load 0
 int 0
@@ -1297,14 +1254,13 @@ swap
 store 0
 !
 b sub0_l3
-
 sub0_l2:
 int 1
-
 sub0_l3:
 retsub
 
-sub1: // isOdd
+// isOdd
+sub1:
 store 1
 load 1
 int 0
@@ -1320,10 +1276,8 @@ swap
 store 1
 !
 b sub1_l3
-
 sub1_l2:
 int 0
-
 sub1_l3:
 retsub
     """.strip()
@@ -1347,11 +1301,11 @@ callsub sub0
 int 1
 return
 
-sub0: // setState
+// setState
+sub0:
 store 0
 int 0
 store 1
-
 sub0_l1:
 load 1
 int 10
@@ -1366,7 +1320,6 @@ int 1
 +
 store 1
 b sub0_l1
-
 sub0_l3:
 retsub
     """.strip()
@@ -1409,12 +1362,12 @@ intc_0 // 1
 intc_0 // 1
 pushint 3 // 3
 callsub sub0
-
 main_l2:
 intc_0 // 1
 return
 
-sub0: // storeValue
+// storeValue
+sub0:
 store 3
 store 2
 store 1

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -51,8 +51,10 @@ int 1
 bnz main_l2
 int 3
 b main_l3
+
 main_l2:
 int 2
+
 main_l3:
 return
 """.strip()
@@ -74,11 +76,14 @@ int 3
 bnz main_l3
 int 5
 b main_l5
+
 main_l3:
 int 4
 b main_l5
+
 main_l4:
 int 2
+
 main_l5:
 return
 """.strip()
@@ -102,6 +107,7 @@ txn ApplicationID
 int 0
 ==
 bnz main_l1
+
 main_l1:
 int 1
 return
@@ -336,6 +342,7 @@ def test_compile_while():
     #pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 2
@@ -346,6 +353,7 @@ int 1
 +
 store 0
 b main_l1
+
 main_l3:
 int 1
 return
@@ -376,6 +384,7 @@ return
     expected = """#pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 2
@@ -383,6 +392,7 @@ int 2
 bz main_l6
 int 0
 store 1
+
 main_l3:
 load 1
 int 5
@@ -393,12 +403,14 @@ int 1
 +
 store 0
 b main_l1
+
 main_l5:
 load 1
 int 1
 +
 store 1
 b main_l3
+
 main_l6:
 int 1
 return
@@ -423,6 +435,7 @@ def test_compile_for():
     #pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 10
@@ -439,6 +452,7 @@ int 1
 +
 store 0
 b main_l1
+
 main_l3:
 int 1
 return
@@ -470,6 +484,7 @@ return
         #pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 10
@@ -477,6 +492,7 @@ int 10
 bz main_l6
 int 0
 store 1
+
 main_l3:
 load 1
 int 4
@@ -487,6 +503,7 @@ int 1
 +
 store 0
 b main_l1
+
 main_l5:
 load 1
 itob
@@ -499,6 +516,7 @@ int 2
 +
 store 1
 b main_l3
+
 main_l6:
 int 1
 return
@@ -524,6 +542,7 @@ def test_compile_break():
     expected = """#pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 3
@@ -538,6 +557,7 @@ int 1
 +
 store 0
 b main_l1
+
 main_l4:
 int 1
 return
@@ -564,6 +584,7 @@ return
     expected = """#pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 10
@@ -584,6 +605,7 @@ int 1
 +
 store 0
 b main_l1
+
 main_l4:
 int 1
 return
@@ -608,11 +630,13 @@ def test_compile_continue():
     expected = """#pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 3
 <
 bz main_l4
+
 main_l2:
 load 0
 int 2
@@ -623,6 +647,7 @@ int 1
 +
 store 0
 b main_l1
+
 main_l4:
 int 1
 return
@@ -649,6 +674,7 @@ return
     expected = """#pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 10
@@ -664,12 +690,14 @@ load 0
 int 2
 *
 app_global_put
+
 main_l4:
 load 0
 int 1
 +
 store 0
 b main_l1
+
 main_l5:
 int 1
 return
@@ -703,6 +731,7 @@ load 0
 int 10
 <
 bz main_l2
+
 main_l1:
 load 0
 int 1
@@ -712,6 +741,7 @@ load 0
 int 4
 <
 bnz main_l1
+
 main_l2:
 int 1
 return
@@ -747,21 +777,25 @@ return
     expected = """#pragma version 4
 int 0
 store 0
+
 main_l1:
 load 0
 int 10
 <
 bz main_l8
+
 main_l2:
 load 0
 int 8
 ==
 bnz main_l8
+
 main_l3:
 load 0
 int 6
 <
 bnz main_l6
+
 main_l4:
 load 0
 int 5
@@ -772,6 +806,7 @@ int 1
 +
 store 0
 b main_l1
+
 main_l6:
 load 0
 int 3
@@ -782,6 +817,7 @@ int 1
 +
 store 0
 b main_l3
+
 main_l8:
 int 1
 return
@@ -829,9 +865,11 @@ global CreatorAddress
 bz main_l2
 txna ApplicationArgs 0
 callsub sub0
+
 main_l2:
 int 1
 return
+
 sub0: // storeValue
 store 0
 byte "key"
@@ -867,6 +905,7 @@ txn Sender
 global CreatorAddress
 ==
 bnz main_l3
+
 main_l1:
 callsub sub1
 byte "fail"
@@ -874,19 +913,23 @@ byte "fail"
 bz main_l4
 int 0
 return
+
 main_l3:
 txna ApplicationArgs 0
 callsub sub0
 b main_l1
+
 main_l4:
 int 1
 return
+
 sub0: // storeValue
 store 0
 byte "key"
 load 0
 app_global_put
 retsub
+
 sub1: // getValue
 byte "key"
 app_global_get
@@ -919,6 +962,7 @@ callsub sub0
 int 21
 ==
 return
+
 sub0: // calculateSum
 store 5
 store 4
@@ -960,6 +1004,7 @@ def test_compile_subroutine_recursive():
 int 6
 callsub sub0
 return
+
 sub0: // isEven
 store 0
 load 0
@@ -981,11 +1026,14 @@ store 0
 swap
 pop
 b sub0_l5
+
 sub0_l3:
 int 0
 b sub0_l5
+
 sub0_l4:
 int 1
+
 sub0_l5:
 retsub
     """.strip()
@@ -1010,6 +1058,7 @@ def test_compile_subroutine_recursive_5():
 int 6
 callsub sub0
 return
+
 sub0: // isEven
 store 0
 load 0
@@ -1029,11 +1078,14 @@ callsub sub0
 swap
 store 0
 b sub0_l5
+
 sub0_l3:
 int 0
 b sub0_l5
+
 sub0_l4:
 int 1
+
 sub0_l5:
 retsub
     """.strip()
@@ -1057,6 +1109,7 @@ int 3
 int 5
 callsub sub0
 return
+
 sub0: // multiplyByAdding
 store 1
 store 0
@@ -1085,6 +1138,7 @@ swap
 pop
 +
 retsub
+
 sub0_l2:
 int 0
 retsub
@@ -1109,6 +1163,7 @@ int 3
 int 5
 callsub sub0
 return
+
 sub0: // multiplyByAdding
 store 1
 store 0
@@ -1131,6 +1186,7 @@ store 1
 store 0
 +
 retsub
+
 sub0_l2:
 int 0
 retsub
@@ -1154,6 +1210,7 @@ def test_compile_subroutine_mutually_recursive():
 int 6
 callsub sub0
 return
+
 sub0: // isEven
 store 0
 load 0
@@ -1172,10 +1229,13 @@ swap
 pop
 !
 b sub0_l3
+
 sub0_l2:
 int 1
+
 sub0_l3:
 retsub
+
 sub1: // isOdd
 store 1
 load 1
@@ -1194,8 +1254,10 @@ swap
 pop
 !
 b sub1_l3
+
 sub1_l2:
 int 0
+
 sub1_l3:
 retsub
     """.strip()
@@ -1218,6 +1280,7 @@ def test_compile_subroutine_mutually_recursive_5():
 int 6
 callsub sub0
 return
+
 sub0: // isEven
 store 0
 load 0
@@ -1234,10 +1297,13 @@ swap
 store 0
 !
 b sub0_l3
+
 sub0_l2:
 int 1
+
 sub0_l3:
 retsub
+
 sub1: // isOdd
 store 1
 load 1
@@ -1254,8 +1320,10 @@ swap
 store 1
 !
 b sub1_l3
+
 sub1_l2:
 int 0
+
 sub1_l3:
 retsub
     """.strip()
@@ -1278,10 +1346,12 @@ byte "value"
 callsub sub0
 int 1
 return
+
 sub0: // setState
 store 0
 int 0
 store 1
+
 sub0_l1:
 load 1
 int 10
@@ -1296,6 +1366,7 @@ int 1
 +
 store 1
 b sub0_l1
+
 sub0_l3:
 retsub
     """.strip()
@@ -1338,9 +1409,11 @@ intc_0 // 1
 intc_0 // 1
 pushint 3 // 3
 callsub sub0
+
 main_l2:
 intc_0 // 1
 return
+
 sub0: // storeValue
 store 3
 store 2

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -1327,6 +1327,26 @@ retsub
     assert actual == expected
 
 
+def test_compile_subroutine_invalid_name():
+    def tmp() -> Expr:
+        return Int(1)
+
+    tmp.__name__ = "invalid-;)"
+
+    program = Subroutine(TealType.uint64)(tmp)()
+    expected = """#pragma version 4
+callsub invalid_0
+return
+
+// invalid-;)
+invalid_0:
+int 1
+retsub
+    """.strip()
+    actual = compileTeal(program, Mode.Application, version=4, assembleConstants=False)
+    assert actual == expected
+
+
 def test_compile_subroutine_assemble_constants():
     @Subroutine(TealType.none)
     def storeValue(key: Expr, t1: Expr, t2: Expr, t3: Expr) -> Expr:

--- a/pyteal/compiler/subroutines.py
+++ b/pyteal/compiler/subroutines.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Dict, Set, Optional, TypeVar
 from collections import OrderedDict
 from itertools import chain
@@ -226,7 +227,8 @@ def resolveSubroutines(
     subroutineOrder = sorted(allButMainRoutine, key=lambda subroutine: subroutine.id)
     subroutineToLabel: Dict[SubroutineDefinition, str] = OrderedDict()
     for index, subroutine in enumerate(subroutineOrder):
-        subroutineToLabel[subroutine] = "sub{}".format(index)
+        safer_name = re.sub(r"[^A-Za-z0-9]", "", subroutine.name())
+        subroutineToLabel[subroutine] = "{}_{}".format(safer_name, index)
 
     for subroutine, label in subroutineToLabel.items():
         for ops in subroutineMapping.values():

--- a/pyteal/compiler/subroutines.py
+++ b/pyteal/compiler/subroutines.py
@@ -226,7 +226,7 @@ def resolveSubroutines(
     subroutineOrder = sorted(allButMainRoutine, key=lambda subroutine: subroutine.id)
     subroutineToLabel: Dict[SubroutineDefinition, str] = OrderedDict()
     for index, subroutine in enumerate(subroutineOrder):
-        subroutineToLabel[subroutine] = "sub{}".format(index)  # subroutine.name()
+        subroutineToLabel[subroutine] = "sub{}".format(index)
 
     for subroutine, label in subroutineToLabel.items():
         for ops in subroutineMapping.values():

--- a/pyteal/compiler/subroutines.py
+++ b/pyteal/compiler/subroutines.py
@@ -226,7 +226,7 @@ def resolveSubroutines(
     subroutineOrder = sorted(allButMainRoutine, key=lambda subroutine: subroutine.id)
     subroutineToLabel: Dict[SubroutineDefinition, str] = OrderedDict()
     for index, subroutine in enumerate(subroutineOrder):
-        subroutineToLabel[subroutine] = subroutine.name()
+        subroutineToLabel[subroutine] = "sub{}".format(index)  # subroutine.name()
 
     for subroutine, label in subroutineToLabel.items():
         for ops in subroutineMapping.values():

--- a/pyteal/compiler/subroutines.py
+++ b/pyteal/compiler/subroutines.py
@@ -226,7 +226,7 @@ def resolveSubroutines(
     subroutineOrder = sorted(allButMainRoutine, key=lambda subroutine: subroutine.id)
     subroutineToLabel: Dict[SubroutineDefinition, str] = OrderedDict()
     for index, subroutine in enumerate(subroutineOrder):
-        subroutineToLabel[subroutine] = "sub{}".format(index)
+        subroutineToLabel[subroutine] = subroutine.name()
 
     for subroutine, label in subroutineToLabel.items():
         for ops in subroutineMapping.values():

--- a/pyteal/compiler/subroutines_test.py
+++ b/pyteal/compiler/subroutines_test.py
@@ -1366,9 +1366,9 @@ def test_resolveSubroutines():
     }
 
     expected = OrderedDict()
-    expected[subroutine1] = "sub0"
-    expected[subroutine2] = "sub1"
-    expected[subroutine3] = "sub2"
+    expected[subroutine1] = "sub1Impl_0"
+    expected[subroutine2] = "sub2Impl_1"
+    expected[subroutine3] = "sub3Impl_2"
 
     actual = resolveSubroutines(subroutineMapping)
     assert actual == expected

--- a/pyteal/compiler/subroutines_test.py
+++ b/pyteal/compiler/subroutines_test.py
@@ -1288,8 +1288,8 @@ def test_resolveSubroutines():
         return None
 
     subroutine1 = SubroutineDefinition(sub1Impl, TealType.uint64)
-    subroutine2 = SubroutineDefinition(sub1Impl, TealType.uint64)
-    subroutine3 = SubroutineDefinition(sub1Impl, TealType.none)
+    subroutine2 = SubroutineDefinition(sub2Impl, TealType.uint64)
+    subroutine3 = SubroutineDefinition(sub3Impl, TealType.none)
 
     subroutine1L1Label = LabelReference("l1")
     subroutine1Ops = [

--- a/pyteal/ir/teallabel.py
+++ b/pyteal/ir/teallabel.py
@@ -19,8 +19,8 @@ class TealLabel(TealComponent):
         return self.label
 
     def assemble(self) -> str:
-        comment = " // {}".format(self.comment) if self.comment is not None else ""
-        return "\n{}:{}".format(self.label.getLabel(), comment)
+        comment = "\n// {}\n".format(self.comment) if self.comment is not None else ""
+        return "{}{}:".format(comment, self.label.getLabel())
 
     def __repr__(self) -> str:
         return "TealLabel({}, {}, {})".format(

--- a/pyteal/ir/teallabel.py
+++ b/pyteal/ir/teallabel.py
@@ -20,7 +20,7 @@ class TealLabel(TealComponent):
 
     def assemble(self) -> str:
         comment = " // {}".format(self.comment) if self.comment is not None else ""
-        return "{}:{}".format(self.label.getLabel(), comment)
+        return "\n{}:{}".format(self.label.getLabel(), comment)
 
     def __repr__(self) -> str:
         return "TealLabel({}, {}, {})".format(


### PR DESCRIPTION
To make the TEAL output a little more readable, add a newline before the labels.  This will be removed during assembly to bytecode so should be no change to bytecode/addresses. 

Updated the tests and examples to account for this as well.