### PR TITLE
Merge #227 into feature/abi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+# Tests generating TEAL output to compared against an expected example.
+tests/teal/*.teal
+!tests/teal/*_expected.teal
+
 # Translations
 *.mo
 *.pot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,6 @@ For each of our repositories we use the same model for contributing code. Develo
 
 # Code Guidelines
 
-We recommand the contributing code following [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
+We recommend the contributing code following [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
 
 [issues_url]: https://github.com/algorand/pyteal/issues


### PR DESCRIPTION
Merges #227 into `feature/abi` to update gitignore.

Since there's multiple branches based off of `feature/abi`, I'm providing the PR instead of pushing to the branch for increased awareness.  Feel welcomed to merge on approval.