### PR TITLE
Test py-algorand-sdk Python version bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-20.04
-    container: python:${{ matrix.python }}-slim
+    container: python:${{ matrix.python }}
     strategy:
       matrix:
         python: ['3.10']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ black==22.3.0
 mypy==0.931
 pytest
 pytest-timeout
-py-algorand-sdk
+git+https://github.com/algorand/py-algorand-sdk@algochoi/bump-python-version


### PR DESCRIPTION
Provides a proof point that https://github.com/algorand/py-algorand-sdk/pull/313 works for downstream consumers.

I create the PR only to support running the build.  I intend to close the PR after successful build.