### PR TITLE
Fix docs warning about multiple OptimizeOptions targets

### DIFF
--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -100,3 +100,6 @@ def apply_global_optimizations(start: TealBlock, options: OptimizeOptions) -> Te
                 break
 
     return start
+
+
+OptimizeOptions.__module__ = "pyteal"


### PR DESCRIPTION
Fixes the warning shown in https://github.com/algorand/pyteal/pull/270 and reproduced below _without_ requiring docs modification.  Thanks to @jasonpaulos for suggesting the fix!  ☕ 

```
~/dev/pyteal/docs master *3 ?3 ──────────────────────────────────────────────────────────────────────────────────────────  pyteal 03:14:55 PM
❯ make html
Running Sphinx v4.5.0
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] compiler_optimization
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index
/Users/michael/dev/pyteal/docs/compiler_optimization.rst:15: WARNING: more than one target found for 'any' cross-reference 'OptimizeOptions': could be :py:class:`pyteal.OptimizeOptions` or :py:class:`pyteal.compiler.optimizer.optimizer.OptimizeOptions`
/Users/michael/dev/pyteal/docs/compiler_optimization.rst:15: WARNING: more than one target found for 'any' cross-reference 'OptimizeOptions': could be :py:class:`pyteal.OptimizeOptions` or :py:class:`pyteal.compiler.optimizer.optimizer.OptimizeOptions`
/Users/michael/dev/pyteal/docs/compiler_optimization.rst:15: WARNING: more than one target found for 'any' cross-reference 'OptimizeOptions': could be :py:class:`pyteal.OptimizeOptions` or :py:class:`pyteal.compiler.optimizer.optimizer.OptimizeOptions`
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 3 warnings.

The HTML pages are in _build/html.
```