### PR TITLE
Bring #225 to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           pip install -e .
       - name: Build and Test
         run: |
-          pytest
-          mypy pyteal
           python scripts/generate_init.py --check
           black --check .
+          mypy pyteal
+          pytest
   build-docset:
     runs-on: ubuntu-20.04
     container: python:3.9  # Needs `make`, can't be slim


### PR DESCRIPTION
Brings #225 to `master`. 

* #225 is merged into `feature/abi` and I thought it'd make sense to reflect the `build.yml` change into `master`. 
* At least as far as I understand, the squash-and-merge commit in #224 prevents cherry picking the specific change.  So, I've reproduced the diff.  If that's considered painful, then let's close the PR and hold until `feature/abi` is merged.