### PR TITLE
Upgrade minimum Python version to 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     container: python:${{ matrix.python }}-slim
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.10']
     steps:
       - run: python3 --version
       - name: Check out code
@@ -31,7 +31,7 @@ jobs:
           pytest
   build-docset:
     runs-on: ubuntu-20.04
-    container: python:3.9  # Needs `make`, can't be slim
+    container: python:3.10  # Needs `make`, can't be slim
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
           path: docs/pyteal.docset.tar.gz
   upload-to-pypi:
     runs-on: ubuntu-20.04
-    container: python:3.9
+    container: python:3.10
     needs: ['build-test']
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.10
   install:
     - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ PyTeal provides high level, functional programming style abstractions over TEAL 
 
 ### Install 
 
-PyTeal requires Python version >= 3.6.
+PyTeal requires Python version >= 3.10.
+
+To manage multiple Python versions use tooling like [pyenv](https://github.com/pyenv/pyenv).
 
 #### Recommended: Install from PyPi
 

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     package_data={"pyteal": ["*.pyi"]},
-    python_requires=">=3.6",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
https://github.com/algorand/pyteal/issues/244 - Upgrades minimum Python version 3.10.

Details:
* Reuses concurrent Python version tooling suggestion from https://github.com/algorand/py-algorand-sdk/pull/313/.