### PR TITLE
Change Subroutine Wrapped Callable to a class with call method

### DIFF
--- a/pyteal/__init__.pyi
+++ b/pyteal/__init__.pyi
@@ -114,6 +114,7 @@ __all__ = [
     "SubroutineDefinition",
     "SubroutineDeclaration",
     "SubroutineCall",
+    "SubroutineFnWrapper",
     "ScratchSlot",
     "ScratchLoad",
     "ScratchStore",

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -111,6 +111,7 @@ from .subroutine import (
     SubroutineDefinition,
     SubroutineDeclaration,
     SubroutineCall,
+    SubroutineFnWrapper,
 )
 from .while_ import While
 from .for_ import For
@@ -221,6 +222,7 @@ __all__ = [
     "SubroutineDefinition",
     "SubroutineDeclaration",
     "SubroutineCall",
+    "SubroutineFnWrapper",
     "ScratchSlot",
     "ScratchLoad",
     "ScratchStore",

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -167,6 +167,27 @@ class SubroutineCall(Expr):
 SubroutineCall.__module__ = "pyteal"
 
 
+class SubroutineFnWrapper:
+    def __init__(self, fnImplementation: Callable[..., Expr], returnType: TealType, name: str = None) -> None:
+        self.fnImplementation = fnImplementation
+        self.returnType = returnType
+        self.name = name
+
+    def __call__(self, *args: Expr, **kwds) -> Expr:
+        # TODO
+        return Seq()
+
+    def type_of(self):
+        return self.returnType
+
+    def has_return(self):
+        # TODO
+        return True
+
+
+SubroutineFnWrapper.__module__ = "pyteal"
+
+
 class Subroutine:
     """Used to create a PyTeal subroutine from a Python function.
 

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -187,6 +187,9 @@ class SubroutineFnWrapper:
             )
         return self.subroutine.invoke(list(args))
 
+    def name(self) -> str:
+        return self.subroutine.name()
+
     def type_of(self):
         return self.subroutine.getDeclaration().type_of()
 

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -168,7 +168,12 @@ SubroutineCall.__module__ = "pyteal"
 
 
 class SubroutineFnWrapper:
-    def __init__(self, fnImplementation: Callable[..., Expr], returnType: TealType, name: str = None) -> None:
+    def __init__(
+        self,
+        fnImplementation: Callable[..., Expr],
+        returnType: TealType,
+        name: str = None,
+    ) -> None:
         self.fnImplementation = fnImplementation
         self.returnType = returnType
         self.name = name

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -1,8 +1,7 @@
-from typing import Callable, Tuple, List, Optional, cast, TYPE_CHECKING
+from typing import Callable, List, Optional, TYPE_CHECKING
 from inspect import Parameter, signature
-from functools import wraps
 
-from ..types import TealType, require_type
+from ..types import TealType
 from ..ir import TealOp, Op, TealBlock
 from ..errors import TealInputError, verifyTealVersion
 from .expr import Expr

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -148,7 +148,7 @@ def test_decorator():
     def mySubroutine(a):
         return Return()
 
-    assert callable(mySubroutine)
+    assert isinstance(mySubroutine, SubroutineFnWrapper)
 
     invocation = mySubroutine(Int(1))
     assert isinstance(invocation, SubroutineCall)


### PR DESCRIPTION
# Summary

Previous implementation of subroutine wraps a function implementation and return a callable object, allowing for subroutine syntax definition and subroutine call syntax. But this does not allow for much information extractable about underlying subroutine.

This PR allows for more information (name, return type, has return) about the subroutine extractable.