### PR TITLE
Print diff of `__init__.pyi`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 script:
   - pytest
   - mypy pyteal
-  - python3 -c "import pyteal" scripts/generate_init.py --check
+  - python3 scripts/generate_init.py --check
   - black --check .
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 script:
   - pytest
   - mypy pyteal
-  - python3 scripts/generate_init.py --check
+  - python3 -c "import pyteal" scripts/generate_init.py --check
   - black --check .
 
 jobs:

--- a/pyteal/__init__.pyi
+++ b/pyteal/__init__.pyi
@@ -23,6 +23,7 @@ __all__ = [
     "Bytes",
     "Int",
     "EnumInt",
+    "MethodSignature",
     "Arg",
     "TxnType",
     "TxnField",

--- a/scripts/generate_init.py
+++ b/scripts/generate_init.py
@@ -56,16 +56,14 @@ def is_different(regen: str) -> bool:
 
     curr_lines = regen.splitlines(keepends=True)
 
-    diff = list(difflib.unified_diff(
-        orig_lines,
-        curr_lines,
-        fromfile="original",
-        tofile="generated",
-        n=3
-    ))
+    diff = list(
+        difflib.unified_diff(
+            orig_lines, curr_lines, fromfile="original", tofile="generated", n=3
+        )
+    )
 
     if len(diff) != 0:
-        print(''.join(diff), end="")
+        print("".join(diff), end="")
         return True
 
     return False

--- a/scripts/generate_init.py
+++ b/scripts/generate_init.py
@@ -1,4 +1,4 @@
-import argparse, os, sys
+import argparse, os, sys, difflib
 from pyteal import __all__ as static_all
 
 
@@ -30,7 +30,7 @@ py_file = "__init__.py"
 init_file = os.path.join(orig_dir, py_file)
 
 
-def generate_tmp():
+def generate_init_pyi() -> str:
     with open(init_file, "r") as f:
         init_contents = f.read()
 
@@ -47,19 +47,31 @@ def generate_tmp():
     )
 
 
-def is_different(regen):
+def is_different(regen: str) -> bool:
     if not os.path.exists(orig_file):
         return True
 
     with open(orig_file, "r") as f:
         orig_lines = f.readlines()
 
-    curr_lines = regen.split("\n")
+    curr_lines = regen.splitlines(keepends=True)
 
-    return orig_lines == curr_lines
+    diff = list(difflib.unified_diff(
+        orig_lines,
+        curr_lines,
+        fromfile="original",
+        tofile="generated",
+        n=3
+    ))
+
+    if len(diff) != 0:
+        print(''.join(diff), end="")
+        return True
+
+    return False
 
 
-def overwrite(regen):
+def overwrite(regen: str):
     with open(orig_file, "w") as f:
         f.write(regen)
 
@@ -74,7 +86,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    regen = generate_tmp()
+    regen = generate_init_pyi()
 
     if args.check:
         if is_different(regen):


### PR DESCRIPTION
For some unknown reason the `scripts/generate_init.py` script was failing to detect differences in the `pyteal/__init__.pyi` file. To fix it, and to improve the error message when there is a difference, I used Python's `difflib` module to create a human-readable diff.

For example, prior to updating `pyteal/__init__.pyi` in this commit, the new script would output:

```
$ python scripts/generate_init.py --check
--- original
+++ generated
@@ -23,6 +23,7 @@
     "Bytes",
     "Int",
     "EnumInt",
+    "MethodSignature",
     "Arg",
     "TxnType",
     "TxnField",
The __init__.pyi needs to be regenerated. Please run scripts/generate_init.py
```