### PR TITLE
Remove redundant test imports

### DIFF
--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -1,8 +1,5 @@
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 teal4Options = CompileOptions(version=4)
 teal5Options = CompileOptions(version=5)

--- a/pyteal/ast/app_test.py
+++ b/pyteal/ast/app_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 teal4Options = CompileOptions(version=4)
 teal5Options = CompileOptions(version=5)

--- a/pyteal/ast/arg_test.py
+++ b/pyteal/ast/arg_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal2Options = CompileOptions(version=2)
 teal4Options = CompileOptions(version=4)
 teal5Options = CompileOptions(version=5)

--- a/pyteal/ast/assert_test.py
+++ b/pyteal/ast/assert_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal2Options = CompileOptions(version=2)
 teal3Options = CompileOptions(version=3)
 

--- a/pyteal/ast/asset_test.py
+++ b/pyteal/ast/asset_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal2Options = CompileOptions()
 teal4Options = CompileOptions(version=4)
 teal5Options = CompileOptions(version=5)

--- a/pyteal/ast/binaryexpr_test.py
+++ b/pyteal/ast/binaryexpr_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal2Options = CompileOptions(version=2)
 teal3Options = CompileOptions(version=3)
 teal4Options = CompileOptions(version=4)

--- a/pyteal/ast/break_test.py
+++ b/pyteal/ast/break_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/bytes_test.py
+++ b/pyteal/ast/bytes_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/cond_test.py
+++ b/pyteal/ast/cond_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/continue_test.py
+++ b/pyteal/ast/continue_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/for_test.py
+++ b/pyteal/ast/for_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/gaid_test.py
+++ b/pyteal/ast/gaid_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import MAX_GROUP_SIZE, CompileOptions
-
 teal3Options = CompileOptions(version=3)
 teal4Options = CompileOptions(version=4)
 

--- a/pyteal/ast/gload_test.py
+++ b/pyteal/ast/gload_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import MAX_GROUP_SIZE, NUM_SLOTS, CompileOptions
-
 teal3Options = CompileOptions(version=3)
 teal4Options = CompileOptions(version=4)
 teal6Options = CompileOptions(version=6)

--- a/pyteal/ast/global_test.py
+++ b/pyteal/ast/global_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal2Options = CompileOptions(version=2)
 teal3Options = CompileOptions(version=3)
 teal5Options = CompileOptions(version=5)

--- a/pyteal/ast/if_test.py
+++ b/pyteal/ast/if_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/int_test.py
+++ b/pyteal/ast/int_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/itxn_test.py
+++ b/pyteal/ast/itxn_test.py
@@ -3,9 +3,6 @@ import pytest
 from .. import *
 from ..types import types_match
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal4Options = CompileOptions(version=4)
 teal5Options = CompileOptions(version=5)
 teal6Options = CompileOptions(version=6)

--- a/pyteal/ast/maybe_test.py
+++ b/pyteal/ast/maybe_test.py
@@ -1,8 +1,5 @@
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/naryexpr_test.py
+++ b/pyteal/ast/naryexpr_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/nonce_test.py
+++ b/pyteal/ast/nonce_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/return_test.py
+++ b/pyteal/ast/return_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions(version=4)
 
 

--- a/pyteal/ast/scratch_test.py
+++ b/pyteal/ast/scratch_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/scratchvar_test.py
+++ b/pyteal/ast/scratchvar_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/seq_test.py
+++ b/pyteal/ast/seq_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -4,9 +4,6 @@ import pytest
 from .. import *
 from .subroutine import evaluateSubroutine
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions, Return
-
 options = CompileOptions(version=4)
 
 

--- a/pyteal/ast/substring_test.py
+++ b/pyteal/ast/substring_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal2Options = CompileOptions(version=2)
 teal3Options = CompileOptions(version=3)
 teal4Options = CompileOptions(version=4)

--- a/pyteal/ast/ternaryexpr_test.py
+++ b/pyteal/ast/ternaryexpr_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal2Options = CompileOptions(version=2)
 teal3Options = CompileOptions(version=3)
 teal4Options = CompileOptions(version=4)

--- a/pyteal/ast/tmpl_test.py
+++ b/pyteal/ast/tmpl_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/ast/txn_test.py
+++ b/pyteal/ast/txn_test.py
@@ -4,9 +4,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import Expr, TxnField, TxnObject, TxnArray, CompileOptions
-
 fieldToMethod: Dict[TxnField, Callable[[TxnObject], Expr]] = {
     TxnField.sender: lambda txn: txn.sender(),
     TxnField.fee: lambda txn: txn.fee(),

--- a/pyteal/ast/unaryexpr_test.py
+++ b/pyteal/ast/unaryexpr_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 teal2Options = CompileOptions(version=2)
 teal3Options = CompileOptions(version=3)
 teal4Options = CompileOptions(version=4)

--- a/pyteal/ast/while_test.py
+++ b/pyteal/ast/while_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -2,9 +2,6 @@ import pytest
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from ..ast import *
-
 
 def test_compile_single():
     expr = Int(1)

--- a/pyteal/compiler/flatten_test.py
+++ b/pyteal/compiler/flatten_test.py
@@ -2,9 +2,6 @@ from collections import OrderedDict
 
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from ..ast import *
-
 from .flatten import flattenBlocks, flattenSubroutines
 
 

--- a/pyteal/ir/tealblock_test.py
+++ b/pyteal/ir/tealblock_test.py
@@ -1,8 +1,5 @@
 from .. import *
 
-# this is not necessary but mypy complains if it's not included
-from .. import CompileOptions
-
 options = CompileOptions()
 
 


### PR DESCRIPTION
Removes redundant test imports as requested in https://github.com/algorand/pyteal/pull/273#discussion_r849969441.

Unfortunately, I made the changes by hand.  I was unable to craft a sed expression to match the comment + next line _and_ delete.

As a sanity check, here's proof that there ought to be 34 files modified:

```
~/dev/pyteal make-and-flake *1 ?5 ──────────────────────────────────────────────────────────────────────────────────────  pyteal 09:54:15 PM
❯ grep -R "this is not necessary" pyteal | sort | uniq -c
   1 pyteal/ast/acct_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/app_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/arg_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/assert_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/asset_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/binaryexpr_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/break_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/bytes_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/cond_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/continue_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/for_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/gaid_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/gload_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/global_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/if_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/int_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/itxn_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/maybe_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/naryexpr_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/nonce_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/return_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/scratch_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/scratchvar_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/seq_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/subroutine_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/substring_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/ternaryexpr_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/tmpl_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/txn_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/unaryexpr_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ast/while_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/compiler/compiler_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/compiler/flatten_test.py:# this is not necessary but mypy complains if it's not included
   1 pyteal/ir/tealblock_test.py:# this is not necessary but mypy complains if it's not included

~/dev/pyteal make-and-flake *1 ?5 ──────────────────────────────────────────────────────────────────────────────────────  pyteal 09:56:08 PM
❯ grep -R "this is not necessary" pyteal | wc -l
      34
```