### PR TITLE
Call type_of() in require_type() for better exception messages

### DIFF
--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -95,8 +95,8 @@ class App(LeafExpr):
                 must be evaluated to uint64 (or, since v4, an application id that appears in
                 Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to bytes).
         """
-        require_type(account.type_of(), TealType.anytype)
-        require_type(app.type_of(), TealType.uint64)
+        require_type(account, TealType.anytype)
+        require_type(app, TealType.uint64)
         return cls(AppField.optedIn, [account, app])
 
     @classmethod
@@ -109,8 +109,8 @@ class App(LeafExpr):
                 Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
-        require_type(account.type_of(), TealType.anytype)
-        require_type(key.type_of(), TealType.bytes)
+        require_type(account, TealType.anytype)
+        require_type(key, TealType.bytes)
         return cls(AppField.localGet, [account, key])
 
     @classmethod
@@ -126,9 +126,9 @@ class App(LeafExpr):
                 Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to bytes).
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
-        require_type(account.type_of(), TealType.anytype)
-        require_type(app.type_of(), TealType.uint64)
-        require_type(key.type_of(), TealType.bytes)
+        require_type(account, TealType.anytype)
+        require_type(app, TealType.uint64)
+        require_type(key, TealType.bytes)
         return MaybeValue(
             AppField.localGetEx.get_op(), TealType.anytype, args=[account, app, key]
         )
@@ -140,7 +140,7 @@ class App(LeafExpr):
         Args:
             key: The key to read from the global application state. Must evaluate to bytes.
         """
-        require_type(key.type_of(), TealType.bytes)
+        require_type(key, TealType.bytes)
         return cls(AppField.globalGet, [key])
 
     @classmethod
@@ -153,8 +153,8 @@ class App(LeafExpr):
                 Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to uint64).
             key: The key to read from the global application state. Must evaluate to bytes.
         """
-        require_type(app.type_of(), TealType.uint64)
-        require_type(key.type_of(), TealType.bytes)
+        require_type(app, TealType.uint64)
+        require_type(key, TealType.bytes)
         return MaybeValue(
             AppField.globalGetEx.get_op(), TealType.anytype, args=[app, key]
         )
@@ -170,9 +170,9 @@ class App(LeafExpr):
             key: The key to write in the account's local state. Must evaluate to bytes.
             value: The value to write in the account's local state. Can evaluate to any type.
         """
-        require_type(account.type_of(), TealType.anytype)
-        require_type(key.type_of(), TealType.bytes)
-        require_type(value.type_of(), TealType.anytype)
+        require_type(account, TealType.anytype)
+        require_type(key, TealType.bytes)
+        require_type(value, TealType.anytype)
         return cls(AppField.localPut, [account, key, value])
 
     @classmethod
@@ -183,8 +183,8 @@ class App(LeafExpr):
             key: The key to write in the global application state. Must evaluate to bytes.
             value: THe value to write in the global application state. Can evaluate to any type.
         """
-        require_type(key.type_of(), TealType.bytes)
-        require_type(value.type_of(), TealType.anytype)
+        require_type(key, TealType.bytes)
+        require_type(value, TealType.anytype)
         return cls(AppField.globalPut, [key, value])
 
     @classmethod
@@ -197,8 +197,8 @@ class App(LeafExpr):
                 Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
             key: The key to delete from the account's local state. Must evaluate to bytes.
         """
-        require_type(account.type_of(), TealType.anytype)
-        require_type(key.type_of(), TealType.bytes)
+        require_type(account, TealType.anytype)
+        require_type(key, TealType.bytes)
         return cls(AppField.localDel, [account, key])
 
     @classmethod
@@ -208,7 +208,7 @@ class App(LeafExpr):
         Args:
             key: The key to delete from the global application state. Must evaluate to bytes.
         """
-        require_type(key.type_of(), TealType.bytes)
+        require_type(key, TealType.bytes)
         return cls(AppField.globalDel, [key])
 
 
@@ -224,7 +224,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.bytes,
@@ -240,7 +240,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.bytes,
@@ -256,7 +256,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -272,7 +272,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -288,7 +288,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -304,7 +304,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -320,7 +320,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -336,7 +336,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get, TealType.bytes, immediate_args=["AppCreator"], args=[app]
         )
@@ -349,7 +349,7 @@ class AppParam:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get, TealType.bytes, immediate_args=["AppAddress"], args=[app]
         )

--- a/pyteal/ast/arg.py
+++ b/pyteal/ast/arg.py
@@ -29,7 +29,7 @@ class Arg(LeafExpr):
             if index < 0 or index > 255:
                 raise TealInputError("invalid arg index {}".format(index))
         else:
-            require_type(cast(Expr, index).type_of(), TealType.uint64)
+            require_type(cast(Expr, index), TealType.uint64)
 
         self.index = index
 

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -18,7 +18,7 @@ class Assert(Expr):
             cond: The condition to check. Must evaluate to a uint64.
         """
         super().__init__()
-        require_type(cond.type_of(), TealType.uint64)
+        require_type(cond, TealType.uint64)
         self.cond = cond
 
     def __teal__(self, options: "CompileOptions"):

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -19,8 +19,8 @@ class AssetHolding:
             asset: The ID of the asset to get, must be evaluated to uint64 (or, since v4,
                 a Txn.ForeignAssets offset).
         """
-        require_type(account.type_of(), TealType.anytype)
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(account, TealType.anytype)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_holding_get,
             TealType.uint64,
@@ -41,8 +41,8 @@ class AssetHolding:
             asset: The ID of the asset to get, must be evaluated to uint64 (or, since v4,
                 a Txn.ForeignAssets offset).
         """
-        require_type(account.type_of(), TealType.anytype)
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(account, TealType.anytype)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_holding_get,
             TealType.uint64,
@@ -64,7 +64,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.uint64,
@@ -81,7 +81,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.uint64,
@@ -98,7 +98,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.uint64,
@@ -115,7 +115,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -132,7 +132,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -149,7 +149,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -168,7 +168,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -185,7 +185,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -202,7 +202,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -219,7 +219,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -236,7 +236,7 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -252,7 +252,7 @@ class AssetParam:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -26,8 +26,8 @@ class BinaryExpr(Expr):
         else:
             leftType = cast(TealType, inputType)
             rightType = leftType
-        require_type(argLeft.type_of(), leftType)
-        require_type(argRight.type_of(), rightType)
+        require_type(argLeft, leftType)
+        require_type(argRight, rightType)
 
         self.op = op
         self.outputType = outputType

--- a/pyteal/ast/cond.py
+++ b/pyteal/ast/cond.py
@@ -46,12 +46,12 @@ class Cond(Expr):
             if len(arg) != 2:
                 raise TealInputError(msg.format(arg))
 
-            require_type(arg[0].type_of(), TealType.uint64)  # cond_n should be int
+            require_type(arg[0], TealType.uint64)  # cond_n should be int
 
             if value_type is None:  # the types of all branches should be the same
                 value_type = arg[1].type_of()
             else:
-                require_type(arg[1].type_of(), value_type)
+                require_type(arg[1], value_type)
 
         self.value_type = value_type
         self.args = argv

--- a/pyteal/ast/for_.py
+++ b/pyteal/ast/for_.py
@@ -27,9 +27,9 @@ class For(Expr):
             step: Expression to update the variable's value.
         """
         super().__init__()
-        require_type(cond.type_of(), TealType.uint64)
-        require_type(start.type_of(), TealType.none)
-        require_type(step.type_of(), TealType.none)
+        require_type(cond, TealType.uint64)
+        require_type(start, TealType.none)
+        require_type(step, TealType.none)
 
         self.start = start
         self.cond = cond
@@ -94,7 +94,7 @@ class For(Expr):
     def Do(self, doBlock: Expr):
         if self.doBlock is not None:
             raise TealCompileError("For expression already has a doBlock", self)
-        require_type(doBlock.type_of(), TealType.none)
+        require_type(doBlock, TealType.none)
         self.doBlock = doBlock
         return self
 

--- a/pyteal/ast/gaid.py
+++ b/pyteal/ast/gaid.py
@@ -34,7 +34,7 @@ class GeneratedID(LeafExpr):
                     )
                 )
         else:
-            require_type(cast(Expr, txnIndex).type_of(), TealType.uint64)
+            require_type(cast(Expr, txnIndex), TealType.uint64)
         self.txnIndex = txnIndex
 
     def __str__(self):

--- a/pyteal/ast/gload.py
+++ b/pyteal/ast/gload.py
@@ -37,7 +37,7 @@ class ImportScratchValue(LeafExpr):
                     )
                 )
         else:
-            require_type(cast(Expr, txnIndex).type_of(), TealType.uint64)
+            require_type(cast(Expr, txnIndex), TealType.uint64)
         if slotId < 0 or slotId >= NUM_SLOTS:
             raise TealInputError(
                 "Invalid slot ID {}, shoud be in [0, {})".format(slotId, NUM_SLOTS)

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -110,7 +110,7 @@ class TxnGroup:
                     )
                 )
         else:
-            require_type(cast(Expr, txnIndex).type_of(), TealType.uint64)
+            require_type(cast(Expr, txnIndex), TealType.uint64)
         return TxnObject(
             lambda field: GtxnExpr(txnIndex, field),
             lambda field, index: GtxnaExpr(txnIndex, field, index),

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -28,16 +28,16 @@ class If(Expr):
                 to the same type as thenBranch, if provided. Defaults to None.
         """
         super().__init__()
-        require_type(cond.type_of(), TealType.uint64)
+        require_type(cond, TealType.uint64)
         # Flag to denote and check whether the new If().Then() syntax is being used
         self.alternateSyntaxFlag = False
 
         if thenBranch:
             if elseBranch:
-                require_type(thenBranch.type_of(), elseBranch.type_of())
+                require_type(thenBranch, elseBranch.type_of())
             else:
                 # If there is only a thenBranch, then it should evaluate to none type
-                require_type(thenBranch.type_of(), TealType.none)
+                require_type(thenBranch, TealType.none)
         else:
             self.alternateSyntaxFlag = True
 

--- a/pyteal/ast/itxn.py
+++ b/pyteal/ast/itxn.py
@@ -42,7 +42,7 @@ class InnerTxnFieldExpr(Expr):
         super().__init__()
         if field.is_array:
             raise TealInputError("Unexpected array field: {}".format(field))
-        require_type(value.type_of(), field.type_of())
+        require_type(value, field.type_of())
         self.field = field
         self.value = value
 

--- a/pyteal/ast/naryexpr.py
+++ b/pyteal/ast/naryexpr.py
@@ -26,7 +26,7 @@ class NaryExpr(Expr):
                 raise TealInputError(
                     "Argument is not a PyTeal expression: {}".format(arg)
                 )
-            require_type(arg.type_of(), inputType)
+            require_type(arg, inputType)
         self.op = op
         self.outputType = outputType
         self.args = args

--- a/pyteal/ast/return_.py
+++ b/pyteal/ast/return_.py
@@ -26,7 +26,7 @@ class Return(Expr):
         """
         super().__init__()
         if value is not None:
-            require_type(value.type_of(), TealType.anytype)
+            require_type(value, TealType.anytype)
         self.value = value
 
     def __teal__(self, options: "CompileOptions"):
@@ -97,7 +97,7 @@ class ExitProgram(Expr):
 
     def __init__(self, success: Expr) -> None:
         super().__init__()
-        require_type(success.type_of(), TealType.uint64)
+        require_type(success, TealType.uint64)
         self.success = success
 
     def __teal__(self, options: "CompileOptions"):

--- a/pyteal/ast/scratchvar.py
+++ b/pyteal/ast/scratchvar.py
@@ -40,7 +40,7 @@ class ScratchVar:
         Args:
             value: The value to store. Must conform to this ScratchVar's type.
         """
-        require_type(value.type_of(), self.type)
+        require_type(value, self.type)
         return self.slot.store(value)
 
     def load(self) -> ScratchLoad:

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -47,7 +47,7 @@ class Seq(Expr):
             if not isinstance(expr, Expr):
                 raise TealInputError("{} is not a pyteal expression.".format(expr))
             if i + 1 < len(exprs):
-                require_type(expr.type_of(), TealType.none)
+                require_type(expr, TealType.none)
 
         self.args = exprs
 

--- a/pyteal/ast/substring.py
+++ b/pyteal/ast/substring.py
@@ -18,9 +18,9 @@ class SubstringExpr(Expr):
     def __init__(self, stringArg: Expr, startArg: Expr, endArg: Expr) -> None:
         super().__init__()
 
-        require_type(stringArg.type_of(), TealType.bytes)
-        require_type(startArg.type_of(), TealType.uint64)
-        require_type(endArg.type_of(), TealType.uint64)
+        require_type(stringArg, TealType.bytes)
+        require_type(startArg, TealType.uint64)
+        require_type(endArg, TealType.uint64)
 
         self.stringArg = stringArg
         self.startArg = startArg
@@ -113,9 +113,9 @@ class ExtractExpr(Expr):
     def __init__(self, stringArg: Expr, startArg: Expr, lenArg: Expr) -> None:
         super().__init__()
 
-        require_type(stringArg.type_of(), TealType.bytes)
-        require_type(startArg.type_of(), TealType.uint64)
-        require_type(lenArg.type_of(), TealType.uint64)
+        require_type(stringArg, TealType.bytes)
+        require_type(startArg, TealType.uint64)
+        require_type(lenArg, TealType.uint64)
 
         self.stringArg = stringArg
         self.startArg = startArg
@@ -180,8 +180,8 @@ class SuffixExpr(Expr):
     ) -> None:
         super().__init__()
 
-        require_type(stringArg.type_of(), TealType.bytes)
-        require_type(startArg.type_of(), TealType.uint64)
+        require_type(stringArg, TealType.bytes)
+        require_type(startArg, TealType.uint64)
 
         self.stringArg = stringArg
         self.startArg = startArg

--- a/pyteal/ast/ternaryexpr.py
+++ b/pyteal/ast/ternaryexpr.py
@@ -24,9 +24,9 @@ class TernaryExpr(Expr):
         thirdArg: Expr,
     ) -> None:
         super().__init__()
-        require_type(firstArg.type_of(), inputTypes[0])
-        require_type(secondArg.type_of(), inputTypes[1])
-        require_type(thirdArg.type_of(), inputTypes[2])
+        require_type(firstArg, inputTypes[0])
+        require_type(secondArg, inputTypes[1])
+        require_type(thirdArg, inputTypes[2])
 
         self.op = op
         self.outputType = outputType

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -250,7 +250,7 @@ class TxnArray(Array):
             if index < 0:
                 raise TealInputError("Invalid array index: {}".format(index))
         else:
-            require_type(cast(Expr, index).type_of(), TealType.uint64)
+            require_type(cast(Expr, index), TealType.uint64)
 
         return self.txnObject.makeTxnaExpr(self.accessField, index)
 

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -16,7 +16,7 @@ class UnaryExpr(Expr):
         self, op: Op, inputType: TealType, outputType: TealType, arg: Expr
     ) -> None:
         super().__init__()
-        require_type(arg.type_of(), inputType)
+        require_type(arg, inputType)
         self.op = op
         self.outputType = outputType
         self.arg = arg

--- a/pyteal/ast/while_.py
+++ b/pyteal/ast/while_.py
@@ -24,7 +24,7 @@ class While(Expr):
             cond: The condition to check. Must evaluate to uint64.
         """
         super().__init__()
-        require_type(cond.type_of(), TealType.uint64)
+        require_type(cond, TealType.uint64)
 
         self.cond = cond
         self.doBlock: Optional[Expr] = None
@@ -74,7 +74,7 @@ class While(Expr):
     def Do(self, doBlock: Expr):
         if self.doBlock is not None:
             raise TealCompileError("While expression already has a doBlock", self)
-        require_type(doBlock.type_of(), TealType.none)
+        require_type(doBlock, TealType.none)
         self.doBlock = doBlock
         return self
 

--- a/pyteal/types.py
+++ b/pyteal/types.py
@@ -28,8 +28,7 @@ def require_type(input: Any, expected: TealType):
     try:
         actual = input.type_of()
     except AttributeError:
-        raise TypeError(f'Expected a {expected} object, but got a {type(input)}')
-        
+        raise TypeError(f"Expected a {expected} object, but got a {type(input)}")
 
     if actual != expected and (
         expected == TealType.none

--- a/pyteal/types.py
+++ b/pyteal/types.py
@@ -1,5 +1,6 @@
 import re
 from enum import Enum
+from typing import Any
 
 from .errors import TealTypeError, TealInputError
 
@@ -23,7 +24,13 @@ class TealType(Enum):
 TealType.__module__ = "pyteal"
 
 
-def require_type(actual: TealType, expected: TealType):
+def require_type(input: Any, expected: TealType):
+    try:
+        actual = input.type_of()
+    except AttributeError:
+        raise TypeError(f'Expected a {expected} object, but got a {type(input)}')
+        
+
     if actual != expected and (
         expected == TealType.none
         or actual == TealType.none

--- a/pyteal/types_test.py
+++ b/pyteal/types_test.py
@@ -2,9 +2,11 @@ from . import *
 from .types import require_type
 import pytest
 
+
 def test_require_type():
     require_type(Bytes("str"), TealType.bytes)
     assert True
+
 
 def test_require_type_invalid():
     with pytest.raises(TypeError):

--- a/pyteal/types_test.py
+++ b/pyteal/types_test.py
@@ -1,0 +1,11 @@
+from . import *
+from .types import require_type
+import pytest
+
+def test_require_type():
+    require_type(Bytes("str"), TealType.bytes)
+    assert True
+
+def test_require_type_invalid():
+    with pytest.raises(TypeError):
+        App.globalGet(["This is certainly invalid"])


### PR DESCRIPTION
With the current implementation of `require_type` you can get unclear exceptions. For example:

```
from pyteal import App
App.globalGet("Key")
```

Will result in
```  
Traceback (most recent call last):
  File "test.py", line 2, in <module>
    App.globalGet("Key")
  File "/home/joe/git/joe-p/pyteal/pyteal/ast/app.py", line 143, in globalGet
    require_type(key.type_of(), TealType.bytes)
AttributeError: 'str' object has no attribute 'type_of'
```

With this PR, the exception messages are now more clear and look like the following:

```
Traceback (most recent call last):
  File "/home/joe/git/joe-p/pyteal/pyteal/types.py", line 30, in require_type
    actual = input.type_of()
AttributeError: 'str' object has no attribute 'type_of'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 2, in <module>
    App.globalGet("Key")
  File "/home/joe/git/joe-p/pyteal/pyteal/ast/app.py", line 143, in globalGet
    require_type(key, TealType.bytes)
  File "/home/joe/git/joe-p/pyteal/pyteal/types.py", line 33, in require_type
    raise TypeError(f'Expected a {expected} object, but got a {type(input)}')
TypeError: Expected a TealType.bytes object, but got a <class 'str'>
```