### PR TITLE
Allow various methods to accept a union of Expr, int, and/or str

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,3 +5,6 @@ ignore_missing_imports = True
 
 [mypy-algosdk.*]
 ignore_missing_imports = True
+
+[mypy-pyteal.*]
+allow_redefinition = True

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -241,5 +241,5 @@ __all__ = [
     "For",
     "Break",
     "Continue",
-    "get_teal_type"
+    "get_teal_type",
 ]

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -118,6 +118,7 @@ from .continue_ import Continue
 from .scratch import ScratchSlot, ScratchLoad, ScratchStore, ScratchStackStore
 from .scratchvar import ScratchVar
 from .maybe import MaybeValue
+from .get_teal_type import get_teal_type
 
 __all__ = [
     "Expr",
@@ -240,4 +241,5 @@ __all__ = [
     "For",
     "Break",
     "Continue",
+    "get_teal_type"
 ]

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -85,7 +85,9 @@ class App(LeafExpr):
         return Global.current_application_id()
 
     @classmethod
-    def optedIn(cls, account: Union[int, str, Expr], app: Union[int, str, Expr]) -> "App":
+    def optedIn(
+        cls, account: Union[int, str, Expr], app: Union[int, str, Expr]
+    ) -> "App":
         """Check if an account has opted in for an application.
 
         Args:
@@ -119,7 +121,12 @@ class App(LeafExpr):
         return cls(AppField.localGet, [account, key])
 
     @classmethod
-    def localGetEx(cls, account: Union[int, str, Expr], app: Union[int, str, Expr], key: Union[str, Expr]) -> MaybeValue:
+    def localGetEx(
+        cls,
+        account: Union[int, str, Expr],
+        app: Union[int, str, Expr],
+        key: Union[str, Expr],
+    ) -> MaybeValue:
         """Read from an account's local state for an application.
 
         Args:
@@ -171,7 +178,12 @@ class App(LeafExpr):
         )
 
     @classmethod
-    def localPut(cls, account: Union[int, str, Expr], key: Union[str, Expr], value: Union[int, str, Expr]) -> "App":
+    def localPut(
+        cls,
+        account: Union[int, str, Expr],
+        key: Union[str, Expr],
+        value: Union[int, str, Expr],
+    ) -> "App":
         """Write to an account's local state for the current application.
 
         Args:

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -212,7 +212,7 @@ class App(LeafExpr):
                 Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
             key: The key to delete from the account's local state. Must evaluate to bytes.
         """
-        key = get_teal_type(key)
+        account, key = map(get_teal_type, [account, key])
 
         require_type(account.type_of(), TealType.anytype)
         require_type(key.type_of(), TealType.bytes)

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -100,8 +100,8 @@ class App(LeafExpr):
         """
         account, app = map(get_teal_type, [account, app])
 
-        require_type(account.type_of(), TealType.anytype)
-        require_type(app.type_of(), TealType.uint64)
+        require_type(account, TealType.anytype)
+        require_type(app, TealType.uint64)
         return cls(AppField.optedIn, [account, app])
 
     @classmethod
@@ -116,8 +116,8 @@ class App(LeafExpr):
         """
         account, key = map(get_teal_type, [account, key])
 
-        require_type(account.type_of(), TealType.anytype)
-        require_type(key.type_of(), TealType.bytes)
+        require_type(account, TealType.anytype)
+        require_type(key, TealType.bytes)
         return cls(AppField.localGet, [account, key])
 
     @classmethod
@@ -140,9 +140,9 @@ class App(LeafExpr):
         """
         account, app, key = map(get_teal_type, [account, app, key])
 
-        require_type(account.type_of(), TealType.anytype)
-        require_type(app.type_of(), TealType.uint64)
-        require_type(key.type_of(), TealType.bytes)
+        require_type(account, TealType.anytype)
+        require_type(app, TealType.uint64)
+        require_type(key, TealType.bytes)
         return MaybeValue(
             AppField.localGetEx.get_op(), TealType.anytype, args=[account, app, key]
         )
@@ -156,7 +156,7 @@ class App(LeafExpr):
         """
         key = get_teal_type(key)
 
-        require_type(key.type_of(), TealType.bytes)
+        require_type(key, TealType.bytes)
         return cls(AppField.globalGet, [key])
 
     @classmethod
@@ -171,8 +171,8 @@ class App(LeafExpr):
         """
         app, key = map(get_teal_type, [app, key])
 
-        require_type(app.type_of(), TealType.uint64)
-        require_type(key.type_of(), TealType.bytes)
+        require_type(app, TealType.uint64)
+        require_type(key, TealType.bytes)
         return MaybeValue(
             AppField.globalGetEx.get_op(), TealType.anytype, args=[app, key]
         )
@@ -195,9 +195,9 @@ class App(LeafExpr):
         """
         account, value, key = map(get_teal_type, [account, value, key])
 
-        require_type(account.type_of(), TealType.anytype)
-        require_type(key.type_of(), TealType.bytes)
-        require_type(value.type_of(), TealType.anytype)
+        require_type(account, TealType.anytype)
+        require_type(key, TealType.bytes)
+        require_type(value, TealType.anytype)
         return cls(AppField.localPut, [account, key, value])
 
     @classmethod
@@ -210,8 +210,8 @@ class App(LeafExpr):
         """
         value, key = map(get_teal_type, [value, key])
 
-        require_type(key.type_of(), TealType.bytes)
-        require_type(value.type_of(), TealType.anytype)
+        require_type(key, TealType.bytes)
+        require_type(value, TealType.anytype)
         return cls(AppField.globalPut, [key, value])
 
     @classmethod
@@ -226,8 +226,8 @@ class App(LeafExpr):
         """
         account, key = map(get_teal_type, [account, key])
 
-        require_type(account.type_of(), TealType.anytype)
-        require_type(key.type_of(), TealType.bytes)
+        require_type(account, TealType.anytype)
+        require_type(key, TealType.bytes)
         return cls(AppField.localDel, [account, key])
 
     @classmethod
@@ -239,7 +239,7 @@ class App(LeafExpr):
         """
         key = get_teal_type(key)
 
-        require_type(key.type_of(), TealType.bytes)
+        require_type(key, TealType.bytes)
         return cls(AppField.globalDel, [key])
 
 
@@ -257,7 +257,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.bytes,
@@ -275,7 +275,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.bytes,
@@ -293,7 +293,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -311,7 +311,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -329,7 +329,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -347,7 +347,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -365,7 +365,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
             TealType.uint64,
@@ -383,7 +383,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get, TealType.bytes, immediate_args=["AppCreator"], args=[app]
         )
@@ -398,7 +398,7 @@ class AppParam:
         """
         app = get_teal_type(app)
 
-        require_type(app.type_of(), TealType.uint64)
+        require_type(app, TealType.uint64)
         return MaybeValue(
             Op.app_params_get, TealType.bytes, immediate_args=["AppAddress"], args=[app]
         )

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 from enum import Enum
 
 from ..types import TealType, require_type
@@ -8,6 +8,7 @@ from .expr import Expr
 from .maybe import MaybeValue
 from .int import EnumInt
 from .global_ import Global
+from .get_teal_type import get_teal_type
 
 if TYPE_CHECKING:
     from ..compiler import CompileOptions
@@ -84,7 +85,7 @@ class App(LeafExpr):
         return Global.current_application_id()
 
     @classmethod
-    def optedIn(cls, account: Expr, app: Expr) -> "App":
+    def optedIn(cls, account: Union[int, str, Expr], app: Union[int, str, Expr]) -> "App":
         """Check if an account has opted in for an application.
 
         Args:
@@ -95,12 +96,14 @@ class App(LeafExpr):
                 must be evaluated to uint64 (or, since v4, an application id that appears in
                 Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to bytes).
         """
+        account, app = map(get_teal_type, [account, app])
+
         require_type(account.type_of(), TealType.anytype)
         require_type(app.type_of(), TealType.uint64)
         return cls(AppField.optedIn, [account, app])
 
     @classmethod
-    def localGet(cls, account: Expr, key: Expr) -> "App":
+    def localGet(cls, account: Union[int, str, Expr], key: Union[str, Expr]) -> "App":
         """Read from an account's local state for the current application.
 
         Args:
@@ -109,12 +112,14 @@ class App(LeafExpr):
                 Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
+        account, key = map(get_teal_type, [account, key])
+
         require_type(account.type_of(), TealType.anytype)
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.localGet, [account, key])
 
     @classmethod
-    def localGetEx(cls, account: Expr, app: Expr, key: Expr) -> MaybeValue:
+    def localGetEx(cls, account: Union[int, str, Expr], app: Union[int, str, Expr], key: Union[str, Expr]) -> MaybeValue:
         """Read from an account's local state for an application.
 
         Args:
@@ -126,6 +131,8 @@ class App(LeafExpr):
                 Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to bytes).
             key: The key to read from the account's local state. Must evaluate to bytes.
         """
+        account, app, key = map(get_teal_type, [account, app, key])
+
         require_type(account.type_of(), TealType.anytype)
         require_type(app.type_of(), TealType.uint64)
         require_type(key.type_of(), TealType.bytes)
@@ -134,17 +141,19 @@ class App(LeafExpr):
         )
 
     @classmethod
-    def globalGet(cls, key: Expr) -> "App":
+    def globalGet(cls, key: Union[str, Expr]) -> "App":
         """Read from the global state of the current application.
 
         Args:
             key: The key to read from the global application state. Must evaluate to bytes.
         """
+        key = get_teal_type(key)
+
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.globalGet, [key])
 
     @classmethod
-    def globalGetEx(cls, app: Expr, key: Expr) -> MaybeValue:
+    def globalGetEx(cls, app: Union[str, Expr], key: Union[str, Expr]) -> MaybeValue:
         """Read from the global state of an application.
 
         Args:
@@ -153,6 +162,8 @@ class App(LeafExpr):
                 Txn.ForeignApps or is the CurrentApplicationID, must be evaluated to uint64).
             key: The key to read from the global application state. Must evaluate to bytes.
         """
+        app, key = map(get_teal_type, [app, key])
+
         require_type(app.type_of(), TealType.uint64)
         require_type(key.type_of(), TealType.bytes)
         return MaybeValue(
@@ -160,7 +171,7 @@ class App(LeafExpr):
         )
 
     @classmethod
-    def localPut(cls, account: Expr, key: Expr, value: Expr) -> "App":
+    def localPut(cls, account: Union[int, str, Expr], key: Union[str, Expr], value: Union[int, str, Expr]) -> "App":
         """Write to an account's local state for the current application.
 
         Args:
@@ -170,25 +181,29 @@ class App(LeafExpr):
             key: The key to write in the account's local state. Must evaluate to bytes.
             value: The value to write in the account's local state. Can evaluate to any type.
         """
+        account, value, key = map(get_teal_type, [account, value, key])
+
         require_type(account.type_of(), TealType.anytype)
         require_type(key.type_of(), TealType.bytes)
         require_type(value.type_of(), TealType.anytype)
         return cls(AppField.localPut, [account, key, value])
 
     @classmethod
-    def globalPut(cls, key: Expr, value: Expr) -> "App":
+    def globalPut(cls, key: Union[str, Expr], value: Union[int, str, Expr]) -> "App":
         """Write to the global state of the current application.
 
         Args:
             key: The key to write in the global application state. Must evaluate to bytes.
             value: THe value to write in the global application state. Can evaluate to any type.
         """
+        value, key = map(get_teal_type, [value, key])
+
         require_type(key.type_of(), TealType.bytes)
         require_type(value.type_of(), TealType.anytype)
         return cls(AppField.globalPut, [key, value])
 
     @classmethod
-    def localDel(cls, account: Expr, key: Expr) -> "App":
+    def localDel(cls, account: Union[int, str, Expr], key: Union[str, Expr]) -> "App":
         """Delete a key from an account's local state for the current application.
 
         Args:
@@ -197,17 +212,21 @@ class App(LeafExpr):
                 Txn.Accounts or is Txn.Sender, must be evaluated to bytes).
             key: The key to delete from the account's local state. Must evaluate to bytes.
         """
+        key = get_teal_type(key)
+
         require_type(account.type_of(), TealType.anytype)
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.localDel, [account, key])
 
     @classmethod
-    def globalDel(cls, key: Expr) -> "App":
+    def globalDel(cls, key: Union[str, Expr]) -> "App":
         """Delete a key from the global state of the current application.
 
         Args:
             key: The key to delete from the global application state. Must evaluate to bytes.
         """
+        key = get_teal_type(key)
+
         require_type(key.type_of(), TealType.bytes)
         return cls(AppField.globalDel, [key])
 
@@ -217,13 +236,15 @@ App.__module__ = "pyteal"
 
 class AppParam:
     @classmethod
-    def approvalProgram(cls, app: Expr) -> MaybeValue:
+    def approvalProgram(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the bytecode of Approval Program for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
@@ -233,13 +254,15 @@ class AppParam:
         )
 
     @classmethod
-    def clearStateProgram(cls, app: Expr) -> MaybeValue:
+    def clearStateProgram(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the bytecode of Clear State Program for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
@@ -249,13 +272,15 @@ class AppParam:
         )
 
     @classmethod
-    def globalNumUnit(cls, app: Expr) -> MaybeValue:
+    def globalNumUnit(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the number of uint64 values allowed in Global State for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
@@ -265,13 +290,15 @@ class AppParam:
         )
 
     @classmethod
-    def globalNumByteSlice(cls, app: Expr) -> MaybeValue:
+    def globalNumByteSlice(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the number of byte array values allowed in Global State for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
@@ -281,13 +308,15 @@ class AppParam:
         )
 
     @classmethod
-    def localNumUnit(cls, app: Expr) -> MaybeValue:
+    def localNumUnit(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the number of uint64 values allowed in Local State for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
@@ -297,13 +326,15 @@ class AppParam:
         )
 
     @classmethod
-    def localNumByteSlice(cls, app: Expr) -> MaybeValue:
+    def localNumByteSlice(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the number of byte array values allowed in Local State for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
@@ -313,13 +344,15 @@ class AppParam:
         )
 
     @classmethod
-    def extraProgramPages(cls, app: Expr) -> MaybeValue:
+    def extraProgramPages(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the number of Extra Program Pages of code space for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get,
@@ -329,26 +362,30 @@ class AppParam:
         )
 
     @classmethod
-    def creator(cls, app: Expr) -> MaybeValue:
+    def creator(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the creator address for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get, TealType.bytes, immediate_args=["AppCreator"], args=[app]
         )
 
     @classmethod
-    def address(cls, app: Expr) -> MaybeValue:
+    def address(cls, app: Union[int, Expr]) -> MaybeValue:
         """Get the escrow address for the application.
 
         Args:
             app: An index into Txn.ForeignApps that correspond to the application to check.
                 Must evaluate to uint64.
         """
+        app = get_teal_type(app)
+
         require_type(app.type_of(), TealType.uint64)
         return MaybeValue(
             Op.app_params_get, TealType.bytes, immediate_args=["AppAddress"], args=[app]

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -1,15 +1,17 @@
 from enum import Enum
+from typing import Union
 
 from ..types import TealType, require_type
 from ..ir import Op
 from .expr import Expr
 from .leafexpr import LeafExpr
 from .maybe import MaybeValue
+from .get_teal_type import get_teal_type
 
 
 class AssetHolding:
     @classmethod
-    def balance(cls, account: Expr, asset: Expr) -> MaybeValue:
+    def balance(cls, account: Union[int, str, Expr], asset: Union[int, Expr]) -> MaybeValue:
         """Get the amount of an asset held by an account.
 
         Args:
@@ -19,6 +21,8 @@ class AssetHolding:
             asset: The ID of the asset to get, must be evaluated to uint64 (or, since v4,
                 a Txn.ForeignAssets offset).
         """
+        account, asset = map(get_teal_type, [account, asset])
+
         require_type(account.type_of(), TealType.anytype)
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
@@ -29,7 +33,7 @@ class AssetHolding:
         )
 
     @classmethod
-    def frozen(cls, account: Expr, asset: Expr) -> MaybeValue:
+    def frozen(cls, account: Union[int, str, Expr], asset: Union[int, Expr]) -> MaybeValue:
         """Check if an asset is frozen for an account.
 
         A value of 1 indicates frozen and 0 indicates not frozen.
@@ -41,6 +45,8 @@ class AssetHolding:
             asset: The ID of the asset to get, must be evaluated to uint64 (or, since v4,
                 a Txn.ForeignAssets offset).
         """
+        account, asset = map(get_teal_type, [account, asset])
+
         require_type(account.type_of(), TealType.anytype)
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
@@ -56,7 +62,7 @@ AssetHolding.__module__ = "pyteal"
 
 class AssetParam:
     @classmethod
-    def total(cls, asset: Expr) -> MaybeValue:
+    def total(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the total number of units of an asset.
 
         Args:
@@ -64,6 +70,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -73,7 +81,7 @@ class AssetParam:
         )
 
     @classmethod
-    def decimals(cls, asset: Expr) -> MaybeValue:
+    def decimals(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the number of decimals for an asset.
 
         Args:
@@ -81,6 +89,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -90,7 +100,7 @@ class AssetParam:
         )
 
     @classmethod
-    def defaultFrozen(cls, asset: Expr) -> MaybeValue:
+    def defaultFrozen(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Check if an asset is frozen by default.
 
         Args:
@@ -98,6 +108,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -107,7 +119,7 @@ class AssetParam:
         )
 
     @classmethod
-    def unitName(cls, asset: Expr) -> MaybeValue:
+    def unitName(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the unit name of an asset.
 
         Args:
@@ -115,6 +127,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -124,7 +138,7 @@ class AssetParam:
         )
 
     @classmethod
-    def name(cls, asset: Expr) -> MaybeValue:
+    def name(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the name of an asset.
 
         Args:
@@ -132,6 +146,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -141,7 +157,7 @@ class AssetParam:
         )
 
     @classmethod
-    def url(cls, asset: Expr) -> MaybeValue:
+    def url(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the URL of an asset.
 
         Args:
@@ -149,6 +165,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -158,7 +176,7 @@ class AssetParam:
         )
 
     @classmethod
-    def metadataHash(cls, asset: Expr) -> MaybeValue:
+    def metadataHash(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the arbitrary commitment for an asset.
 
         If set, this will be 32 bytes long.
@@ -168,6 +186,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -177,7 +197,7 @@ class AssetParam:
         )
 
     @classmethod
-    def manager(cls, asset: Expr) -> MaybeValue:
+    def manager(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the manager address for an asset.
 
         Args:
@@ -185,6 +205,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -194,7 +216,7 @@ class AssetParam:
         )
 
     @classmethod
-    def reserve(cls, asset: Expr) -> MaybeValue:
+    def reserve(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the reserve address for an asset.
 
         Args:
@@ -202,6 +224,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -211,7 +235,7 @@ class AssetParam:
         )
 
     @classmethod
-    def freeze(cls, asset: Expr) -> MaybeValue:
+    def freeze(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the freeze address for an asset.
 
         Args:
@@ -219,6 +243,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -228,7 +254,7 @@ class AssetParam:
         )
 
     @classmethod
-    def clawback(cls, asset: Expr) -> MaybeValue:
+    def clawback(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the clawback address for an asset.
 
         Args:
@@ -236,6 +262,8 @@ class AssetParam:
                 must be evaluated to uint64 (or since v4, an asset ID that appears in
                 Txn.ForeignAssets).
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
@@ -245,13 +273,15 @@ class AssetParam:
         )
 
     @classmethod
-    def creator(cls, asset: Expr) -> MaybeValue:
+    def creator(cls, asset: Union[int, Expr]) -> MaybeValue:
         """Get the creator address for an asset.
 
         Args:
             asset: An index into Txn.ForeignAssets that corresponds to the asset to check. Must
                 evaluate to uint64.
         """
+        asset = get_teal_type(asset)
+
         require_type(asset.type_of(), TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -11,7 +11,9 @@ from .get_teal_type import get_teal_type
 
 class AssetHolding:
     @classmethod
-    def balance(cls, account: Union[int, str, Expr], asset: Union[int, Expr]) -> MaybeValue:
+    def balance(
+        cls, account: Union[int, str, Expr], asset: Union[int, Expr]
+    ) -> MaybeValue:
         """Get the amount of an asset held by an account.
 
         Args:
@@ -33,7 +35,9 @@ class AssetHolding:
         )
 
     @classmethod
-    def frozen(cls, account: Union[int, str, Expr], asset: Union[int, Expr]) -> MaybeValue:
+    def frozen(
+        cls, account: Union[int, str, Expr], asset: Union[int, Expr]
+    ) -> MaybeValue:
         """Check if an asset is frozen for an account.
 
         A value of 1 indicates frozen and 0 indicates not frozen.

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -25,8 +25,8 @@ class AssetHolding:
         """
         account, asset = map(get_teal_type, [account, asset])
 
-        require_type(account.type_of(), TealType.anytype)
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(account, TealType.anytype)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_holding_get,
             TealType.uint64,
@@ -51,8 +51,8 @@ class AssetHolding:
         """
         account, asset = map(get_teal_type, [account, asset])
 
-        require_type(account.type_of(), TealType.anytype)
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(account, TealType.anytype)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_holding_get,
             TealType.uint64,
@@ -76,7 +76,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.uint64,
@@ -95,7 +95,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.uint64,
@@ -114,7 +114,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.uint64,
@@ -133,7 +133,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -152,7 +152,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -171,7 +171,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -192,7 +192,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -211,7 +211,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -230,7 +230,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -249,7 +249,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -268,7 +268,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,
@@ -286,7 +286,7 @@ class AssetParam:
         """
         asset = get_teal_type(asset)
 
-        require_type(asset.type_of(), TealType.uint64)
+        require_type(asset, TealType.uint64)
         return MaybeValue(
             Op.asset_params_get,
             TealType.bytes,

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -4,6 +4,7 @@ from ..types import TealType, require_type
 from ..errors import verifyTealVersion
 from ..ir import TealOp, Op, TealBlock
 from .expr import Expr
+from .get_teal_type import get_teal_type
 
 if TYPE_CHECKING:
     from ..compiler import CompileOptions
@@ -58,7 +59,7 @@ class BinaryExpr(Expr):
 BinaryExpr.__module__ = "pyteal"
 
 
-def Add(left: Expr, right: Expr) -> BinaryExpr:
+def Add(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Add two numbers.
 
     Produces left + right.
@@ -67,10 +68,11 @@ def Add(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.add, TealType.uint64, TealType.uint64, left, right)
 
 
-def Minus(left: Expr, right: Expr) -> BinaryExpr:
+def Minus(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Subtract two numbers.
 
     Produces left - right.
@@ -79,10 +81,11 @@ def Minus(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.minus, TealType.uint64, TealType.uint64, left, right)
 
 
-def Mul(left: Expr, right: Expr) -> BinaryExpr:
+def Mul(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Multiply two numbers.
 
     Produces left * right.
@@ -91,10 +94,11 @@ def Mul(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.mul, TealType.uint64, TealType.uint64, left, right)
 
 
-def Div(left: Expr, right: Expr) -> BinaryExpr:
+def Div(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Divide two numbers.
 
     Produces left / right.
@@ -103,10 +107,11 @@ def Div(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.div, TealType.uint64, TealType.uint64, left, right)
 
 
-def Mod(left: Expr, right: Expr) -> BinaryExpr:
+def Mod(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Modulo expression.
 
     Produces left % right.
@@ -115,10 +120,11 @@ def Mod(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.mod, TealType.uint64, TealType.uint64, left, right)
 
 
-def Exp(a: Expr, b: Expr) -> BinaryExpr:
+def Exp(a: Union[int, Expr], b: Union[int, Expr]) -> BinaryExpr:
     """Exponential expression.
 
     Produces a ** b.
@@ -129,10 +135,11 @@ def Exp(a: Expr, b: Expr) -> BinaryExpr:
         a: Must evaluate to uint64.
         b: Must evaluate to uint64.
     """
+    a, b = map(get_teal_type, [a, b])
     return BinaryExpr(Op.exp, TealType.uint64, TealType.uint64, a, b)
 
 
-def BitwiseAnd(left: Expr, right: Expr) -> BinaryExpr:
+def BitwiseAnd(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Bitwise and expression.
 
     Produces left & right.
@@ -141,10 +148,11 @@ def BitwiseAnd(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.bitwise_and, TealType.uint64, TealType.uint64, left, right)
 
 
-def BitwiseOr(left: Expr, right: Expr) -> BinaryExpr:
+def BitwiseOr(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Bitwise or expression.
 
     Produces left | right.
@@ -153,10 +161,11 @@ def BitwiseOr(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.bitwise_or, TealType.uint64, TealType.uint64, left, right)
 
 
-def BitwiseXor(left: Expr, right: Expr) -> BinaryExpr:
+def BitwiseXor(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Bitwise xor expression.
 
     Produces left ^ right.
@@ -165,10 +174,11 @@ def BitwiseXor(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.bitwise_xor, TealType.uint64, TealType.uint64, left, right)
 
 
-def ShiftLeft(a: Expr, b: Expr) -> BinaryExpr:
+def ShiftLeft(a: Union[int, Expr], b: Union[int, Expr]) -> BinaryExpr:
     """Bitwise left shift expression.
 
     Produces a << b. This is equivalent to a times 2^b, modulo 2^64.
@@ -179,10 +189,11 @@ def ShiftLeft(a: Expr, b: Expr) -> BinaryExpr:
         a: Must evaluate to uint64.
         b: Must evaluate to uint64.
     """
+    a, b = map(get_teal_type, [a, b])
     return BinaryExpr(Op.shl, TealType.uint64, TealType.uint64, a, b)
 
 
-def ShiftRight(a: Expr, b: Expr) -> BinaryExpr:
+def ShiftRight(a: Union[int, Expr], b: Union[int, Expr]) -> BinaryExpr:
     """Bitwise right shift expression.
 
     Produces a >> b. This is equivalent to a divided by 2^b.
@@ -193,10 +204,11 @@ def ShiftRight(a: Expr, b: Expr) -> BinaryExpr:
         a: Must evaluate to uint64.
         b: Must evaluate to uint64.
     """
+    a, b = map(get_teal_type, [a, b])
     return BinaryExpr(Op.shr, TealType.uint64, TealType.uint64, a, b)
 
 
-def Eq(left: Expr, right: Expr) -> BinaryExpr:
+def Eq(left: Union[int, str, Expr], right: Union[int, str, Expr]) -> BinaryExpr:
     """Equality expression.
 
     Checks if left == right.
@@ -205,10 +217,11 @@ def Eq(left: Expr, right: Expr) -> BinaryExpr:
         left: A value to check.
         right: The other value to check. Must evaluate to the same type as left.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.eq, right.type_of(), TealType.uint64, left, right)
 
 
-def Neq(left: Expr, right: Expr) -> BinaryExpr:
+def Neq(left: Union[int, str, Expr], right: Union[int, str, Expr]) -> BinaryExpr:
     """Difference expression.
 
     Checks if left != right.
@@ -217,10 +230,11 @@ def Neq(left: Expr, right: Expr) -> BinaryExpr:
         left: A value to check.
         right: The other value to check. Must evaluate to the same type as left.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.neq, right.type_of(), TealType.uint64, left, right)
 
 
-def Lt(left: Expr, right: Expr) -> BinaryExpr:
+def Lt(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Less than expression.
 
     Checks if left < right.
@@ -229,10 +243,11 @@ def Lt(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.lt, TealType.uint64, TealType.uint64, left, right)
 
 
-def Le(left: Expr, right: Expr) -> BinaryExpr:
+def Le(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Less than or equal to expression.
 
     Checks if left <= right.
@@ -241,10 +256,11 @@ def Le(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.le, TealType.uint64, TealType.uint64, left, right)
 
 
-def Gt(left: Expr, right: Expr) -> BinaryExpr:
+def Gt(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Greater than expression.
 
     Checks if left > right.
@@ -253,10 +269,11 @@ def Gt(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.gt, TealType.uint64, TealType.uint64, left, right)
 
 
-def Ge(left: Expr, right: Expr) -> BinaryExpr:
+def Ge(left: Union[int, Expr], right: Union[int, Expr]) -> BinaryExpr:
     """Greater than or equal to expression.
 
     Checks if left >= right.
@@ -265,10 +282,11 @@ def Ge(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to uint64.
         right: Must evaluate to uint64.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.ge, TealType.uint64, TealType.uint64, left, right)
 
 
-def GetBit(value: Expr, index: Expr) -> BinaryExpr:
+def GetBit(value: Union[int, str, Expr], index: Union[int, Expr]) -> BinaryExpr:
     """Get the bit value of an expression at a specific index.
 
     The meaning of index differs if value is an integer or a byte string.
@@ -287,12 +305,13 @@ def GetBit(value: Expr, index: Expr) -> BinaryExpr:
         value: The value containing bits. Can evaluate to any type.
         index: The index of the bit to extract. Must evaluate to uint64.
     """
+    value, index = map(get_teal_type, [value, index])
     return BinaryExpr(
         Op.getbit, (TealType.anytype, TealType.uint64), TealType.uint64, value, index
     )
 
 
-def GetByte(value: Expr, index: Expr) -> BinaryExpr:
+def GetByte(value: Union[str, Expr], index: Union[int, Expr]) -> BinaryExpr:
     """Extract a single byte as an integer from a byte string.
 
     Similar to GetBit, indexing begins at the first byte. For example, :code:`GetByte(Bytes("base16", "0xff0000"), Int(0))`
@@ -309,7 +328,7 @@ def GetByte(value: Expr, index: Expr) -> BinaryExpr:
     )
 
 
-def BytesAdd(left: Expr, right: Expr) -> BinaryExpr:
+def BytesAdd(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Add two numbers as bytes.
 
     Produces left + right, where left and right are interpreted as big-endian unsigned integers.
@@ -321,10 +340,11 @@ def BytesAdd(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_add, TealType.bytes, TealType.bytes, left, right)
 
 
-def BytesMinus(left: Expr, right: Expr) -> BinaryExpr:
+def BytesMinus(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Subtract two numbers as bytes.
 
     Produces left - right, where left and right are interpreted as big-endian unsigned integers.
@@ -336,10 +356,11 @@ def BytesMinus(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_minus, TealType.bytes, TealType.bytes, left, right)
 
 
-def BytesDiv(left: Expr, right: Expr) -> BinaryExpr:
+def BytesDiv(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Divide two numbers as bytes.
 
     Produces left / right, where left and right are interpreted as big-endian unsigned integers.
@@ -353,10 +374,11 @@ def BytesDiv(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_div, TealType.bytes, TealType.bytes, left, right)
 
 
-def BytesMul(left: Expr, right: Expr) -> BinaryExpr:
+def BytesMul(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Multiply two numbers as bytes.
 
     Produces left * right, where left and right are interpreted as big-endian unsigned integers.
@@ -368,10 +390,11 @@ def BytesMul(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_mul, TealType.bytes, TealType.bytes, left, right)
 
 
-def BytesMod(left: Expr, right: Expr) -> BinaryExpr:
+def BytesMod(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Modulo expression with bytes as arguments.
 
     Produces left % right, where left and right are interpreted as big-endian unsigned integers.
@@ -385,10 +408,11 @@ def BytesMod(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_mod, TealType.bytes, TealType.bytes, left, right)
 
 
-def BytesAnd(left: Expr, right: Expr) -> BinaryExpr:
+def BytesAnd(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Bitwise and expression with bytes as arguments.
 
     Produces left & right.
@@ -401,10 +425,11 @@ def BytesAnd(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_and, TealType.bytes, TealType.bytes, left, right)
 
 
-def BytesOr(left: Expr, right: Expr) -> BinaryExpr:
+def BytesOr(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Bitwise or expression with bytes as arguments.
 
     Produces left | right.
@@ -417,10 +442,11 @@ def BytesOr(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_or, TealType.bytes, TealType.bytes, left, right)
 
 
-def BytesXor(left: Expr, right: Expr) -> BinaryExpr:
+def BytesXor(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Bitwise xor expression with bytes as arguments.
 
     Produces left ^ right.
@@ -433,10 +459,11 @@ def BytesXor(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_xor, TealType.bytes, TealType.bytes, left, right)
 
 
-def BytesEq(left: Expr, right: Expr) -> BinaryExpr:
+def BytesEq(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Equality expression with bytes as arguments.
 
     Checks if left == right, where left and right are interpreted as big-endian unsigned integers.
@@ -448,10 +475,11 @@ def BytesEq(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_eq, TealType.bytes, TealType.uint64, left, right)
 
 
-def BytesNeq(left: Expr, right: Expr) -> BinaryExpr:
+def BytesNeq(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Difference expression with bytes as arguments.
 
     Checks if left != right, where left and right are interpreted as big-endian unsigned integers.
@@ -463,10 +491,11 @@ def BytesNeq(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_neq, TealType.bytes, TealType.uint64, left, right)
 
 
-def BytesLt(left: Expr, right: Expr) -> BinaryExpr:
+def BytesLt(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Less than expression with bytes as arguments.
 
     Checks if left < right, where left and right are interpreted as big-endian unsigned integers.
@@ -478,10 +507,11 @@ def BytesLt(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_lt, TealType.bytes, TealType.uint64, left, right)
 
 
-def BytesLe(left: Expr, right: Expr) -> BinaryExpr:
+def BytesLe(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Less than or equal to expression with bytes as arguments.
 
     Checks if left <= right, where left and right are interpreted as big-endian unsigned integers.
@@ -493,10 +523,11 @@ def BytesLe(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_le, TealType.bytes, TealType.uint64, left, right)
 
 
-def BytesGt(left: Expr, right: Expr) -> BinaryExpr:
+def BytesGt(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Greater than expression with bytes as arguments.
 
     Checks if left > right, where left and right are interpreted as big-endian unsigned integers.
@@ -508,10 +539,11 @@ def BytesGt(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_gt, TealType.bytes, TealType.uint64, left, right)
 
 
-def BytesGe(left: Expr, right: Expr) -> BinaryExpr:
+def BytesGe(left: Union[str, Expr], right: Union[str, Expr]) -> BinaryExpr:
     """Greater than or equal to expression with bytes as arguments.
 
     Checks if left >= right, where left and right are interpreted as big-endian unsigned integers.
@@ -523,10 +555,11 @@ def BytesGe(left: Expr, right: Expr) -> BinaryExpr:
         left: Must evaluate to bytes.
         right: Must evaluate to bytes.
     """
+    left, right = map(get_teal_type, [left, right])
     return BinaryExpr(Op.b_ge, TealType.bytes, TealType.uint64, left, right)
 
 
-def ExtractUint16(string: Expr, offset: Expr) -> BinaryExpr:
+def ExtractUint16(string: Union[str, Expr], offset: Union[int, Expr]) -> BinaryExpr:
     """Extract 2 bytes (16 bits) and convert them to an integer.
 
     The bytes starting at :code:`offset` up to but not including :code:`offset + 2` will be
@@ -540,6 +573,7 @@ def ExtractUint16(string: Expr, offset: Expr) -> BinaryExpr:
         string: The bytestring to extract from. Must evaluate to bytes.
         offset: The offset in the bytestring to start extracing. Must evaluate to uint64.
     """
+    string, offset = map(get_teal_type, [string, offset])
     return BinaryExpr(
         Op.extract_uint16,
         (TealType.bytes, TealType.uint64),
@@ -549,7 +583,7 @@ def ExtractUint16(string: Expr, offset: Expr) -> BinaryExpr:
     )
 
 
-def ExtractUint32(string: Expr, offset: Expr) -> BinaryExpr:
+def ExtractUint32(string: Union[str, Expr], offset: Union[int, Expr]) -> BinaryExpr:
     """Extract 4 bytes (32 bits) and convert them to an integer.
 
     The bytes starting at :code:`offset` up to but not including :code:`offset + 4` will be
@@ -563,6 +597,7 @@ def ExtractUint32(string: Expr, offset: Expr) -> BinaryExpr:
         string: The bytestring to extract from. Must evaluate to bytes.
         offset: The offset in the bytestring to start extracing. Must evaluate to uint64.
     """
+    string, offset = map(get_teal_type, [string, offset])
     return BinaryExpr(
         Op.extract_uint32,
         (TealType.bytes, TealType.uint64),
@@ -572,7 +607,7 @@ def ExtractUint32(string: Expr, offset: Expr) -> BinaryExpr:
     )
 
 
-def ExtractUint64(string: Expr, offset: Expr) -> BinaryExpr:
+def ExtractUint64(string: Union[str, Expr], offset: Union[int, Expr]) -> BinaryExpr:
     """Extract 8 bytes (64 bits) and convert them to an integer.
 
     The bytes starting at :code:`offset` up to but not including :code:`offset + 8` will be
@@ -586,6 +621,7 @@ def ExtractUint64(string: Expr, offset: Expr) -> BinaryExpr:
         string: The bytestring to extract from. Must evaluate to bytes.
         offset: The offset in the bytestring to start extracing. Must evaluate to uint64.
     """
+    string, offset = map(get_teal_type, [string, offset])
     return BinaryExpr(
         Op.extract_uint64,
         (TealType.bytes, TealType.uint64),

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -323,6 +323,7 @@ def GetByte(value: Union[str, Expr], index: Union[int, Expr]) -> BinaryExpr:
         value: The value containing the bytes. Must evaluate to bytes.
         index: The index of the byte to extract. Must evaluate to an integer less than Len(value).
     """
+    value, index = map(get_teal_type, [value, index])
     return BinaryExpr(
         Op.getbyte, (TealType.bytes, TealType.uint64), TealType.uint64, value, index
     )

--- a/pyteal/ast/get_teal_type.py
+++ b/pyteal/ast/get_teal_type.py
@@ -1,6 +1,7 @@
 from .bytes import Bytes
 from .int import Int
 
+
 def get_teal_type(obj):
     if isinstance(obj, str):
         return Bytes(obj)

--- a/pyteal/ast/get_teal_type.py
+++ b/pyteal/ast/get_teal_type.py
@@ -1,0 +1,10 @@
+from .bytes import Bytes
+from .int import Int
+
+def get_teal_type(obj):
+    if isinstance(obj, str):
+        return Bytes(obj)
+    elif isinstance(obj, int):
+        return Int(obj)
+    else:
+        return obj

--- a/pyteal/ast/get_teal_type_test.py
+++ b/pyteal/ast/get_teal_type_test.py
@@ -1,12 +1,17 @@
 from .. import *
+
+
 def test_get_teal_type_str():
-    assert get_teal_type('str') == Bytes('str')
+    assert get_teal_type("str") == Bytes("str")
+
 
 def test_get_teal_type_int():
     assert get_teal_type(1) == Int(1)
 
+
 def test_get_teal_type_pyteal_bytes():
-    assert get_teal_type(Bytes('str')) == Bytes('str')
+    assert get_teal_type(Bytes("str")) == Bytes("str")
+
 
 def test_get_teal_type_pyteal_int():
     assert get_teal_type(Int(1)) == Int(1)

--- a/pyteal/ast/get_teal_type_test.py
+++ b/pyteal/ast/get_teal_type_test.py
@@ -1,0 +1,12 @@
+from .. import *
+def test_get_teal_type_str():
+    assert get_teal_type('str') == Bytes('str')
+
+def test_get_teal_type_int():
+    assert get_teal_type(1) == Int(1)
+
+def test_get_teal_type_pyteal_bytes():
+    assert get_teal_type(Bytes('str')) == Bytes('str')
+
+def test_get_teal_type_pyteal_int():
+    assert get_teal_type(Int(1)) == Int(1)

--- a/pyteal/ast/return_.py
+++ b/pyteal/ast/return_.py
@@ -26,8 +26,10 @@ class Return(Expr):
         return value, or the given return value if it does produce a return value.
         """
         super().__init__()
+        
+        value = get_teal_type(value)
+
         if value is not None:
-            value = get_teal_type(value)
             require_type(value.type_of(), TealType.anytype)
         self.value = value
 

--- a/pyteal/ast/return_.py
+++ b/pyteal/ast/return_.py
@@ -26,7 +26,7 @@ class Return(Expr):
         return value, or the given return value if it does produce a return value.
         """
         super().__init__()
-        
+
         value = get_teal_type(value)
 
         if value is not None:

--- a/pyteal/ast/return_.py
+++ b/pyteal/ast/return_.py
@@ -1,10 +1,11 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from ..types import TealType, require_type, types_match
 from ..errors import verifyTealVersion, TealCompileError
 from ..ir import TealOp, Op, TealBlock
 from .expr import Expr
 from .int import Int
+from .get_teal_type import get_teal_type
 
 if TYPE_CHECKING:
     from ..compiler import CompileOptions
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
 class Return(Expr):
     """Return a value from the current execution context."""
 
-    def __init__(self, value: Expr = None) -> None:
+    def __init__(self, value: Union[int, Expr] = None) -> None:
         """Create a new Return expression.
 
         If called from the main program, this will immediately exit the program
@@ -26,6 +27,7 @@ class Return(Expr):
         """
         super().__init__()
         if value is not None:
+            value = get_teal_type(value)
             require_type(value.type_of(), TealType.anytype)
         self.value = value
 

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from ..types import TealType
 from ..config import NUM_SLOTS
@@ -38,7 +38,7 @@ class ScratchSlot:
             self.id = requestedSlotId
             self.isReservedSlot = True
 
-    def store(self, value: Expr = None) -> Expr:
+    def store(self, value: Union[int, str, Expr] = None) -> Expr:
         """Get an expression to store a value in this slot.
 
         Args:

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -4,6 +4,7 @@ from ..types import TealType
 from ..config import NUM_SLOTS
 from ..errors import TealInputError
 from .expr import Expr
+from .get_teal_type import get_teal_type
 
 if TYPE_CHECKING:
     from ..compiler import CompileOptions
@@ -47,7 +48,8 @@ class ScratchSlot:
             semantics of PyTeal, only use if you know what you're doing.
         """
         if value is not None:
-            return ScratchStore(self, value)
+            value_expr = get_teal_type(value)
+            return ScratchStore(self, value_expr)
         return ScratchStackStore(self)
 
     def load(self, type: TealType = TealType.anytype) -> "ScratchLoad":

--- a/pyteal/ast/substring.py
+++ b/pyteal/ast/substring.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import cast, Tuple, TYPE_CHECKING
+from typing import cast, Tuple, TYPE_CHECKING, Union
 
 from ..types import TealType, require_type
 from ..errors import TealCompileError, verifyTealVersion
@@ -7,6 +7,7 @@ from ..ir import TealOp, Op, TealBlock, TealSimpleBlock
 from .expr import Expr
 from .int import Int
 from .ternaryexpr import TernaryExpr
+from .get_teal_type import get_teal_type
 
 if TYPE_CHECKING:
     from ..compiler import CompileOptions
@@ -240,7 +241,7 @@ class SuffixExpr(Expr):
         return False
 
 
-def Substring(string: Expr, start: Expr, end: Expr) -> Expr:
+def Substring(string: Union[str, Expr], start: Union[int, Expr], end: Union[int, Expr]) -> Expr:
     """Take a substring of a byte string.
 
     Produces a new byte string consisting of the bytes starting at :code:`start` up to but not
@@ -258,6 +259,7 @@ def Substring(string: Expr, start: Expr, end: Expr) -> Expr:
         end: The ending index for the substring. Must be an integer greater or equal to start, but
             less than or equal to Len(string).
     """
+    string, start, end = map(get_teal_type, [string, start, end])
     return SubstringExpr(
         string,
         start,
@@ -265,7 +267,7 @@ def Substring(string: Expr, start: Expr, end: Expr) -> Expr:
     )
 
 
-def Extract(string: Expr, start: Expr, length: Expr) -> Expr:
+def Extract(string: Union[str, Expr], start: Union[int, Expr], length: Union[int, Expr]) -> Expr:
     """Extract a section of a byte string.
 
     Produces a new byte string consisting of the bytes starting at :code:`start` up to but not
@@ -282,6 +284,8 @@ def Extract(string: Expr, start: Expr, length: Expr) -> Expr:
             :code:`Len(string)`.
         length: The number of bytes to extract. Must be an integer such that :code:`start + length <= Len(string)`.
     """
+    string, start, length = map(get_teal_type, [string, start, length])
+
     return ExtractExpr(
         string,
         start,
@@ -289,7 +293,7 @@ def Extract(string: Expr, start: Expr, length: Expr) -> Expr:
     )
 
 
-def Suffix(string: Expr, start: Expr) -> Expr:
+def Suffix(string: Union[str, Expr], start: Union[int, Expr]) -> Expr:
     """Take a suffix of a byte string.
 
     Produces a new byte string consisting of the suffix of the byte string starting at :code:`start`
@@ -303,6 +307,8 @@ def Suffix(string: Expr, start: Expr) -> Expr:
         string: The byte string.
         start: The starting index for the suffix. Must be an integer less than or equal to :code:`Len(string)`.
     """
+    string, start = map(get_teal_type, [string, start])
+
     return SuffixExpr(
         string,
         start,

--- a/pyteal/ast/substring.py
+++ b/pyteal/ast/substring.py
@@ -241,7 +241,9 @@ class SuffixExpr(Expr):
         return False
 
 
-def Substring(string: Union[str, Expr], start: Union[int, Expr], end: Union[int, Expr]) -> Expr:
+def Substring(
+    string: Union[str, Expr], start: Union[int, Expr], end: Union[int, Expr]
+) -> Expr:
     """Take a substring of a byte string.
 
     Produces a new byte string consisting of the bytes starting at :code:`start` up to but not
@@ -267,7 +269,9 @@ def Substring(string: Union[str, Expr], start: Union[int, Expr], end: Union[int,
     )
 
 
-def Extract(string: Union[str, Expr], start: Union[int, Expr], length: Union[int, Expr]) -> Expr:
+def Extract(
+    string: Union[str, Expr], start: Union[int, Expr], length: Union[int, Expr]
+) -> Expr:
     """Extract a section of a byte string.
 
     Produces a new byte string consisting of the bytes starting at :code:`start` up to but not

--- a/pyteal/ast/ternaryexpr.py
+++ b/pyteal/ast/ternaryexpr.py
@@ -1,4 +1,4 @@
-from typing import Tuple, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING, Union
 
 from ..types import TealType, require_type
 from ..errors import verifyTealVersion
@@ -6,6 +6,7 @@ from ..ir import TealOp, Op, TealBlock
 from .expr import Expr
 from .int import Int
 from .unaryexpr import Len
+from .get_teal_type import get_teal_type
 
 if TYPE_CHECKING:
     from ..compiler import CompileOptions
@@ -60,7 +61,7 @@ class TernaryExpr(Expr):
 TernaryExpr.__module__ = "pyteal"
 
 
-def Ed25519Verify(data: Expr, sig: Expr, key: Expr) -> TernaryExpr:
+def Ed25519Verify(data: Union[str, Expr], sig: Union[str, Expr], key: Union[str, Expr]) -> TernaryExpr:
     """Verify the ed25519 signature of the concatenation ("ProgData" + hash_of_current_program + data).
 
     Args:
@@ -69,6 +70,8 @@ def Ed25519Verify(data: Expr, sig: Expr, key: Expr) -> TernaryExpr:
             Must evalute to bytes.
         key: The 32 byte public key that produced the signature. Must evaluate to bytes.
     """
+    data, sig, key = map(get_teal_type, [data, sig, key])
+    
     return TernaryExpr(
         Op.ed25519verify,
         (TealType.bytes, TealType.bytes, TealType.bytes),
@@ -79,7 +82,7 @@ def Ed25519Verify(data: Expr, sig: Expr, key: Expr) -> TernaryExpr:
     )
 
 
-def SetBit(value: Expr, index: Expr, newBitValue: Expr) -> TernaryExpr:
+def SetBit(value: Union[int, str, Expr], index: Union[int, Expr], newBitValue: Union[int, Expr]) -> TernaryExpr:
     """Set the bit value of an expression at a specific index.
 
     The meaning of index differs if value is an integer or a byte string.
@@ -97,6 +100,8 @@ def SetBit(value: Expr, index: Expr, newBitValue: Expr) -> TernaryExpr:
         index: The index of the bit to set. Must evaluate to uint64.
         newBitValue: The new bit value to set. Must evaluate to the integer 0 or 1.
     """
+    value, index, newBitValue = map(get_teal_type, [value, index, newBitValue])
+
     return TernaryExpr(
         Op.setbit,
         (TealType.anytype, TealType.uint64, TealType.uint64),
@@ -107,7 +112,7 @@ def SetBit(value: Expr, index: Expr, newBitValue: Expr) -> TernaryExpr:
     )
 
 
-def SetByte(value: Expr, index: Expr, newByteValue: Expr) -> TernaryExpr:
+def SetByte(value: Union[str, Expr], index: Union[int, Expr], newByteValue: Union[int, Expr]) -> TernaryExpr:
     """Set a single byte in a byte string from an integer value.
 
     Similar to SetBit, indexing begins at the first byte. For example, :code:`SetByte(Bytes("base16", "0x000000"), Int(0), Int(255))`
@@ -120,6 +125,8 @@ def SetByte(value: Expr, index: Expr, newByteValue: Expr) -> TernaryExpr:
         index: The index of the byte to set. Must evaluate to an integer less than Len(value).
         newByteValue: The new byte value to set. Must evaluate to an integer less than 256.
     """
+    value, index, newByteValue = map(get_teal_type, [value, index, newByteValue])
+
     return TernaryExpr(
         Op.setbyte,
         (TealType.bytes, TealType.uint64, TealType.uint64),

--- a/pyteal/ast/ternaryexpr.py
+++ b/pyteal/ast/ternaryexpr.py
@@ -61,7 +61,9 @@ class TernaryExpr(Expr):
 TernaryExpr.__module__ = "pyteal"
 
 
-def Ed25519Verify(data: Union[str, Expr], sig: Union[str, Expr], key: Union[str, Expr]) -> TernaryExpr:
+def Ed25519Verify(
+    data: Union[str, Expr], sig: Union[str, Expr], key: Union[str, Expr]
+) -> TernaryExpr:
     """Verify the ed25519 signature of the concatenation ("ProgData" + hash_of_current_program + data).
 
     Args:
@@ -71,7 +73,7 @@ def Ed25519Verify(data: Union[str, Expr], sig: Union[str, Expr], key: Union[str,
         key: The 32 byte public key that produced the signature. Must evaluate to bytes.
     """
     data, sig, key = map(get_teal_type, [data, sig, key])
-    
+
     return TernaryExpr(
         Op.ed25519verify,
         (TealType.bytes, TealType.bytes, TealType.bytes),
@@ -82,7 +84,9 @@ def Ed25519Verify(data: Union[str, Expr], sig: Union[str, Expr], key: Union[str,
     )
 
 
-def SetBit(value: Union[int, str, Expr], index: Union[int, Expr], newBitValue: Union[int, Expr]) -> TernaryExpr:
+def SetBit(
+    value: Union[int, str, Expr], index: Union[int, Expr], newBitValue: Union[int, Expr]
+) -> TernaryExpr:
     """Set the bit value of an expression at a specific index.
 
     The meaning of index differs if value is an integer or a byte string.
@@ -112,7 +116,9 @@ def SetBit(value: Union[int, str, Expr], index: Union[int, Expr], newBitValue: U
     )
 
 
-def SetByte(value: Union[str, Expr], index: Union[int, Expr], newByteValue: Union[int, Expr]) -> TernaryExpr:
+def SetByte(
+    value: Union[str, Expr], index: Union[int, Expr], newByteValue: Union[int, Expr]
+) -> TernaryExpr:
     """Set a single byte in a byte string from an integer value.
 
     Similar to SetBit, indexing begins at the first byte. For example, :code:`SetByte(Bytes("base16", "0x000000"), Int(0), Int(255))`


### PR DESCRIPTION
Currently, any method that expects a `pyteal.Bytes` or `pyteal.Int` object will throw an exception when a `str` or `int` is given. This can make some method calls more verbose than they really need to be. For example, `App.globalGet("Key")` is code that one would reasonable expect to work, but since `"key"` is a `str` and not `pyteal.Bytes`, it throws an exception .

This PR implements a function, `get_teal_type` that will return a `pyteal.Int` or `pyteal.Bytes` object given a `int` or `str`, respectively. As demonstrated in the test, `App.globalGet("Key")` now behaves the same as `App.globalGet(Bytes("Key"))`.

# Caveats

* `allow_redefinition = True` was added to `mypy.ini` to prevent mypy from complaining about incorrect types being passed down. Since `get_teal_type` will always return a valid type or throw an exception this isn't a legitimate concern. It's possible that the implementation of these calls could be properly casted to appease mypy, but I think allowing redefinition is a more elegant solution. The reason mypy doesn't allow redefinition by default is to improve readability, but having a bunch of casts would likely hurt readability more than help it. 


* I also put this function in it's own file because I wasn't sure where else it would fit. If there's a preexisting file that this could go into, we should probably do so. 