### PR TITLE
Add docs README to explain testing procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ If needed, it's possible to install directly from the latest commit on master to
 
 ### Documentation
 
-[PyTeal Docs](https://pyteal.readthedocs.io/)
+* [PyTeal Docs](https://pyteal.readthedocs.io/)
+* `docs/` ([README](docs/README.md)) contains raw docs.
 
 ### Development Setup
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,8 @@ Here's the process:
 * Generate HTML docs:  `make html`.
 * If successful, generated HTML is available in `docs/_build/html`.
 
-Additionally, each PR commit generates HTML docs via https://github.com/algorand/pyteal/blob/master/.github/workflows/build.yml.
+Additionally, each PR commit generates HTML docs via [Github Actions](../.github/workflows/build.yml).
 
 ## Releasing
 
-Production docs live at https://pyteal.readthedocs.io/en/stable/.  Github actions automate the releasing process:  https://github.com/algorand/pyteal/blob/master/.github/workflows/build.yml.
+Production docs live at https://pyteal.readthedocs.io/en/stable/.  [Github Actions](../.github/workflows/build.yml) automate the releasing process.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Docs
+
+`docs/` contains end user documentation geared towards writing smart contracts with PyTeal.  The README explains how to edit docs.
+
+## Local testing
+
+Pyteal uses [Sphinx](https://github.com/sphinx-doc/sphinx) to generate HTML from RST files.  Test changes by generating HTML and viewing with a web browser.
+
+Here's the process:
+* Perform one-time environment setup:
+  * Create a virtual environment isolated to `docs/`.  Do _not_ mix with a top-level virtual environment.
+  * Install dependencies via `pip`.
+* Generate HTML docs:  `make html`.
+* If successful, generated HTML is available in `docs/_build/html`.
+
+Additionally, each PR commit generates HTML docs via https://github.com/algorand/pyteal/blob/master/.github/workflows/build.yml.
+
+## Releasing
+
+Production docs live at https://pyteal.readthedocs.io/en/stable/.  Github actions automate the releasing process:  https://github.com/algorand/pyteal/blob/master/.github/workflows/build.yml.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@ Pyteal uses [Sphinx](https://github.com/sphinx-doc/sphinx) to generate HTML from
 
 Here's the process:
 * Perform one-time environment setup:
-  * Create a virtual environment isolated to `docs/`.  Do _not_ mix with a top-level virtual environment.
-  * Install dependencies via `pip`.
+  * Activate the top-level virtual environment.
+  * Install dependencies: `pip install -r requirements.txt`.
 * Generate HTML docs:  `make html`.
 * If successful, generated HTML is available in `docs/_build/html`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,4 +17,4 @@ Additionally, each PR commit generates HTML docs via [Github Actions](../.github
 
 ## Releasing
 
-Production docs live at https://pyteal.readthedocs.io/en/stable/.  [Github Actions](../.github/workflows/build.yml) automate the releasing process.
+Production docs live at https://pyteal.readthedocs.io/en/stable/.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,9 +28,8 @@ author = "Algorand"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-# extensions = ['m2r']
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
-source_suffix = [".rst", ".md"]
+source_suffix = [".rst"]
 master_doc = "index"
 
 napoleon_include_init_with_doc = True
@@ -54,4 +53,4 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-m2r
 sphinx_rtd_theme
 py-algorand-sdk


### PR DESCRIPTION
Add `docs/` README to explain testing procedure.

While working on https://github.com/algorand/pyteal/pull/204, I stumbled to test changes locally.  I provide the PR in case folks think the instructions are a worthwhile addition.  If folks think the process is sufficiently clear, I'll close the PR.