### PR TITLE
Fix build script invocation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install pip dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
       - name: Build and Test
         run: |
           pytest
           mypy pyteal
-          python3 -c "import pyteal" scripts/generate_init.py --check
+          python scripts/generate_init.py --check
           black --check .
   build-docset:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Currently the build step `python3 -c "import pyteal" scripts/generate_init.py --check` does not actually invoke `scripts/generate_init.py`, it just runs `import pyteal` then exits.

This PR fixes that.

You can verify by seeing that the build now includes a line that says `No changes in __init__.py`, which is printed from `scripts/generate_init.py`.

In order to make the script work in CI, I also added a line to install the current version of pyteal in editable state.