### PR TITLE
Add Github action to generate docset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,30 @@ jobs:
           mypy pyteal
           python3 -c "import pyteal" scripts/generate_init.py --check
           black --check .
+  build-docset:
+    runs-on: ubuntu-20.04
+    container: python:3.9-slim
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install pip dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r docs/requirements.txt
+          pip install doc2dash
+      - name: Make docs
+        run: |
+          cd docs
+          make html
+          doc2dash --name pyteal --index-page index.html --online-redirect-url https://pyteal.readthedocs.io/en/ _build/html
+          tar -czvf pyteal.docset.tar.gz pyteal.docset
+      - name: Archive docset
+        uses: actions/upload-artifact@v2
+        with:
+          name: pyteal.docset
+          path: docs/pyteal.docset.tar.gz
   upload-to-pypi:
     runs-on: ubuntu-20.04
     needs: ['build-test']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           black --check .
   build-docset:
     runs-on: ubuntu-20.04
-    container: python:3.9-slim
+    container: python:3.9  # Needs `make`, can't be slim
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
Analogous to [this one](https://github.com/algorand/py-algorand-sdk/pull/285) for the Python SDK.

This PR adds a CircleCI build step to generate docsets for [Kapeli's Dash](https://kapeli.com/dash) and [zeal](https://zealdocs.org/). The result is uploaded as a Github action artifact.

Looks like this:
<img width="1131" alt="Screenshot 2022-02-17 at 10 34 48" src="https://user-images.githubusercontent.com/1721633/154447322-3674e522-3772-4804-baad-00cd6ce64796.png">

I used to do this locally for me, so though to share it. If it's not useful we can just close this.