### PR TITLE
Upgrade black formatter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==21.7b0
+black==22.3.0
 mypy==0.931
 pytest
 pytest-timeout


### PR DESCRIPTION
The recent builds (e.g., https://github.com/algorand/pyteal/runs/5728134514?check_suite_focus=true and https://github.com/algorand/pyteal/runs/5727657498?check_suite_focus=true) failed for `black` using a previous click version, which is described https://github.com/psf/black/issues/2969.

Solution is straightforward, upgrading `black` version to latest one.