### PR TITLE
Refactor Uint8.set to make data size a first class concept

### DIFF
--- a/pyteal/ast/abi/sized.py
+++ b/pyteal/ast/abi/sized.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Union
+from .. import Expr
+from ..assert_ import Assert
+from pyteal.ast import Int, Seq, ScratchVar
+
+
+@dataclass(frozen=True)
+class SizedExpr:
+    """Provides a wrapper class to tag `Expr`s with known ABI data sizes.
+
+    Knowing the data size removes the need for a runtime `Assert` confirming it fits into the ScratchVar."""
+
+    underlying: Expr
+
+    @staticmethod
+    def store_into(
+        u: Union[Expr, "SizedExpr"], s: ScratchVar, supported_bit_size: int
+    ) -> Expr:
+        return (
+            s.store(u.underlying)
+            if isinstance(u, SizedExpr)
+            else Seq(s.store(u), Assert(s.load() < Int(2 ** supported_bit_size)))
+        )

--- a/pyteal/ast/abi/uint.py
+++ b/pyteal/ast/abi/uint.py
@@ -73,7 +73,7 @@ class Uint8(Uint):
                 # There's insufficient evidence to attempt resolution.
                 return cast(Expr, value)
             else:
-                raise TypeError(f"Unsupported type: {value = } with { type(value) = }")
+                raise TypeError(f"Unsupported type: {type(value)}")
 
         r = resolve_storage_value()
         return SizedExpr.store_into(r, self.stored_value, self.bit_size)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mypy==0.931
 pytest
 pytest-timeout
 py-algorand-sdk
+types-dataclasses


### PR DESCRIPTION
Optionally proposes a refactoring of `Uint8.set` to isolate the storage data size as a first class concept.

Rationale:
* `Uint8` is my introduction to PyTeal ABI support.  I found myself spending _some_ time understanding `Uint8.set` implementation and incrementally refactored for my comprehension.  It's quite possible that I'm _just_ unfamiliar with the space.  
* In case folks feel it's a sufficient improvement, I thought I'd present the PR while the content is fresh in my mind.  If we'd prefer to keep as is, I'll happily close the PR.

Notes:
* I didn't extend the change to other `Uint` subclasses because it's unclear we want the change.  _If_ we want the change, I can extend the concept in a follow on PR.