### PR TITLE
Ignore tests generating TEAL file outputs used for expected comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+# Tests generating TEAL output to compared against an expected example.
+tests/teal/*.teal
+!tests/teal/*_expected.teal
+
 # Translations
 *.mo
 *.pot


### PR DESCRIPTION
Adds gitignore for select tests generating TEAL file outputs that should _not_ be versioned.

* Credit to @tzaffi for supplying the change.  I simply packaged the PR.
* Here's an example of local state _before_ applying the PR:

```
~/dev/pyteal master ⇡2 *3 ───────────────────────────────────────────────────────────────────  pyteal 12:58:24 PM
❯ pytest tests
=============================================== test session starts ===============================================
platform darwin -- Python 3.10.2, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/michael/dev/pyteal
plugins: timeout-2.1.0
collected 15 items

tests/compile_test.py ...........                                                                           [ 73%]
tests/module_test.py .                                                                                      [ 80%]
tests/pass_by_ref_test.py ...                                                                               [100%]

=============================================== 15 passed in 0.76s ================================================

~/dev/pyteal master ⇡2 *3 ?9 ────────────────────────────────────────────────────────────────  pyteal 12:58:28 PM
❯ gs
# On branch: master...origin/master  |  +2  |  [*] => $e*
#
➤ Untracked files
#
#      untracked: [1] tests/teal/fac_by_ref.teal
#      untracked: [2] tests/teal/sub_even.teal
#      untracked: [3] tests/teal/sub_fastfib.teal
#      untracked: [4] tests/teal/sub_logcat.teal
#      untracked: [5] tests/teal/sub_logcat_dynamic.teal
#      untracked: [6] tests/teal/sub_mixed.teal
#      untracked: [7] tests/teal/sub_slowfib.teal
#      untracked: [8] tests/teal/swapper.teal
#      untracked: [9] tests/teal/wilt_the_stilt.teal
#
```