### PR TITLE
Demo flake8 usage

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+
+extend-ignore =
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,
+ignore = 
+    # Allow longer lines permissively.
+    E501,
+per-file-ignores =
+    # Allow tests to import permissively.
+    *_test.py:F403,F405
+    # Disable checks where black is disabled via `# fmt: off`.
+    pyteal/ir/ops.py:E221,E241

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 black==21.7b0
+flake8
+flake8-black
 mypy==0.910
+pep8-naming
 pytest
 pytest-timeout
 py-algorand-sdk


### PR DESCRIPTION
Demonstrate linting with [flake8](https://flake8.pycqa.org/en/latest/) so that we can assess how much further (if at all) we'd like to pursue the topic.

Notes:
* _If_ we wish to go further, I'll open a ticket.  Regardless, I expect to close the PR after a round of discussion.
* I'm loosely aware [pylint](https://pylint.org/) is a more mature linting tool.  I opted for flake8 after a brief docs survey and some googling.  My perception is flake8 might be easier to setup though on some long-term horizon, pylint might be more comprehensive. 
* Without having heard feedback, my initial takeaway is:  It's worthwhile to integrate flake8 without `pep8-naming`.  Here's why:
  * I think it'll address some common PR nitpicks (e.g. unused imports).
  * Moves the ball towards enforcing consistent repo standards so that we don't have to think abuot it.
  * I think it's low cost to integrate with CI tooling.  And/or a script can be added to provide convenience methods for running some vs all tooling (e.g. mypy, pytest, black, etc) locally + CI.
  * Over time, I think we'll want to consider how `pep8-naming` or some other uniform naming convention approach can be implemented.  But, I believe it's too difficult (for a number of reasons) to implement _today_.

Demo results:
* There's 3 summary results to consider for `flake8 pyteal`:
  *  [flake8-01-default.log](https://github.com/algorand/pyteal/files/8155635/flake8-01-default.log) - Out-of-the-box behavior without customization.
  * [flake8-02-excludes-added.log](https://github.com/algorand/pyteal/files/8155636/flake8-02-excludes-added.log) - Applies the PR configuration _without_  `pep8-naming` installed.
  * [flake8-03-enforce-pep8-naming.log](https://github.com/algorand/pyteal/files/8155637/flake8-03-enforce-pep8-naming.log) - Adds `pep8-naming` to the PR's configuration.
* Here's the violation count by scenario:
```
~/dev/pyteal flake8_trial *1 ─────────────────────────────────────────────────────────────────  pyteal 09:31:48 AM
❯ wc -l /tmp/flake8-*-*
    9833 /tmp/flake8-01-default.log
      84 /tmp/flake8-02-excludes-added.log
    1111 /tmp/flake8-03-enforce-pep8-naming.log
   11028 total
```