### PR TITLE
ABI Strings

### DIFF
--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -1,5 +1,5 @@
 from .string import String, StringTypeSpec
-from .address import AddressTypeSpec, Address
+from .address import AddressTypeSpec, Address, ADDRESS_LENGTH
 from .type import TypeSpec, BaseType, ComputedValue
 from .bool import BoolTypeSpec, Bool
 from .uint import (
@@ -38,6 +38,7 @@ __all__ = [
     "StringTypeSpec",
     "Address",
     "AddressTypeSpec",
+    "ADDRESS_LENGTH",
     "TypeSpec",
     "BaseType",
     "ComputedValue",

--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -1,3 +1,4 @@
+from .string import String, Address, StringTypeSpec, AddressTypeSpec
 from .type import TypeSpec, BaseType, ComputedValue
 from .bool import BoolTypeSpec, Bool
 from .uint import (
@@ -32,6 +33,10 @@ from .util import type_spec_from_annotation
 from .method_return import MethodReturn
 
 __all__ = [
+    "String",
+    "StringTypeSpec",
+    "Address",
+    "AddressTypeSpec",
     "TypeSpec",
     "BaseType",
     "ComputedValue",

--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -1,4 +1,5 @@
-from .string import String, Address, StringTypeSpec, AddressTypeSpec
+from .string import String, StringTypeSpec
+from .address import AddressTypeSpec, Address
 from .type import TypeSpec, BaseType, ComputedValue
 from .bool import BoolTypeSpec, Bool
 from .uint import (

--- a/pyteal/ast/abi/address.py
+++ b/pyteal/ast/abi/address.py
@@ -2,12 +2,12 @@ from .array_static import StaticArray, StaticArrayTypeSpec
 from .uint import ByteTypeSpec
 from ..expr import Expr
 
-address_length = 32
+ADDRESS_LENGTH = 32
 
 
 class AddressTypeSpec(StaticArrayTypeSpec):
     def __init__(self) -> None:
-        super().__init__(ByteTypeSpec(), address_length)
+        super().__init__(ByteTypeSpec(), ADDRESS_LENGTH)
 
     def new_instance(self) -> "Address":
         return Address()
@@ -21,7 +21,7 @@ AddressTypeSpec.__module__ = "pyteal"
 
 class Address(StaticArray):
     def __init__(self) -> None:
-        super().__init__(AddressTypeSpec(), address_length)
+        super().__init__(AddressTypeSpec(), ADDRESS_LENGTH)
 
     def type_spec(self) -> AddressTypeSpec:
         return AddressTypeSpec()

--- a/pyteal/ast/abi/address.py
+++ b/pyteal/ast/abi/address.py
@@ -1,0 +1,33 @@
+from .array_static import StaticArray, StaticArrayTypeSpec
+from .uint import ByteTypeSpec
+from ..expr import Expr
+
+address_length = 32
+
+
+class AddressTypeSpec(StaticArrayTypeSpec):
+    def __init__(self) -> None:
+        super().__init__(ByteTypeSpec(), address_length)
+
+    def new_instance(self) -> "Address":
+        return Address()
+
+    def __str__(self) -> str:
+        return "address"
+
+
+AddressTypeSpec.__module__ = "pyteal"
+
+
+class Address(StaticArray):
+    def __init__(self) -> None:
+        super().__init__(AddressTypeSpec(), address_length)
+
+    def type_spec(self) -> AddressTypeSpec:
+        return AddressTypeSpec()
+
+    def get(self) -> Expr:
+        return self.stored_value.load()
+
+
+Address.__module__ = "pyteal"

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -1,21 +1,25 @@
 from .type_test import ContainerType
-from os import urandom
 
 from ... import *
 
 options = CompileOptions(version=5)
 
+
 def test_AddressTypeSpec_str():
     assert str(abi.AddressTypeSpec()) == "address"
-        
+
+
 def test_AddressTypeSpec_is_dynamic():
     assert not (abi.AddressTypeSpec()).is_dynamic()
 
-def test_AddressTypeSpec_is_dynamic():
+
+def test_AddressTypeSpec_byte_length_static():
     assert (abi.AddressTypeSpec()).byte_length_static() == 32
+
 
 def test_AddressTypeSpec_new_instance():
     assert isinstance(abi.AddressTypeSpec().new_instance(), abi.Address)
+
 
 def test_AddressTypeSpec_eq():
     assert abi.AddressTypeSpec() == abi.AddressTypeSpec()
@@ -27,6 +31,7 @@ def test_AddressTypeSpec_eq():
     ):
         assert abi.AddressTypeSpec() != otherType
 
+
 def test_Address_encode():
     value = abi.Address()
     expr = value.encode()
@@ -37,7 +42,10 @@ def test_Address_encode():
     actual, _ = expr.__teal__(options)
     assert actual == expected
 
+
 def test_Address_decode():
+    from os import urandom
+
     value = abi.Address()
     for value_to_set in [urandom(32) for x in range(10)]:
         expr = value.decode(Bytes(value_to_set))
@@ -48,7 +56,7 @@ def test_Address_decode():
         expected = TealSimpleBlock(
             [
                 TealOp(None, Op.byte, f"0x{value_to_set.hex()}"),
-                TealOp(None, Op.store, value.stored_value.slot)
+                TealOp(None, Op.store, value.stored_value.slot),
             ]
         )
         actual, _ = expr.__teal__(options)
@@ -58,14 +66,6 @@ def test_Address_decode():
         with TealComponent.Context.ignoreExprEquality():
             assert actual == expected
 
-#def test_Address_set_static():
-#    value = abi.Address()
-#    for value_to_set in [urandom(32) for x in range(10)]:
-#        print(value_to_set)
-#        expr = value.set(Bytes(value_to_set))
-#
-#        assert expr.type_of() == TealType.none
-#        assert not expr.has_return()
 
 def test_Address_get():
     value = abi.Address()
@@ -76,3 +76,13 @@ def test_Address_get():
     expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
     actual, _ = expr.__teal__(options)
     assert actual == expected
+
+
+# def test_Address_set_static():
+#    value = abi.Address()
+#    for value_to_set in [urandom(32) for x in range(10)]:
+#        print(value_to_set)
+#        expr = value.set(Bytes(value_to_set))
+#
+#        assert expr.type_of() == TealType.none
+#        assert not expr.has_return()

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -76,13 +76,3 @@ def test_Address_get():
     expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
     actual, _ = expr.__teal__(options)
     assert actual == expected
-
-
-# def test_Address_set_static():
-#    value = abi.Address()
-#    for value_to_set in [urandom(32) for x in range(10)]:
-#        print(value_to_set)
-#        expr = value.set(Bytes(value_to_set))
-#
-#        assert expr.type_of() == TealType.none
-#        assert not expr.has_return()

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -8,7 +8,7 @@ def test_AddressTypeSpec_str():
 
 
 def test_AddressTypeSpec_is_dynamic():
-    assert not (abi.AddressTypeSpec()).is_dynamic()
+    assert (abi.AddressTypeSpec()).is_dynamic() is False
 
 
 def test_AddressTypeSpec_byte_length_static():

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -1,0 +1,78 @@
+from .type_test import ContainerType
+from os import urandom
+
+from ... import *
+
+options = CompileOptions(version=5)
+
+def test_AddressTypeSpec_str():
+    assert str(abi.AddressTypeSpec()) == "address"
+        
+def test_AddressTypeSpec_is_dynamic():
+    assert not (abi.AddressTypeSpec()).is_dynamic()
+
+def test_AddressTypeSpec_is_dynamic():
+    assert (abi.AddressTypeSpec()).byte_length_static() == 32
+
+def test_AddressTypeSpec_new_instance():
+    assert isinstance(abi.AddressTypeSpec().new_instance(), abi.Address)
+
+def test_AddressTypeSpec_eq():
+    assert abi.AddressTypeSpec() == abi.AddressTypeSpec()
+
+    for otherType in (
+        abi.ByteTypeSpec,
+        abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 31),
+        abi.DynamicArrayTypeSpec(abi.ByteTypeSpec()),
+    ):
+        assert abi.AddressTypeSpec() != otherType
+
+def test_Address_encode():
+    value = abi.Address()
+    expr = value.encode()
+    assert expr.type_of() == TealType.bytes
+    assert not expr.has_return()
+
+    expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
+    actual, _ = expr.__teal__(options)
+    assert actual == expected
+
+def test_Address_decode():
+    value = abi.Address()
+    for value_to_set in [urandom(32) for x in range(10)]:
+        expr = value.decode(Bytes(value_to_set))
+
+        assert expr.type_of() == TealType.none
+        assert not expr.has_return()
+
+        expected = TealSimpleBlock(
+            [
+                TealOp(None, Op.byte, f"0x{value_to_set.hex()}"),
+                TealOp(None, Op.store, value.stored_value.slot)
+            ]
+        )
+        actual, _ = expr.__teal__(options)
+        actual.addIncoming()
+        actual = TealBlock.NormalizeBlocks(actual)
+
+        with TealComponent.Context.ignoreExprEquality():
+            assert actual == expected
+
+#def test_Address_set_static():
+#    value = abi.Address()
+#    for value_to_set in [urandom(32) for x in range(10)]:
+#        print(value_to_set)
+#        expr = value.set(Bytes(value_to_set))
+#
+#        assert expr.type_of() == TealType.none
+#        assert not expr.has_return()
+
+def test_Address_get():
+    value = abi.Address()
+    expr = value.get()
+    assert expr.type_of() == TealType.bytes
+    assert not expr.has_return()
+
+    expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
+    actual, _ = expr.__teal__(options)
+    assert actual == expected

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -34,7 +34,7 @@ def test_Address_encode():
     value = abi.Address()
     expr = value.encode()
     assert expr.type_of() == TealType.bytes
-    assert not expr.has_return()
+    assert expr.has_return() is False
 
     expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
     actual, _ = expr.__teal__(options)
@@ -49,7 +49,7 @@ def test_Address_decode():
         expr = value.decode(Bytes(value_to_set))
 
         assert expr.type_of() == TealType.none
-        assert not expr.has_return()
+        assert expr.has_return() is False
 
         expected = TealSimpleBlock(
             [
@@ -69,7 +69,7 @@ def test_Address_get():
     value = abi.Address()
     expr = value.get()
     assert expr.type_of() == TealType.bytes
-    assert not expr.has_return()
+    assert expr.has_return() is False
 
     expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
     actual, _ = expr.__teal__(options)

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -1,5 +1,3 @@
-from .type_test import ContainerType
-
 from ... import *
 
 options = CompileOptions(version=5)
@@ -14,7 +12,7 @@ def test_AddressTypeSpec_is_dynamic():
 
 
 def test_AddressTypeSpec_byte_length_static():
-    assert (abi.AddressTypeSpec()).byte_length_static() == 32
+    assert (abi.AddressTypeSpec()).byte_length_static() == abi.ADDRESS_LENGTH
 
 
 def test_AddressTypeSpec_new_instance():
@@ -47,7 +45,7 @@ def test_Address_decode():
     from os import urandom
 
     value = abi.Address()
-    for value_to_set in [urandom(32) for x in range(10)]:
+    for value_to_set in [urandom(abi.ADDRESS_LENGTH) for x in range(10)]:
         expr = value.decode(Bytes(value_to_set))
 
         assert expr.type_of() == TealType.none

--- a/pyteal/ast/abi/string.py
+++ b/pyteal/ast/abi/string.py
@@ -1,0 +1,55 @@
+from .array_static import StaticArray, StaticArrayTypeSpec
+from .array_dynamic import DynamicArray, DynamicArrayTypeSpec
+from .uint import ByteTypeSpec
+
+address_length = 32
+
+
+class AddressTypeSpec(StaticArrayTypeSpec):
+    def __init__(self) -> None:
+        super().__init__(ByteTypeSpec, address_length)
+
+    def new_instance(self) -> "Address":
+        return Address()
+
+    def __str__(self) -> str:
+        return "address"
+
+
+AddressTypeSpec.__module__ = "pyteal"
+
+
+class Address(StaticArray):
+    def __init__(self) -> None:
+        super().__init__(AddressTypeSpec(), address_length)
+
+    def type_spec(self) -> AddressTypeSpec:
+        return AddressTypeSpec()
+
+
+Address.__module__ = "pyteal"
+
+
+class StringTypeSpec(DynamicArrayTypeSpec):
+    def __init__(self) -> None:
+        super().__init__(ByteTypeSpec)
+
+    def new_instance(self) -> "String":
+        return String()
+
+    def __str__(self) -> str:
+        return "string"
+
+
+StringTypeSpec.__module__ = "pyteal"
+
+
+class String(DynamicArray):
+    def __init__(self) -> None:
+        super().__init__(StringTypeSpec())
+
+    def type_spec(self) -> StringTypeSpec:
+        return StringTypeSpec()
+
+
+String.__module__ = "pyteal"

--- a/pyteal/ast/abi/string.py
+++ b/pyteal/ast/abi/string.py
@@ -1,7 +1,5 @@
-from typing import Union
-from .array_static import StaticArray, StaticArrayTypeSpec
 from .array_dynamic import DynamicArray, DynamicArrayTypeSpec
-from .uint import ByteTypeSpec
+from .uint import ByteTypeSpec, Uint16TypeSpec
 from .util import substringForDecoding
 
 from ..int import Int
@@ -30,22 +28,9 @@ class String(DynamicArray):
         return StringTypeSpec()
 
     def get(self) -> Expr:
-        return substringForDecoding(self.stored_value.load(), startIndex=Int(2))
-
-    def __getslice__(self, low: Union[int, Int], high: Union[int, Int]):
-        if type(low) is int:
-            low = Int(low)
-
-        if type(high) is int:
-            high = Int(high)
-
-        if not isinstance(low, Int):
-            raise TypeError("low expected int or Int, got {low}")
-        if not isinstance(high, Int):
-            raise TypeError("high expected int or Int, got {high}")
-
         return substringForDecoding(
-            self.stored_value.load(), startIndex=Int(2) + low, endIndex=Int(2) + high
+            self.stored_value.load(),
+            startIndex=Int(Uint16TypeSpec().byte_length_static()),
         )
 
 

--- a/pyteal/ast/abi/string.py
+++ b/pyteal/ast/abi/string.py
@@ -1,3 +1,4 @@
+from typing import Union
 from .array_static import StaticArray, StaticArrayTypeSpec
 from .array_dynamic import DynamicArray, DynamicArrayTypeSpec
 from .uint import ByteTypeSpec
@@ -60,6 +61,22 @@ class String(DynamicArray):
 
     def get(self) -> Expr:
         return substringForDecoding(self.stored_value.load(), startIndex=Int(2))
+
+    def __getslice__(self, low: Union[int, Int], high: Union[int, Int]):
+        if type(low) is int:
+            low = Int(low)
+
+        if type(high) is int:
+            high = Int(high)
+
+        if not isinstance(low, Int):
+            raise TypeError("low expected int or Int, got {low}")
+        if not isinstance(high, Int):
+            raise TypeError("high expected int or Int, got {high}")
+
+        
+        return substringForDecoding(self.stored_value.load(), startIndex=Int(2)+low, endIndex=Int(2)+high)
+
 
 
 String.__module__ = "pyteal"

--- a/pyteal/ast/abi/string.py
+++ b/pyteal/ast/abi/string.py
@@ -7,36 +7,6 @@ from .util import substringForDecoding
 from ..int import Int
 from ..expr import Expr
 
-address_length = 32
-
-
-class AddressTypeSpec(StaticArrayTypeSpec):
-    def __init__(self) -> None:
-        super().__init__(ByteTypeSpec(), address_length)
-
-    def new_instance(self) -> "Address":
-        return Address()
-
-    def __str__(self) -> str:
-        return "address"
-
-
-AddressTypeSpec.__module__ = "pyteal"
-
-
-class Address(StaticArray):
-    def __init__(self) -> None:
-        super().__init__(AddressTypeSpec(), address_length)
-
-    def type_spec(self) -> AddressTypeSpec:
-        return AddressTypeSpec()
-
-    def get(self) -> Expr:
-        return self.stored_value.load()
-
-
-Address.__module__ = "pyteal"
-
 
 class StringTypeSpec(DynamicArrayTypeSpec):
     def __init__(self) -> None:
@@ -74,9 +44,9 @@ class String(DynamicArray):
         if not isinstance(high, Int):
             raise TypeError("high expected int or Int, got {high}")
 
-        
-        return substringForDecoding(self.stored_value.load(), startIndex=Int(2)+low, endIndex=Int(2)+high)
-
+        return substringForDecoding(
+            self.stored_value.load(), startIndex=Int(2) + low, endIndex=Int(2) + high
+        )
 
 
 String.__module__ = "pyteal"

--- a/pyteal/ast/abi/string.py
+++ b/pyteal/ast/abi/string.py
@@ -1,13 +1,17 @@
 from .array_static import StaticArray, StaticArrayTypeSpec
 from .array_dynamic import DynamicArray, DynamicArrayTypeSpec
 from .uint import ByteTypeSpec
+from .util import substringForDecoding
+
+from ..int import Int
+from ..expr import Expr
 
 address_length = 32
 
 
 class AddressTypeSpec(StaticArrayTypeSpec):
     def __init__(self) -> None:
-        super().__init__(ByteTypeSpec, address_length)
+        super().__init__(ByteTypeSpec(), address_length)
 
     def new_instance(self) -> "Address":
         return Address()
@@ -26,13 +30,16 @@ class Address(StaticArray):
     def type_spec(self) -> AddressTypeSpec:
         return AddressTypeSpec()
 
+    def get(self) -> Expr:
+        return self.stored_value.load()
+
 
 Address.__module__ = "pyteal"
 
 
 class StringTypeSpec(DynamicArrayTypeSpec):
     def __init__(self) -> None:
-        super().__init__(ByteTypeSpec)
+        super().__init__(ByteTypeSpec())
 
     def new_instance(self) -> "String":
         return String()
@@ -50,6 +57,9 @@ class String(DynamicArray):
 
     def type_spec(self) -> StringTypeSpec:
         return StringTypeSpec()
+
+    def get(self) -> Expr:
+        return substringForDecoding(self.stored_value.load(), startIndex=Int(2))
 
 
 String.__module__ = "pyteal"

--- a/pyteal/ast/abi/string_test.py
+++ b/pyteal/ast/abi/string_test.py
@@ -30,7 +30,7 @@ def test_String_encode():
     value = abi.String()
     expr = value.encode()
     assert expr.type_of() == TealType.bytes
-    assert not expr.has_return()
+    assert expr.has_return() is False
 
     expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
     actual, _ = expr.__teal__(options)
@@ -46,7 +46,7 @@ def test_String_decode():
         expr = value.decode(Bytes(value_to_set))
 
         assert expr.type_of() == TealType.none
-        assert not expr.has_return()
+        assert expr.has_return() is False
 
         expected = TealSimpleBlock(
             [
@@ -66,7 +66,7 @@ def test_String_get():
     value = abi.String()
     expr = value.get()
     assert expr.type_of() == TealType.bytes
-    assert not expr.has_return()
+    assert expr.has_return() is False
 
     expected = TealSimpleBlock(
         [TealOp(expr, Op.load, value.stored_value.slot), TealOp(None, Op.extract, 2, 0)]

--- a/pyteal/ast/abi/string_test.py
+++ b/pyteal/ast/abi/string_test.py
@@ -1,0 +1,33 @@
+from .type_test import ContainerType
+from os import urandom
+
+from ... import *
+
+import pytest
+
+options = CompileOptions(version=5)
+
+
+def test_String_encode():
+    value = abi.String()
+
+    tspec = value.type_spec() 
+    assert tspec.is_dynamic()
+    assert str(tspec) == "string"
+
+    expr = value.encode()
+    assert expr.type_of() == TealType.bytes
+    assert not expr.has_return()
+    
+
+    expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
+    actual, _ = expr.__teal__(options)
+    assert actual == expected
+    assert expr == value.get()
+
+
+def test_String_decode():
+    pass
+
+def test_String_get():
+    pass

--- a/pyteal/ast/abi/string_test.py
+++ b/pyteal/ast/abi/string_test.py
@@ -77,13 +77,3 @@ def test_String_get():
 
     with TealComponent.Context.ignoreExprEquality():
         assert actual == expected
-
-
-# def test_String_set_static():
-#    value = abi.String()
-#    for value_to_set in [urandom(32) for x in range(10)]:
-#        print(value_to_set)
-#        expr = value.set(Bytes(value_to_set))
-#
-#        assert expr.type_of() == TealType.none
-#        assert not expr.has_return()

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -107,7 +107,8 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         Tuple4,
         Tuple5,
     )
-    from .string import String, Address, StringTypeSpec, AddressTypeSpec
+    from .string import StringTypeSpec, String
+    from .address import AddressTypeSpec, Address 
 
     origin = get_origin(annotation)
     if origin is None:

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -107,6 +107,7 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         Tuple4,
         Tuple5,
     )
+    from .string import String, Address, StringTypeSpec, AddressTypeSpec
 
     origin = get_origin(annotation)
     if origin is None:
@@ -143,6 +144,16 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         if len(args) != 0:
             raise TypeError("Uint64 expects 0 type arguments. Got: {}".format(args))
         return Uint64TypeSpec()
+
+    if origin is String:
+        if len(args) != 0:
+            raise TypeError("String expects 0 arguments. Got: {}".format(args))
+        return StringTypeSpec()
+
+    if origin is Address:
+        if len(args) != 0:
+            raise TypeError("Address expects 0 arguments. Got: {}".format(args))
+        return AddressTypeSpec()
 
     if origin is DynamicArray:
         if len(args) != 1:

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -108,7 +108,7 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         Tuple5,
     )
     from .string import StringTypeSpec, String
-    from .address import AddressTypeSpec, Address 
+    from .address import AddressTypeSpec, Address
 
     origin = get_origin(annotation)
     if origin is None:


### PR DESCRIPTION
Adding Address and String that subclass other Array types with hardcoded type specs

Closes #280 

- [x] Address type def
- [x] Address Testing
- [x] String type def
- [x] String testing

Follow up PR should implement setting directly from a byte string and mayybee a slice overload for __getitem__ on string?