### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,6 @@ For each of our repositories we use the same model for contributing code. Develo
 
 # Code Guidelines
 
-We recommand the contributing code following [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
+We recommend the contributing code following [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
 
 [issues_url]: https://github.com/algorand/pyteal/issues


### PR DESCRIPTION
Fixes a typo I observed in `CONTRIBUTING.md` while reviewing docs.