### PR TITLE
Reorder CI build steps to change source files before running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           pip install -e .
       - name: Build and Test
         run: |
-          pytest
-          mypy pyteal
           python scripts/generate_init.py --check
           black --check .
+          mypy pyteal
+          pytest
   build-docset:
     runs-on: ubuntu-20.04
     container: python:3.9  # Needs `make`, can't be slim


### PR DESCRIPTION
Optionally extends #224 to resorder CI build steps.  PR proposes the following ordering constraints:
* Finish all source code modifications before running tests.  Rationale:  A source code modification _can_ cause test behavior to change.
* Run type checking before tests.  Rationale:  Type checking issues happen before runtime (e.g. test runs).

If the PR feels like it's opening up a debate, I'll happily close the PR.  
* I'm _not_ looking to spend much time here. I only provided the PR because #224 is in the same neighborhood, and Github won't allow a multi-line _suggestion_.
* I'm not attached to the PR because I think #218 offers another opportunity to circle back.