### PR TITLE
Merge #231 into abi-indexable-types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install pip dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
       - name: Build and Test
         run: |
-          pytest
-          mypy pyteal
-          python3 -c "import pyteal" scripts/generate_init.py --check
+          python scripts/generate_init.py --check
           black --check .
+          mypy pyteal
+          pytest
   build-docset:
     runs-on: ubuntu-20.04
     container: python:3.9  # Needs `make`, can't be slim

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+# Tests generating TEAL output to compared against an expected example.
+tests/teal/*.teal
+!tests/teal/*_expected.teal
+
 # Translations
 *.mo
 *.pot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,6 @@ For each of our repositories we use the same model for contributing code. Develo
 
 # Code Guidelines
 
-We recommand the contributing code following [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
+We recommend the contributing code following [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
 
 [issues_url]: https://github.com/algorand/pyteal/issues

--- a/pyteal/__init__.pyi
+++ b/pyteal/__init__.pyi
@@ -170,5 +170,6 @@ __all__ = [
     "UnaryExpr",
     "While",
     "WideRatio",
+    "abi",
     "compileTeal",
 ]


### PR DESCRIPTION
Merges #231 into `abi-indexable-types`.  

I provide the PR because the diff in `pyteal/__init__.pyi` prevents IDE type resolution.  And I assume others will run into the same issue.