### PR TITLE
Fix docs warning about multiple OptimizeOptions targets

### DIFF
--- a/docs/compiler_optimization.rst
+++ b/docs/compiler_optimization.rst
@@ -12,10 +12,10 @@ to: compiled code size, scratch slot usage, opcode cost, etc.
 Optimizer Usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The compiler determines which optimizations to apply based on the provided :any:`OptimizeOptions` object as
-shown in the code block below. The :any:`OptimizeOptions` constructor receives a set of keyword arguments 
+The compiler determines which optimizations to apply based on the provided :any:`pyteal.OptimizeOptions` object as
+shown in the code block below. The :any:`pyteal.OptimizeOptions` constructor receives a set of keyword arguments
 representing flags corresponding to particular optimizations. If arguments are not provided to the
-constructor or no :any:`OptimizeOptions` object is passed to :any:`compileTeal` then the default behavior is
+constructor or no :any:`pyteal.OptimizeOptions` object is passed to :any:`compileTeal` then the default behavior is
 that no optimizations are applied.
 
 ============================== ================================================================================ ===========================


### PR DESCRIPTION
Fixes `make html` warnings about `OptimizationOptions` shown below by fully qualifying the ambiguous reference.

```
~/dev/pyteal/docs master *3 ?3 ──────────────────────────────────────────────────────────────────────────────────────────  pyteal 03:14:55 PM
❯ make html
Running Sphinx v4.5.0
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] compiler_optimization
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index
/Users/michael/dev/pyteal/docs/compiler_optimization.rst:15: WARNING: more than one target found for 'any' cross-reference 'OptimizeOptions': could be :py:class:`pyteal.OptimizeOptions` or :py:class:`pyteal.compiler.optimizer.optimizer.OptimizeOptions`
/Users/michael/dev/pyteal/docs/compiler_optimization.rst:15: WARNING: more than one target found for 'any' cross-reference 'OptimizeOptions': could be :py:class:`pyteal.OptimizeOptions` or :py:class:`pyteal.compiler.optimizer.optimizer.OptimizeOptions`
/Users/michael/dev/pyteal/docs/compiler_optimization.rst:15: WARNING: more than one target found for 'any' cross-reference 'OptimizeOptions': could be :py:class:`pyteal.OptimizeOptions` or :py:class:`pyteal.compiler.optimizer.optimizer.OptimizeOptions`
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 3 warnings.

The HTML pages are in _build/html.
```