### PR TITLE
ScratchVar: Disallow @Subroutine Recursion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 
 # IDE
 .idea
+.vscode

--- a/docs/control_structures.rst
+++ b/docs/control_structures.rst
@@ -364,6 +364,27 @@ argument is even, but uses recursion to do so.
                 .Else(recursiveIsEven(i - Int(2)))
             )
 
+Recursion and `ScratchVar`'s
+----------------------------
+
+Recursion with parameters of type `ScratchVar` is disallowed. For example, the following
+subroutine is considered illegal and attempting compilation will result in a `TealInputError`:
+
+.. code-block:: python
+
+        @Subroutine(TealType.none)
+        def ILLEGAL_recursion(i: ScratchVar):
+            return (
+                If(i.load() == Int(0))
+                .Then(i.store(Int(1)))
+                .ElseIf(i.load() == Int(1))
+                .Then(i.store(Int(0)))
+                .Else(Seq(i.store(i.load() - Int(2)), ILLEGAL_recursion(i)))
+            )
+
+
+
+
 Exiting Subroutines
 -------------------
 

--- a/pyteal/ast/scratchvar.py
+++ b/pyteal/ast/scratchvar.py
@@ -59,7 +59,7 @@ ScratchVar.__module__ = "pyteal"
 class DynamicScratchVar(ScratchVar):
     """
     Example of Dynamic Scratch space whereby the slot index is picked up from the stack:
-        .. code-block:: python1
+        .. code-block:: python
 
             player_score = DynamicScratchVar(TealType.uint64)
 
@@ -97,6 +97,11 @@ class DynamicScratchVar(ScratchVar):
         Followup `store`, `load` and `index` operations will use the provided `index_var` until
         `set_index()` is called again to reset the referenced ScratchVar.
         """
+        # Explanatory comment per Issue #242: Preliminary evidence shows that letting users
+        # pass in any ScratchVar subtype (i.e. DynamicScratchVar) may in fact work.
+        # However, we are leaving this guard in place pending further investigation.
+        # TODO: gain confidence that DynamicScratchVar can be used here and
+        # modify the below strict type equality to `isinstance(index_var, ScratchVar)`
         if type(index_var) is not ScratchVar:
             raise TealInputError(
                 "Only allowed to use ScratchVar objects for setting indices, but was given a {}".format(

--- a/pyteal/compiler/subroutines.py
+++ b/pyteal/compiler/subroutines.py
@@ -12,7 +12,7 @@ from ..ir import TealComponent, TealOp, Op
 Node = TypeVar("Node")
 
 
-def depthFirstSearch(graph: Dict[Node, Set[Node]], start: Node, end: Node) -> bool:
+def graph_search(graph: Dict[Node, Set[Node]], start: Node, end: Node) -> bool:
     """Check whether a path between start and end exists in the graph.
 
     This works even if start == end, in which case True is only returned if the
@@ -57,7 +57,7 @@ def findRecursionPoints(
         reentryPoints[subroutine] = set(
             callee
             for callee in subroutineGraph[subroutine]
-            if depthFirstSearch(subroutineGraph, callee, subroutine)
+            if graph_search(subroutineGraph, callee, subroutine)
         )
 
     return reentryPoints

--- a/tests/compile_asserts.py
+++ b/tests/compile_asserts.py
@@ -4,9 +4,9 @@ from pyteal.compiler import compileTeal
 from pyteal.ir import Mode
 
 
-def compile_and_save(approval):
+def compile_and_save(approval, version):
     teal = Path.cwd() / "tests" / "teal"
-    compiled = compileTeal(approval(), mode=Mode.Application, version=6)
+    compiled = compileTeal(approval(), mode=Mode.Application, version=version)
     name = approval.__name__
     with open(teal / (name + ".teal"), "w") as f:
         f.write(compiled)
@@ -38,8 +38,7 @@ def assert_teal_as_expected(path2actual, path2expected):
 
         assert len(elines) == len(
             alines
-        ), f"""EXPECTED {len(elines)} lines for {path2expected}
-but ACTUALLY got {len(alines)} lines in {path2actual}"""
+        ), f"""EXPECTED {len(elines)} lines for {path2expected} but ACTUALLY got {len(alines)} lines in {path2actual}"""
 
         for i, actual in enumerate(alines):
             expected = elines[i]
@@ -56,18 +55,15 @@ LINE{i+1}:
 """
 
 
-def assert_new_v_old(approve_func):
-    try:
-        teal_dir, name, compiled = compile_and_save(approve_func)
+def assert_new_v_old(approve_func, version):
+    teal_dir, name, compiled = compile_and_save(approve_func, version)
 
-        print(
-            f"""Compilation resulted in TEAL program of length {len(compiled)}. 
-    To view output SEE <{name}.teal> in ({teal_dir})
-    --------------"""
-        )
+    print(
+        f"""Compilation resulted in TEAL program of length {len(compiled)}. 
+To view output SEE <{name}.teal> in ({teal_dir})
+--------------"""
+    )
 
-        path2actual = teal_dir / (name + ".teal")
-        path2expected = teal_dir / (name + "_expected.teal")
-        assert_teal_as_expected(path2actual, path2expected)
-    except Exception as e:
-        assert not e, f"failed to ASSERT NEW v OLD for {approve_func.__name__}: {e}"
+    path2actual = teal_dir / (name + ".teal")
+    path2expected = teal_dir / (name + "_expected.teal")
+    assert_teal_as_expected(path2actual, path2expected)

--- a/tests/pass_by_ref_test.py
+++ b/tests/pass_by_ref_test.py
@@ -202,20 +202,6 @@ def empty_scratches():
     )
 
 
-def make_creatable_factory(approval):
-    """
-    Wrap a pyteal program with code that:
-    * approves immediately in the case of app creation (appId == 0)
-    * runs the original code otherwise
-    """
-
-    def func():
-        return If(Txn.application_id() == Int(0)).Then(Int(1)).Else(approval())
-
-    func.__name__ = approval.__name__
-    return func
-
-
 @Subroutine(TealType.uint64)
 def oldfac(n):
     return If(n < Int(2)).Then(Int(1)).Else(n * oldfac(n - Int(1)))

--- a/tests/pass_by_ref_test.py
+++ b/tests/pass_by_ref_test.py
@@ -1,213 +1,586 @@
+from typing import List, Tuple
+
+import pytest
+
 from pyteal import *
 
 from .compile_asserts import assert_new_v_old, compile_and_save
 
-# Set the following True, if don't want to run pass-by-ref dependent tests
-OLD_CODE_ONLY = False
+# TODO: remove thise skips after the following issue has been fixed https://github.com/algorand/pyteal/issues/199
+STABLE_SLOT_GENERATION = False
 
-#### TESTS FOR PyTEAL THAT PREDATE PASS-BY-REF
-@Subroutine(TealType.bytes)
-def logcat(some_bytes, an_int):
-    catted = ScratchVar(TealType.bytes)
+#### TESTS FOR NEW PyTEAL THAT USES PASS-BY-REF / DYNAMIC
+@Subroutine(TealType.none)
+def logcat_dynamic(first: ScratchVar, an_int):
     return Seq(
-        catted.store(Concat(some_bytes, Itob(an_int))),
-        Log(catted.load()),
-        catted.load(),
+        first.store(Concat(first.load(), Itob(an_int))),
+        Log(first.load()),
     )
 
 
-def sub_logcat():
+def sub_logcat_dynamic():
+    first = ScratchVar(TealType.bytes)
     return Seq(
-        Assert(logcat(Bytes("hello"), Int(42)) == Bytes("hello42")),
+        first.store(Bytes("hello")),
+        logcat_dynamic(first, Int(42)),
+        Assert(Bytes("hello42") == first.load()),
         Int(1),
     )
 
 
-@Subroutine(TealType.uint64)
-def slow_fibonacci(n):
-    return (
-        If(n <= Int(1))
-        .Then(n)
-        .Else(slow_fibonacci(n - Int(2)) + slow_fibonacci(n - Int(1)))
+def wilt_the_stilt():
+    player_score = DynamicScratchVar(TealType.uint64)
+
+    wilt = ScratchVar(TealType.uint64, 129)
+    kobe = ScratchVar(TealType.uint64)
+    dt = ScratchVar(TealType.uint64, 131)
+
+    return Seq(
+        player_score.set_index(wilt),
+        player_score.store(Int(100)),
+        player_score.set_index(kobe),
+        player_score.store(Int(81)),
+        player_score.set_index(dt),
+        player_score.store(Int(73)),
+        Assert(player_score.load() == Int(73)),
+        Assert(player_score.index() == Int(131)),
+        player_score.set_index(wilt),
+        Assert(player_score.load() == Int(100)),
+        Assert(player_score.index() == Int(129)),
+        Int(100),
     )
 
 
-def sub_slowfib():
-    return slow_fibonacci(Int(3))
-
-
-@Subroutine(TealType.uint64)
-def fast_fibonacci(n):
-    i = ScratchVar(TealType.uint64)
-    a = ScratchVar(TealType.uint64)
-    b = ScratchVar(TealType.uint64)
+@Subroutine(TealType.none)
+def swap(x: ScratchVar, y: ScratchVar):
+    z = ScratchVar(TealType.anytype)
     return Seq(
-        a.store(Int(0)),
-        b.store(Int(1)),
-        For(i.store(Int(1)), i.load() <= n, i.store(i.load() + Int(1))).Do(
+        z.store(x.load()),
+        x.store(y.load()),
+        y.store(z.load()),
+    )
+
+
+@Subroutine(TealType.none)
+def cat(x, y):
+    return Pop(Concat(x, y))
+
+
+def swapper():
+    a = ScratchVar(TealType.bytes)
+    b = ScratchVar(TealType.bytes)
+    return Seq(
+        a.store(Bytes("hello")),
+        b.store(Bytes("goodbye")),
+        cat(a.load(), b.load()),
+        swap(a, b),
+        Assert(a.load() == Bytes("goodbye")),
+        Assert(b.load() == Bytes("hello")),
+        Int(1000),
+    )
+
+
+@Subroutine(TealType.none)
+def factorial_BAD(n: ScratchVar):
+    tmp = ScratchVar(TealType.uint64)
+    return (
+        If(n.load() <= Int(1))
+        .Then(n.store(Int(1)))
+        .Else(
             Seq(
-                b.store(a.load() + b.load()),
-                a.store(b.load() - a.load()),
+                tmp.store(n.load() - Int(1)),
+                factorial_BAD(tmp),
+                n.store(n.load() * tmp.load()),
             )
-        ),
-        a.load(),
+        )
     )
 
 
-def sub_fastfib():
-    return fast_fibonacci(Int(3))
+def fac_by_ref_BAD():
+    n = ScratchVar(TealType.uint64)
+    return Seq(
+        n.store(Int(10)),
+        factorial_BAD(n),
+        n.load(),
+    )
+
+
+@Subroutine(TealType.none)
+def factorial(n: ScratchVar):
+    tmp = ScratchVar(TealType.uint64)
+    return (
+        If(n.load() <= Int(1))
+        .Then(n.store(Int(1)))
+        .Else(
+            Seq(
+                tmp.store(n.load()),
+                n.store(n.load() - Int(1)),
+                factorial(n),
+                n.store(n.load() * tmp.load()),
+            )
+        )
+    )
+
+
+def fac_by_ref():
+    n = ScratchVar(TealType.uint64)
+    return Seq(
+        n.store(Int(10)),
+        factorial(n),
+        n.load(),
+    )
 
 
 @Subroutine(TealType.uint64)
-def recursiveIsEven(i):
-    return (
-        If(i == Int(0))
-        .Then(Int(1))
-        .ElseIf(i == Int(1))
-        .Then(Int(0))
-        .Else(recursiveIsEven(i - Int(2)))
-    )
-
-
-def sub_even():
+def mixed_annotations(x: Expr, y: Expr, z: ScratchVar) -> Expr:
     return Seq(
-        Pop(recursiveIsEven(Int(1000))),
-        recursiveIsEven(Int(1001)),
+        z.store(x),
+        Log(Concat(y, Bytes("="), Itob(x))),
+        x,
     )
 
 
-if not OLD_CODE_ONLY:
-    #### TESTS FOR NEW PyTEAL THAT USES PASS-BY-REF / DYNAMIC
-    @Subroutine(TealType.none)
-    def logcat_dynamic(first: ScratchVar, an_int):
-        return Seq(
-            first.store(Concat(first.load(), Itob(an_int))),
-            Log(first.load()),
-        )
+def sub_mixed():
+    x = Int(42)
+    y = Bytes("x")
+    z = ScratchVar(TealType.uint64)
+    return mixed_annotations(x, y, z)
 
-    def sub_logcat_dynamic():
-        first = ScratchVar(TealType.bytes)
-        return Seq(
-            first.store(Bytes("hello")),
-            logcat_dynamic(first, Int(42)),
-            Assert(Bytes("hello42") == first.load()),
-            Int(1),
-        )
 
-    def wilt_the_stilt():
-        player_score = DynamicScratchVar(TealType.uint64)
-
-        wilt = ScratchVar(TealType.uint64, 129)
-        kobe = ScratchVar(TealType.uint64)
-        dt = ScratchVar(TealType.uint64, 131)
-
-        return Seq(
-            player_score.set_index(wilt),
-            player_score.store(Int(100)),
-            player_score.set_index(kobe),
-            player_score.store(Int(81)),
-            player_score.set_index(dt),
-            player_score.store(Int(73)),
-            Assert(player_score.load() == Int(73)),
-            Assert(player_score.index() == Int(131)),
-            player_score.set_index(wilt),
-            Assert(player_score.load() == Int(100)),
-            Assert(player_score.index() == Int(129)),
-            Int(100),
-        )
-
-    @Subroutine(TealType.none)
-    def swap(x: ScratchVar, y: ScratchVar):
-        z = ScratchVar(TealType.anytype)
-        return Seq(
-            z.store(x.load()),
-            x.store(y.load()),
-            y.store(z.load()),
-        )
-
-    @Subroutine(TealType.none)
-    def cat(x, y):
-        return Pop(Concat(x, y))
-
-    def swapper():
-        a = ScratchVar(TealType.bytes)
-        b = ScratchVar(TealType.bytes)
-        return Seq(
-            a.store(Bytes("hello")),
-            b.store(Bytes("goodbye")),
-            cat(a.load(), b.load()),
-            swap(a, b),
-            Assert(a.load() == Bytes("goodbye")),
-            Assert(b.load() == Bytes("hello")),
-            Int(1000),
-        )
-
-    @Subroutine(TealType.none)
-    def factorial(n: ScratchVar):
-        tmp = ScratchVar(TealType.uint64)
-        return (
-            If(n.load() <= Int(1))
-            .Then(n.store(Int(1)))
-            .Else(
-                Seq(
-                    tmp.store(n.load() - Int(1)),
-                    factorial(tmp),
-                    n.store(n.load() * tmp.load()),
-                )
+@Subroutine(TealType.none)
+def plus_one(n: ScratchVar):
+    tmp = ScratchVar(TealType.uint64)
+    return (
+        If(n.load() == Int(0))
+        .Then(n.store(Int(1)))
+        .Else(
+            Seq(
+                tmp.store(n.load() - Int(1)),
+                plus_one(tmp),
+                n.store(tmp.load() + Int(1)),
             )
         )
+    )
 
-    def fac_by_ref():
-        n = ScratchVar(TealType.uint64)
-        return Seq(
-            n.store(Int(42)),
-            factorial(n),
-            n.load(),
+
+def increment():
+    n = ScratchVar(TealType.uint64)
+    return Seq(n.store(Int(4)), plus_one(n), Int(1))
+
+
+@Subroutine(TealType.none)
+def tally(n, result: ScratchVar):
+    return (
+        If(n == Int(0))
+        .Then(result.store(Bytes("")))
+        .Else(
+            Seq(
+                tally(n - Int(1), result),
+                result.store(Concat(result.load(), Bytes("a"))),
+            )
         )
+    )
+
+
+def tallygo():
+    result = ScratchVar(TealType.bytes)
+    # If-Then is a hook for creating + opting in without providing any args
+    return (
+        If(Or(App.id() == Int(0), Txn.application_args.length() == Int(0)))
+        .Then(Int(1))
+        .Else(
+            Seq(
+                result.store(Bytes("dummy")), tally(Int(4), result), Btoi(result.load())
+            )
+        )
+    )
+
+
+def lots_o_vars():
+    z = Int(0)
+    one = ScratchVar()
+    two = ScratchVar()
+    three = ScratchVar()
+    four = ScratchVar()
+    five = Bytes("five")
+    six = Bytes("six")
+    seven = Bytes("seven")
+    eight = Bytes("eight")
+    nine = Bytes("nine")
+    ten = Bytes("ten")
+    eleven = Bytes("eleven")
+    twelve = Bytes("twelve")
+    int_cursor = DynamicScratchVar(TealType.uint64)
+    bytes_cursor = DynamicScratchVar(TealType.bytes)
+    thirteen = ScratchVar(TealType.uint64, 13)
+    fourteen = ScratchVar(TealType.bytes, 14)
+    fifteen = ScratchVar(TealType.uint64)
+    sixteen = ScratchVar(TealType.bytes)
+    leet = Int(1337)
+    ngl = Bytes("NGL: ")
+    return (
+        If(Or(App.id() == Int(0), Txn.application_args.length() == Int(0)))
+        .Then(Int(1))
+        .Else(
+            Seq(
+                one.store(Int(1)),
+                two.store(Bytes("two")),
+                three.store(Int(3)),
+                four.store(Bytes("four")),
+                App.localPut(z, five, Int(5)),
+                App.localPut(z, six, six),
+                App.localPut(z, seven, Int(7)),
+                App.localPut(z, eight, eight),
+                App.globalPut(nine, Int(9)),
+                App.globalPut(ten, ten),
+                App.globalPut(eleven, Int(11)),
+                App.globalPut(twelve, twelve),
+                one.store(one.load() + leet),
+                two.store(Concat(ngl, two.load())),
+                three.store(three.load() + leet),
+                four.store(Concat(ngl, four.load())),
+                App.localPut(z, five, leet + App.localGet(z, five)),
+                App.localPut(z, six, Concat(ngl, App.localGet(z, six))),
+                App.localPut(z, seven, App.localGet(z, seven)),
+                App.localPut(z, eight, Concat(ngl, App.localGet(z, eight))),
+                App.globalPut(nine, leet + App.globalGet(nine)),
+                App.globalPut(ten, Concat(ngl, App.globalGet(ten))),
+                App.globalPut(eleven, leet + App.globalGet(eleven)),
+                App.globalPut(twelve, Concat(ngl, App.globalGet(twelve))),
+                thirteen.store(Btoi(Txn.application_args[0])),
+                fourteen.store(Txn.application_args[1]),
+                fifteen.store(Btoi(Txn.application_args[2])),
+                sixteen.store(Txn.application_args[3]),
+                Pop(one.load()),
+                Pop(two.load()),
+                Pop(three.load()),
+                Pop(four.load()),
+                Pop(App.localGet(z, five)),
+                Pop(App.localGet(z, six)),
+                Pop(App.localGet(z, seven)),
+                Pop(App.localGet(z, eight)),
+                Pop(App.globalGet(nine)),
+                Pop(App.globalGet(ten)),
+                Pop(App.globalGet(eleven)),
+                Pop(App.globalGet(twelve)),
+                int_cursor.set_index(thirteen),
+                Log(Itob(int_cursor.load())),
+                bytes_cursor.set_index(fourteen),
+                Log(bytes_cursor.load()),
+                int_cursor.set_index(fifteen),
+                Log(Itob(int_cursor.load())),
+                bytes_cursor.set_index(sixteen),
+                Log(bytes_cursor.load()),
+                leet,
+            )
+        )
+    )
+
+
+def test_increment():
+    prefix = "ScratchVar arguments not allowed in recursive subroutines, but a recursive call-path was detected: "
+
+    with pytest.raises(TealInputError) as e:
+        compile_and_save(increment, 6)
+    assert f"{prefix}plus_one()-->plus_one()" in str(e)
+
+
+# Testable by black-box:
+def fac_by_ref_args():
+    n = ScratchVar(TealType.uint64)
+    return Seq(
+        If(Or(App.id() == Int(0), Txn.application_args.length() == Int(0)))
+        .Then(Int(1))
+        .Else(
+            Seq(
+                n.store(Btoi(Txn.application_args[0])),
+                factorial(n),
+                n.load(),
+            )
+        )
+    )
+
+
+@Subroutine(TealType.none)
+def subr_string_mult(s: ScratchVar, n):
+    tmp = ScratchVar(TealType.bytes)
+    return (
+        If(n == Int(0))
+        .Then(s.store(Bytes("")))
+        .Else(
+            Seq(
+                tmp.store(s.load()),
+                subr_string_mult(s, n - Int(1)),
+                s.store(Concat(s.load(), tmp.load())),
+            )
+        )
+    )
+
+
+def string_mult():
+    s = ScratchVar(TealType.bytes)
+    return Seq(
+        s.store(Txn.application_args[0]),
+        subr_string_mult(s, Btoi(Txn.application_args[1])),
+        Log(s.load()),
+        Int(100),
+    )
+
+
+def empty_scratches():
+    cursor = DynamicScratchVar()
+    i1 = ScratchVar(TealType.uint64, 0)
+    i2 = ScratchVar(TealType.uint64, 2)
+    i3 = ScratchVar(TealType.uint64, 4)
+    s1 = ScratchVar(TealType.bytes, 1)
+    s2 = ScratchVar(TealType.bytes, 3)
+    s3 = ScratchVar(TealType.bytes, 5)
+    return Seq(
+        cursor.set_index(i1),
+        cursor.store(Int(0)),
+        cursor.set_index(s1),
+        cursor.store(Bytes("")),
+        cursor.set_index(i2),
+        cursor.store(Int(0)),
+        cursor.set_index(s2),
+        cursor.store(Bytes("")),
+        cursor.set_index(i3),
+        cursor.store(Int(0)),
+        cursor.set_index(s3),
+        cursor.store(Bytes("")),
+        Int(42),
+    )
+
+
+def should_it_work() -> Expr:
+    xs = [
+        ScratchVar(TealType.uint64),
+        ScratchVar(TealType.uint64),
+    ]
+
+    def store_initial_values():
+        return [s.store(Int(i + 1)) for i, s in enumerate(xs)]
+
+    d = DynamicScratchVar(TealType.uint64)
+
+    @Subroutine(TealType.none)
+    def retrieve_and_increment(s: ScratchVar):
+        return Seq(d.set_index(s), d.store(d.load() + Int(1)))
+
+    def asserts():
+        return [Assert(x.load() == Int(i + 2)) for i, x in enumerate(xs)]
+
+    return Seq(
+        Seq(store_initial_values()),
+        Seq([retrieve_and_increment(x) for x in xs]),
+        Seq(asserts()),
+        Int(1),
+    )
+
+
+def make_creatable_factory(approval):
+    """
+    Wrap a pyteal program with code that:
+    * approves immediately in the case of app creation (appId == 0)
+    * runs the original code otherwise
+    """
+
+    def func():
+        return If(Txn.application_id() == Int(0)).Then(Int(1)).Else(approval())
+
+    func.__name__ = approval.__name__
+    return func
+
+
+@Subroutine(TealType.uint64)
+def oldfac(n):
+    return If(n < Int(2)).Then(Int(1)).Else(n * oldfac(n - Int(1)))
+
+
+def wrap_for_semantic_e2e(subr_with_params: Tuple[Tuple[Expr, List[TealType]]]) -> Expr:
+    subr, params = subr_with_params
+
+    def arg(i, p):
+        arg = Txn.application_args[i]
+        if p == TealType.uint64:
+            arg = Btoi(arg)
+        return arg
+
+    def approval():
+        return subr(*(arg(i, p) for i, p in enumerate(params)))
+
+    setattr(approval, "__name__", f"sem_{subr.name()}")
+
+    return approval
+
+
+TESTABLE_CASES = [(oldfac, [TealType.uint64])]
+
+
+@pytest.mark.skipif(not STABLE_SLOT_GENERATION, reason="cf. #199")
+@pytest.mark.parametrize("pt", map(wrap_for_semantic_e2e, TESTABLE_CASES))
+def test_semantic_unchanged(pt):
+    assert_new_v_old(pt, 6)
+
+
+CASES = (
+    sub_logcat_dynamic,
+    swapper,
+    wilt_the_stilt,
+    fac_by_ref,
+    fac_by_ref_BAD,
+    fac_by_ref_args,
+    sub_mixed,
+    lots_o_vars,
+    tallygo,
+    empty_scratches,
+    should_it_work,
+)
+
+
+DEPRECATED_CASES = (string_mult, should_it_work)
+
+
+@pytest.mark.skipif(not STABLE_SLOT_GENERATION, reason="cf. #199")
+@pytest.mark.parametrize("pt", CASES)
+def test_teal_output_is_unchanged(pt):
+    assert_new_v_old(pt, 6)
+
+
+@pytest.mark.skipif(not STABLE_SLOT_GENERATION, reason="cf. #199")
+@pytest.mark.parametrize("pt", map(make_creatable_factory, DEPRECATED_CASES))
+def test_deprecated(pt):
+    assert_new_v_old(pt, 6)
+
+
+def test_pass_by_ref_guardrails():
+    ##### Subroutine Definitions #####
+    @Subroutine(TealType.uint64)
+    def ok(x):
+        # not really ok at runtime... but should be ok at compile time
+        return ok(x)
 
     @Subroutine(TealType.uint64)
-    def mixed_annotations(x: Expr, y: Expr, z: ScratchVar) -> Expr:
-        return Seq(
-            z.store(x),
-            Log(Concat(y, Bytes("="), Itob(x))),
-            x,
-        )
+    def ok_byref(x: ScratchVar):
+        return Int(42)
 
-    def sub_mixed():
-        x = Int(42)
-        y = Bytes("x")
-        z = ScratchVar(TealType.uint64)
-        return mixed_annotations(x, y, z)
+    @Subroutine(TealType.uint64)
+    def ok_indirect1(x):
+        return ok_indirect2(x)
 
+    @Subroutine(TealType.uint64)
+    def ok_indirect2(x):
+        return ok_indirect1(x)
 
-OLD_CASES = (sub_logcat, sub_slowfib, sub_fastfib, sub_even)
+    @Subroutine(TealType.uint64)
+    def not_ok(x: ScratchVar):
+        # not ok both at compile and runtime
+        return not_ok(x)
 
+    @Subroutine(TealType.uint64)
+    def not_ok_indirect1(x: ScratchVar):
+        return not_ok_indirect2(x)
 
-def test_old():
-    for pt in OLD_CASES:
-        assert_new_v_old(pt)
+    @Subroutine(TealType.uint64)
+    def not_ok_indirect2(x: ScratchVar):
+        return not_ok_indirect1(x)
 
+    """
+    Complex subroutine graph example:
 
-if __name__ == "__main__":
-    test_old()
+    a --> b --> a (loop)
+            --> e 
+            --> f
+      --> *c--> g --> a (loop)
+            --> h 
+      --> d --> d (loop)
+            --> i
+            --> j
 
+    *c - this is the only "pass by-ref" subroutine
+    Expect the following error path: c-->g-->a-->c
+    """
 
-if not OLD_CODE_ONLY:
-    NEW_CASES = (
-        sub_logcat_dynamic,
-        swapper,
-        wilt_the_stilt,
-        fac_by_ref,
-        sub_mixed,
+    @Subroutine(TealType.uint64)
+    def a(x):
+        tmp = ScratchVar(TealType.uint64)
+        return Seq(tmp.store(x), b(x) + c(tmp) + d(x))
+
+    @Subroutine(TealType.uint64)
+    def b(x):
+        return a(x) + e(x) * f(x)
+
+    @Subroutine(TealType.uint64)
+    def c(x: ScratchVar):
+        return g(Int(42)) - h(x.load())
+
+    @Subroutine(TealType.uint64)
+    def d(x):
+        return d(x) + i(Int(11)) * j(x)
+
+    @Subroutine(TealType.uint64)
+    def e(x):
+        return Int(42)
+
+    @Subroutine(TealType.uint64)
+    def f(x):
+        return Int(42)
+
+    @Subroutine(TealType.uint64)
+    def g(x):
+        return a(Int(17))
+
+    @Subroutine(TealType.uint64)
+    def h(x):
+        return Int(42)
+
+    @Subroutine(TealType.uint64)
+    def i(x):
+        return Int(42)
+
+    @Subroutine(TealType.uint64)
+    def j(x):
+        return Int(42)
+
+    ##### Approval PyTEAL Expressions #####
+
+    approval_ok = ok(Int(42))
+
+    x = ScratchVar(TealType.uint64)
+
+    approval_ok_byref = Seq(x.store(Int(42)), ok_byref(x))
+
+    approval_ok_indirect = ok_indirect1(Int(42))
+
+    approval_not_ok = Seq(x.store(Int(42)), not_ok(x))
+
+    approval_not_ok_indirect = Seq(x.store(Int(42)), not_ok_indirect1(x))
+
+    approval_its_complicated = a(Int(42))
+
+    ##### Assertions #####
+
+    assert compileTeal(approval_ok, Mode.Application, version=6)
+
+    assert compileTeal(approval_ok_byref, Mode.Application, version=6)
+
+    assert compileTeal(approval_ok_indirect, Mode.Application, version=6)
+
+    with pytest.raises(TealInputError) as err:
+        compileTeal(approval_not_ok, Mode.Application, version=6)
+
+    prefix = "ScratchVar arguments not allowed in recursive subroutines, but a recursive call-path was detected: "
+    assert f"{prefix}not_ok()-->not_ok()" in str(err)
+
+    with pytest.raises(TealInputError) as err:
+        compileTeal(approval_not_ok_indirect, Mode.Application, version=6)
+
+    assert (
+        f"{prefix}not_ok_indirect1()-->not_ok_indirect2()-->not_ok_indirect1()"
+        in str(err)
     )
 
-    def test_swapper():
-        compile_and_save(swapper)
+    with pytest.raises(TealInputError) as err:
+        compileTeal(approval_its_complicated, Mode.Application, version=6)
 
-    def test_new():
-        for pt in NEW_CASES:
-            assert_new_v_old(pt)
-
-    if __name__ == "__main__":
-        test_swapper()
-        test_new()
+    assert f"{prefix}c()-->g()-->a()-->c()" in str(err)

--- a/tests/pass_by_ref_test.py
+++ b/tests/pass_by_ref_test.py
@@ -6,7 +6,7 @@ from pyteal import *
 
 from .compile_asserts import assert_new_v_old, compile_and_save
 
-# TODO: remove thise skips after the following issue has been fixed https://github.com/algorand/pyteal/issues/199
+# TODO: remove these skips when the following is fixed: https://github.com/algorand/pyteal/issues/199
 STABLE_SLOT_GENERATION = False
 
 #### TESTS FOR NEW PyTEAL THAT USES PASS-BY-REF / DYNAMIC

--- a/tests/teal/empty_scratches_expected.teal
+++ b/tests/teal/empty_scratches_expected.teal
@@ -1,0 +1,33 @@
+#pragma version 6
+int 0
+store 6
+load 6
+int 0
+stores
+int 1
+store 6
+load 6
+byte ""
+stores
+int 2
+store 6
+load 6
+int 0
+stores
+int 3
+store 6
+load 6
+byte ""
+stores
+int 4
+store 6
+load 6
+int 0
+stores
+int 5
+store 6
+load 6
+byte ""
+stores
+int 42
+return

--- a/tests/teal/lots_o_vars_expected.teal
+++ b/tests/teal/lots_o_vars_expected.teal
@@ -1,0 +1,189 @@
+#pragma version 6
+global CurrentApplicationID
+int 0
+==
+txn NumAppArgs
+int 0
+==
+||
+bnz main_l2
+int 1
+store 0
+byte "two"
+store 1
+int 3
+store 2
+byte "four"
+store 3
+int 0
+byte "five"
+int 5
+app_local_put
+int 0
+byte "six"
+byte "six"
+app_local_put
+int 0
+byte "seven"
+int 7
+app_local_put
+int 0
+byte "eight"
+byte "eight"
+app_local_put
+byte "nine"
+int 9
+app_global_put
+byte "ten"
+byte "ten"
+app_global_put
+byte "eleven"
+int 11
+app_global_put
+byte "twelve"
+byte "twelve"
+app_global_put
+load 0
+int 1337
++
+store 0
+byte "NGL: "
+load 1
+concat
+store 1
+load 2
+int 1337
++
+store 2
+byte "NGL: "
+load 3
+concat
+store 3
+int 0
+byte "five"
+int 1337
+int 0
+byte "five"
+app_local_get
++
+app_local_put
+int 0
+byte "six"
+byte "NGL: "
+int 0
+byte "six"
+app_local_get
+concat
+app_local_put
+int 0
+byte "seven"
+int 0
+byte "seven"
+app_local_get
+app_local_put
+int 0
+byte "eight"
+byte "NGL: "
+int 0
+byte "eight"
+app_local_get
+concat
+app_local_put
+byte "nine"
+int 1337
+byte "nine"
+app_global_get
++
+app_global_put
+byte "ten"
+byte "NGL: "
+byte "ten"
+app_global_get
+concat
+app_global_put
+byte "eleven"
+int 1337
+byte "eleven"
+app_global_get
++
+app_global_put
+byte "twelve"
+byte "NGL: "
+byte "twelve"
+app_global_get
+concat
+app_global_put
+txna ApplicationArgs 0
+btoi
+store 13
+txna ApplicationArgs 1
+store 14
+txna ApplicationArgs 2
+btoi
+store 6
+txna ApplicationArgs 3
+store 7
+load 0
+pop
+load 1
+pop
+load 2
+pop
+load 3
+pop
+int 0
+byte "five"
+app_local_get
+pop
+int 0
+byte "six"
+app_local_get
+pop
+int 0
+byte "seven"
+app_local_get
+pop
+int 0
+byte "eight"
+app_local_get
+pop
+byte "nine"
+app_global_get
+pop
+byte "ten"
+app_global_get
+pop
+byte "eleven"
+app_global_get
+pop
+byte "twelve"
+app_global_get
+pop
+int 13
+store 4
+load 4
+loads
+itob
+log
+int 14
+store 5
+load 5
+loads
+log
+int 6
+store 4
+load 4
+loads
+itob
+log
+int 7
+store 5
+load 5
+loads
+log
+int 1337
+b main_l3
+main_l2:
+int 1
+main_l3:
+return

--- a/tests/teal/user_guide_snippet_recursiveIsEven_expected.teal
+++ b/tests/teal/user_guide_snippet_recursiveIsEven_expected.teal
@@ -1,0 +1,32 @@
+#pragma version 6
+int 15
+callsub recursiveIsEven_0
+return
+
+// recursiveIsEven
+recursiveIsEven_0:
+store 0
+load 0
+int 0
+==
+bnz recursiveIsEven_0_l4
+load 0
+int 1
+==
+bnz recursiveIsEven_0_l3
+load 0
+int 2
+-
+load 0
+swap
+callsub recursiveIsEven_0
+swap
+store 0
+b recursiveIsEven_0_l5
+recursiveIsEven_0_l3:
+int 0
+b recursiveIsEven_0_l5
+recursiveIsEven_0_l4:
+int 1
+recursiveIsEven_0_l5:
+retsub

--- a/tests/user_guide_test.py
+++ b/tests/user_guide_test.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 
 from pyteal import *
@@ -22,6 +23,63 @@ def user_guide_snippet_dynamic_scratch_var() -> Expr:
     )
 
 
-@pytest.mark.parametrize("snippet", [user_guide_snippet_dynamic_scratch_var])
-def test_user_guide_snippets(snippet):
+def user_guide_snippet_recursiveIsEven():
+    @Subroutine(TealType.uint64)
+    def recursiveIsEven(i):
+        return (
+            If(i == Int(0))
+            .Then(Int(1))
+            .ElseIf(i == Int(1))
+            .Then(Int(0))
+            .Else(recursiveIsEven(i - Int(2)))
+        )
+
+    return recursiveIsEven(Int(15))
+
+
+def user_guide_snippet_ILLEGAL_recursion():
+    @Subroutine(TealType.none)
+    def ILLEGAL_recursion(i: ScratchVar):
+        return (
+            If(i.load() == Int(0))
+            .Then(i.store(Int(1)))
+            .ElseIf(i.load() == Int(1))
+            .Then(i.store(Int(0)))
+            .Else(Seq(i.store(i.load() - Int(2)), ILLEGAL_recursion(i)))
+        )
+
+    i = ScratchVar(TealType.uint64)
+    return Seq(i.store(Int(15)), ILLEGAL_recursion(i), Int(1))
+
+
+USER_GUIDE_SNIPPETS_COPACETIC = [
+    user_guide_snippet_dynamic_scratch_var,
+    user_guide_snippet_recursiveIsEven,
+]
+
+
+@pytest.mark.parametrize("snippet", USER_GUIDE_SNIPPETS_COPACETIC)
+def test_user_guide_snippets_good(snippet):
     assert_new_v_old(snippet, 6)
+
+
+USER_GUIDE_SNIPPETS_ERRORING = {
+    user_guide_snippet_ILLEGAL_recursion: (
+        TealInputError,
+        "ScratchVar arguments not allowed in recursive subroutines, but a recursive call-path was detected: ILLEGAL_recursion()-->ILLEGAL_recursion()",
+    )
+}
+
+
+@pytest.mark.parametrize("snippet_etype_e", USER_GUIDE_SNIPPETS_ERRORING.items())
+def test_user_guide_snippets_bad(snippet_etype_e):
+    snippet, etype_e = snippet_etype_e
+    etype, e = etype_e
+
+    print(
+        f"Test case function=[{snippet.__name__}]. Expecting error of type {etype} with message <{e}>"
+    )
+    with pytest.raises(etype) as tie:
+        compileTeal(snippet(), mode=Mode.Application, version=6)
+
+    assert e in str(tie)

--- a/tests/user_guide_test.py
+++ b/tests/user_guide_test.py
@@ -24,4 +24,4 @@ def user_guide_snippet_dynamic_scratch_var() -> Expr:
 
 @pytest.mark.parametrize("snippet", [user_guide_snippet_dynamic_scratch_var])
 def test_user_guide_snippets(snippet):
-    assert_new_v_old(snippet)
+    assert_new_v_old(snippet, 6)


### PR DESCRIPTION
## TODO's of issue #242 

- [x] Recursive by-ref treatment: Impose more constraints - Disallow all recursion for any ScratchVar in any `@Subroutine`
- [x] DynamicScratchVar treatment: Leave as is with explanatory inline comment explaining why it's like that
- [x] Break down associated integration tests in `tests/pass_by_ref_test.py` to smaller components
- [x] Add documentation regarding illegality of pass-by-ref recursion
- [x] Add a simple unit test to `pyteal/compiler/subroutines_test.py` that tests the new functionality of `spillLocalSlotsDuringRecursion`