### PR TITLE
Subroutine Type Annotations

### DIFF
--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Callable, List, Optional, TYPE_CHECKING
 from inspect import Parameter, signature
 
@@ -47,6 +48,14 @@ class SubroutineDefinition:
                     "Function has a parameter with a default value, which is not allowed in a subroutine: {}".format(
                         name
                     )
+                )
+
+        for var, var_type in implementation.__annotations__.items():
+            if var_type != Expr:
+                stub = "return " if var == 'Return' else ("parameter " + var)
+                    
+                raise TealInputError(
+                    "Function has {} of disallowed type {}. Only type Expr is allowed".format(stub, var_type)
                 )
 
         self.implementation = implementation

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -51,7 +51,7 @@ class SubroutineDefinition:
 
         for var, var_type in implementation.__annotations__.items():
             if var_type != Expr:
-                stub = "return " if var == "Return" else ("parameter " + var)
+                stub = "Return" if var == "return" else ("parameter " + var)
 
                 raise TealInputError(
                     "Function has {} of disallowed type {}. Only type Expr is allowed".format(

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Callable, List, Optional, TYPE_CHECKING
 from inspect import Parameter, signature
 

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -52,10 +52,12 @@ class SubroutineDefinition:
 
         for var, var_type in implementation.__annotations__.items():
             if var_type != Expr:
-                stub = "return " if var == 'Return' else ("parameter " + var)
-                    
+                stub = "return " if var == "Return" else ("parameter " + var)
+
                 raise TealInputError(
-                    "Function has {} of disallowed type {}. Only type Expr is allowed".format(stub, var_type)
+                    "Function has {} of disallowed type {}. Only type Expr is allowed".format(
+                        stub, var_type
+                    )
                 )
 
         self.implementation = implementation

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -50,7 +50,7 @@ class SubroutineDefinition:
                 )
 
         for var, var_type in implementation.__annotations__.items():
-            if var_type != Expr:
+            if var_type is not Expr:
                 stub = "Return" if var == "return" else ("parameter " + var)
 
                 raise TealInputError(

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -110,7 +110,8 @@ def test_subroutine_definition_invalid():
     for case, msg in cases:
         with pytest.raises(TealInputError) as e:
             SubroutineDefinition(case, TealType.none)
-        assert msg in str(e), "failed for case [{}]".format(case)
+
+            assert msg in str(e), "failed for case [{}]".format(case)
 
 
 def test_subroutine_declaration():

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -28,6 +28,9 @@ def test_subroutine_definition():
     lam2Args = lambda a1, a2: Return()
     lam10Args = lambda a1, a2, a3, a4, a5, a6, a7, a8, a9, a10: Return()
 
+    def fnWithExprAnnotations(a: Expr, b: Expr) -> Expr:
+        return Return()
+
     cases = (
         (fn0Args, 0, "fn0Args"),
         (fn1Args, 1, "fn1Args"),
@@ -37,6 +40,7 @@ def test_subroutine_definition():
         (lam1Args, 1, "<lambda>"),
         (lam2Args, 2, "<lambda>"),
         (lam10Args, 10, "<lambda>"),
+        (fnWithExprAnnotations, 2, "fnWithExprAnnotations")
     )
 
     for (fn, numArgs, name) in cases:
@@ -72,12 +76,21 @@ def test_subroutine_definition_invalid():
     def fnWithVariableArgs(a, *b):
         return Return()
 
+    def fnWithNonExprReturnAnnotation(a, b) -> TealType.uint64:
+        return Return()
+
+
+    def fnWithNonExprParamAnnotation(a, b: TealType.uint64):
+        return Return()
+
     cases = (
         1,
         None,
         fnWithDefaults,
         fnWithKeywordArgs,
         fnWithVariableArgs,
+        fnWithNonExprReturnAnnotation,
+        fnWithNonExprParamAnnotation,
     )
 
     for case in cases:

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -31,14 +31,11 @@ def test_subroutine_definition():
     def fnWithExprAnnotations(a: Expr, b: Expr) -> Expr:
         return Return()
 
-
     def fnWithOnlyReturnExprAnnotations(a, b) -> Expr:
         return Return()
 
-
     def fnWithOnlyArgExprAnnotations(a: Expr, b: Expr):
         return Return()
-
 
     def fnWithPartialExprAnnotations(a, b: Expr) -> Expr:
         return Return()

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -79,7 +79,6 @@ def test_subroutine_definition_invalid():
     def fnWithNonExprReturnAnnotation(a, b) -> TealType.uint64:
         return Return()
 
-
     def fnWithNonExprParamAnnotation(a, b: TealType.uint64):
         return Return()
 

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -83,34 +83,34 @@ def test_subroutine_definition_invalid():
         return Return()
 
     cases = (
-        (1, "TealInputError('Input to SubroutineDefinition is not callable')"),
-        (None, "TealInputError('Input to SubroutineDefinition is not callable')"),
+        (1, "TealInputError('Input to SubroutineDefinition is not callable'"),
+        (None, "TealInputError('Input to SubroutineDefinition is not callable'"),
         (
             fnWithDefaults,
-            "TealInputError('Function has a parameter with a default value, which is not allowed in a subroutine: b')",
+            "TealInputError('Function has a parameter with a default value, which is not allowed in a subroutine: b'",
         ),
         (
             fnWithKeywordArgs,
-            "TealInputError('Function has a parameter type that is not allowed in a subroutine: parameter b with type KEYWORD_ONLY')",
+            "TealInputError('Function has a parameter type that is not allowed in a subroutine: parameter b with type KEYWORD_ONLY'",
         ),
         (
             fnWithVariableArgs,
-            "TealInputError('Function has a parameter type that is not allowed in a subroutine: parameter b with type VAR_POSITIONAL')",
+            "TealInputError('Function has a parameter type that is not allowed in a subroutine: parameter b with type VAR_POSITIONAL'",
         ),
         (
             fnWithNonExprReturnAnnotation,
-            "TealInputError('Function has Return of disallowed type TealType.uint64. Only type Expr is allowed')",
+            "TealInputError('Function has Return of disallowed type TealType.uint64. Only type Expr is allowed'",
         ),
         (
             fnWithNonExprParamAnnotation,
-            "TealInputError('Function has parameter b of disallowed type TealType.uint64. Only type Expr is allowed')",
+            "TealInputError('Function has parameter b of disallowed type TealType.uint64. Only type Expr is allowed'",
         ),
     )
 
     for case, msg in cases:
         with pytest.raises(TealInputError) as e:
             SubroutineDefinition(case, TealType.none)
-        assert msg in str(e)
+        assert msg in str(e), "failed for case [{}]".format(case)
 
 
 def test_subroutine_declaration():

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -40,7 +40,7 @@ def test_subroutine_definition():
         (lam1Args, 1, "<lambda>"),
         (lam2Args, 2, "<lambda>"),
         (lam10Args, 10, "<lambda>"),
-        (fnWithExprAnnotations, 2, "fnWithExprAnnotations")
+        (fnWithExprAnnotations, 2, "fnWithExprAnnotations"),
     )
 
     for (fn, numArgs, name) in cases:

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -31,6 +31,18 @@ def test_subroutine_definition():
     def fnWithExprAnnotations(a: Expr, b: Expr) -> Expr:
         return Return()
 
+
+    def fnWithOnlyReturnExprAnnotations(a, b) -> Expr:
+        return Return()
+
+
+    def fnWithOnlyArgExprAnnotations(a: Expr, b: Expr):
+        return Return()
+
+
+    def fnWithPartialExprAnnotations(a, b: Expr) -> Expr:
+        return Return()
+
     cases = (
         (fn0Args, 0, "fn0Args"),
         (fn1Args, 1, "fn1Args"),
@@ -41,6 +53,9 @@ def test_subroutine_definition():
         (lam2Args, 2, "<lambda>"),
         (lam10Args, 10, "<lambda>"),
         (fnWithExprAnnotations, 2, "fnWithExprAnnotations"),
+        (fnWithOnlyReturnExprAnnotations, 2, "fnWithOnlyReturnExprAnnotations"),
+        (fnWithOnlyArgExprAnnotations, 2, "fnWithOnlyArgExprAnnotations"),
+        (fnWithPartialExprAnnotations, 2, "fnWithPartialExprAnnotations"),
     )
 
     for (fn, numArgs, name) in cases:

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -83,18 +83,34 @@ def test_subroutine_definition_invalid():
         return Return()
 
     cases = (
-        1,
-        None,
-        fnWithDefaults,
-        fnWithKeywordArgs,
-        fnWithVariableArgs,
-        fnWithNonExprReturnAnnotation,
-        fnWithNonExprParamAnnotation,
+        (1, "TealInputError('Input to SubroutineDefinition is not callable')"),
+        (None, "TealInputError('Input to SubroutineDefinition is not callable')"),
+        (
+            fnWithDefaults,
+            "TealInputError('Function has a parameter with a default value, which is not allowed in a subroutine: b')",
+        ),
+        (
+            fnWithKeywordArgs,
+            "TealInputError('Function has a parameter type that is not allowed in a subroutine: parameter b with type KEYWORD_ONLY')",
+        ),
+        (
+            fnWithVariableArgs,
+            "TealInputError('Function has a parameter type that is not allowed in a subroutine: parameter b with type VAR_POSITIONAL')",
+        ),
+        (
+            fnWithNonExprReturnAnnotation,
+            "TealInputError('Function has Return of disallowed type TealType.uint64. Only type Expr is allowed')",
+        ),
+        (
+            fnWithNonExprParamAnnotation,
+            "TealInputError('Function has parameter b of disallowed type TealType.uint64. Only type Expr is allowed')",
+        ),
     )
 
-    for case in cases:
-        with pytest.raises(TealInputError):
+    for case, msg in cases:
+        with pytest.raises(TealInputError) as e:
             SubroutineDefinition(case, TealType.none)
+        assert msg in str(e)
 
 
 def test_subroutine_declaration():


### PR DESCRIPTION
Assert that `implementation` param of `SubroutineDefinition` has the expected annotation types.

The followup PR #183 expands the allowable annotations types as needed.