### PR TITLE
Refactor parameter validation into method with explanatory comment

### DIFF
--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -79,7 +79,7 @@ class SubroutineDefinition:
     @staticmethod
     def _validate_parameter_type(
         user_defined_annotations: dict, parameter_name: str
-    ) -> Type[Expr]:
+    ) -> Type[Union[Expr, ScratchVar]]:
         ptype = user_defined_annotations.get(parameter_name, None)
         if ptype is None:
             # Without a type annotation, `SubroutineDefinition` presumes an implicit `Expr` declaration rather than these alternatives:

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -77,7 +77,9 @@ class SubroutineDefinition:
         self.__name = self.implementation.__name__ if nameStr is None else nameStr
 
     @staticmethod
-    def _validate_parameter_type(user_defined_annotations: dict, parameter_name: str):
+    def _validate_parameter_type(
+        user_defined_annotations: dict, parameter_name: str
+    ) -> Type[Expr]:
         ptype = user_defined_annotations.get(parameter_name, None)
         if ptype is None:
             # Without a type annotation, `SubroutineDefinition` presumes an implicit `Expr` declaration rather than these alternatives:

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -77,7 +77,9 @@ class SubroutineDefinition:
         self.__name = self.implementation.__name__ if nameStr is None else nameStr
 
     @staticmethod
-    def _validate_parameter_type(user_defined_annotations: OrderedDict, parameter_name: str):
+    def _validate_parameter_type(
+        user_defined_annotations: dict[str, str], parameter_name: str
+    ):
         ptype = user_defined_annotations.get(parameter_name, None)
         if ptype is None:
             # Without a type annotation, `SubroutineDefinition` presumes an implicit `Expr` declaration rather than these alternatives:

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -77,9 +77,7 @@ class SubroutineDefinition:
         self.__name = self.implementation.__name__ if nameStr is None else nameStr
 
     @staticmethod
-    def _validate_parameter_type(
-        user_defined_annotations: dict[str, str], parameter_name: str
-    ):
+    def _validate_parameter_type(user_defined_annotations: dict, parameter_name: str):
         ptype = user_defined_annotations.get(parameter_name, None)
         if ptype is None:
             # Without a type annotation, `SubroutineDefinition` presumes an implicit `Expr` declaration rather than these alternatives:


### PR DESCRIPTION
Refactors parameter type checking validation in #198 into a separate method with explanatory note about implicit `Expr` declaration.

Consider the PR optional.  If we don't feel it's an improvement, feel welcomed to close it.

Motivation:  
* During PR review, I opened a question on the topic:  https://github.com/algorand/pyteal/pull/198#discussion_r815906297.  
* Since the implicit declaration topic took me some time to understand, I supplied an inline comment.
* The method refactoring is optional.  I provided it to eliminate mutation of `expected_arg_type` and secondarily, to shorten constructor definition.

