### PR TITLE
Use absolute imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,3 +24,7 @@ per-file-ignores =
     pyteal/__init__.py:                             F401, F403
     pyteal/ir/ops.py:                               E221
     tests/module_test.py:                           F401, F403
+    tests/*.py:                                     I252
+
+# from flake8-tidy-imports
+ban-relative-imports = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,20 @@
 # Contribution Guide
 
-If you are interested in contributing to the project, we welcome and thank you. We want to make the
-best decentralized and effective blockchain platform available and we appreciate your willingness to
-help us.
+If you are interested in contributing to the project, we welcome and thank you. We want to make the best decentralized and effective blockchain platform available and we appreciate your willingness to help us.
 
 ## Filing Issues
 
-Did you discover a bug? Do you have a feature request? Filing issues is an easy way anyone can
-contribute and helps us improve PyTeal. We use GitHub Issues to track all known bugs and feature
-requests.
+Did you discover a bug? Do you have a feature request? Filing issues is an easy way anyone can contribute and helps us improve PyTeal. We use GitHub Issues to track all known bugs and feature requests.
 
-Before logging an issue be sure to check current issues, check the [open GitHub issues][issues_url]
-to see if your issue is described there.
+Before logging an issue be sure to check current issues, check the [open GitHub issues][issues_url] to see if your issue is described there.
 
-If you’d like to contribute to any of the repositories, please file a [GitHub issue][issues_url]
-using the issues menu item. Make sure to specify whether you are describing a bug or a new
-enhancement using the **Bug report** or **Feature request** button.
+If you’d like to contribute to any of the repositories, please file a [GitHub issue][issues_url] using the issues menu item. Make sure to specify whether you are describing a bug or a new enhancement using the **Bug report** or **Feature request** button.
 
 See the GitHub help guide for more information on [filing an issue](https://help.github.com/en/articles/creating-an-issue).
 
 ## Contribution Model
 
-For each of our repositories we use the same model for contributing code. Developers wanting to 
-contribute must create pull requests. This process is described in the GitHub [Creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork)
-documentation. Each pull request should be initiated against the master branch in the Algorand
-repository.  After a pull request is submitted the core development team will review the submission
-and communicate with the developer using the comments sections of the PR. After the submission is
-reviewed and approved, it will be merged into the master branch of the source. These changes will be
-merged to our release branch on the next viable release date.
+For each of our repositories we use the same model for contributing code. Developers wanting to  contribute must create pull requests. This process is described in the GitHub [Creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) documentation. Each pull request should be initiated against the master branch in the Algorand repository.  After a pull request is submitted the core development team will review the submission and communicate with the developer using the comments sections of the PR. After the submission is reviewed and approved, it will be merged into the master branch of the source. These changes will be merged to our release branch on the next viable release date.
 
 ## Code Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,11 +33,11 @@ Since it's challenging to enforce these exceptions with a linter, we rely on PR 
 
 ### Module Guidelines
 
-Every directory containing source code should be a Python module, meaning it should have an `__init__.py` file. This `__init__.py` file is responsible for exporting all public objects (i.e.  classes, functions, and constants) for use outside of that module.
+Every directory containing source code should be a Python module, meaning it should have an `__init__.py` file. This `__init__.py` file is responsible for exporting all public objects (i.e. classes, functions, and constants) for use outside of that module.
 
 Modules may be created inside of other modules, in which case the deeper module is called a submodule or child module, and the module that contains it is called the parent module. For example, `pyteal` is the parent module to `pyteal.ast`.
 
-A sibling module is defined as a different child module of the parent module. For example, `pyteal.ast` and `pyteal.ir` as sibling modules.
+A sibling module is defined as a different child module of the parent module. For example, `pyteal.ast` and `pyteal.ir` are sibling modules.
 
 ### Import Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,41 @@
 # Contribution Guide
 
-If you are interested in contributing to the project, we welcome and thank you. We want to make the best decentralized and effective blockchain platform available and we appreciate your willingness to help us.
+If you are interested in contributing to the project, we welcome and thank you. We want to make the
+best decentralized and effective blockchain platform available and we appreciate your willingness to
+help us.
 
+## Filing Issues
 
+Did you discover a bug? Do you have a feature request? Filing issues is an easy way anyone can
+contribute and helps us improve PyTeal. We use GitHub Issues to track all known bugs and feature
+requests.
 
-# Filing Issues
+Before logging an issue be sure to check current issues, check the [open GitHub issues][issues_url]
+to see if your issue is described there.
 
-Did you discover a bug? Do you have a feature request? Filing issues is an easy way anyone can contribute and helps us improve PyTeal. We use GitHub Issues to track all known bugs and feature requests.
-
-Before logging an issue be sure to check current issues, check the [Developer Frequently Asked Questions](https://developer.algorand.org/docs/developer-faq) and [GitHub issues][issues_url] to see if your issue is described there.
-
-If you’d like to contribute to any of the repositories, please file a [GitHub issue][issues_url] using the issues menu item. Make sure to specify whether you are describing a bug or a new enhancement using the **Bug report** or **Feature request** button.
+If you’d like to contribute to any of the repositories, please file a [GitHub issue][issues_url]
+using the issues menu item. Make sure to specify whether you are describing a bug or a new
+enhancement using the **Bug report** or **Feature request** button.
 
 See the GitHub help guide for more information on [filing an issue](https://help.github.com/en/articles/creating-an-issue).
 
-# Contribution Model
+## Contribution Model
 
-For each of our repositories we use the same model for contributing code. Developers wanting to contribute must create pull requests. This process is described in the GitHub [Creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) documentation. Each pull request should be initiated against the master branch in the Algorand repository.  After a pull request is submitted the core development team will review the submission and communicate with the developer using the comments sections of the PR. After the submission is reviewed and approved, it will be merged into the master branch of the source. These changes will be merged to our release branch on the next viable release date.
+For each of our repositories we use the same model for contributing code. Developers wanting to 
+contribute must create pull requests. This process is described in the GitHub [Creating a pull request from a fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork)
+documentation. Each pull request should be initiated against the master branch in the Algorand
+repository.  After a pull request is submitted the core development team will review the submission
+and communicate with the developer using the comments sections of the PR. After the submission is
+reviewed and approved, it will be merged into the master branch of the source. These changes will be
+merged to our release branch on the next viable release date.
 
-# Code Guidelines
+## Code Guidelines
 
 We make a best-effort attempt to adhere to [PEP 8 - Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).  Keep the following context in mind:
 * Our default stance is to run linter checks during the build process.
 * Notable exception:  [naming conventions](https://peps.python.org/pep-0008/#naming-conventions).
 
-## Naming Convention Guidelines
+### Naming Convention Guidelines
 Since PyTeal aims for backwards compatibility, it's _not_ straightforward to change naming conventions in public APIs.  Consequently, the repo contains some deviations from PEP 8 naming conventions.
 
 In order to retain a consistent style, we prefer to continue deviating from PEP 8 naming conventions in the following cases.  We try to balance minimizing exceptions against providing a consistent style for existing software.
@@ -32,3 +43,51 @@ In order to retain a consistent style, we prefer to continue deviating from PEP 
 * Factory methods - Define following [class name](https://peps.python.org/pep-0008/#class-names) conventions.  Example:  https://github.com/algorand/pyteal/blob/7c953f600113abcb9a31df68165b61a2c897f591/pyteal/ast/ternaryexpr.py#L63
 
 Since it's challenging to enforce these exceptions with a linter, we rely on PR creators and reviewers to make a best-effort attempt to enforce agreed upon naming conventions.
+
+### Module Guidelines
+
+Every directory containing source code should be a Python module, meaning it should have an `__init__.py` file. This `__init__.py` file is responsible for exporting all public objects (i.e.  classes, functions, and constants) for use outside of that module.
+
+Modules may be created inside of other modules, in which case the deeper module is called a submodule or child module, and the module that contains it is called the parent module. For example, `pyteal` is the parent module to `pyteal.ast`.
+
+A sibling module is defined as a different child module of the parent module. For example, `pyteal.ast` and `pyteal.ir` as sibling modules.
+
+### Import Guidelines
+
+#### In Runtime Code
+
+When a runtime file in this codebase needs to import another module/file in this codebase, you should import the absolute path of the module/file, not the relative one, using the `from X import Y` method.
+
+With regard to modules, there are two ways to import an object from this codebase:
+
+* When importing an object from the same module or a parent module, you should import the full path of the source file that defines the object. For example:
+    * (Import from same module): If `pyteal/ast/seq.py` needs to import `Expr` defined in `pyteal/ast/expr.py`, it should use `from pyteal.ast.expr import Expr`. **DO NOT** use `from pyteal.ast import Expr` or `from pyteal import Expr`, as this will cause an unnecessary circular dependency.
+    * (Import from parent module): If `pyteal/ast/seq.py` needs to import `TealType` defined in `pyteal/types.py`, it should use `from pyteal.types import TealType`. **DO NOT** use `from pyteal import TealType`, as this will cause an unnecessary circular dependency.
+
+* When importing an object from a child module or sibling module, you should import the entire module folder and access the desired object from there. Do not directly import the file that defines the object. For example:
+    * (Import from child module): If `pyteal/compiler/compiler.py` needs to import `OptimizeOptions` from `pyteal/compiler/optimizer/optimizer.py`, it should use `from pyteal.compiler.optimizer import OptimizeOptions`. **DO NOT** use `from pyteal.compiler.optimizer.optimizer import OptimizeOptions`, as this will bypass the file `pyteal/compiler/optimizer/__init__.py`, which carefully defines the exports for the `pyteal.compiler.optimizer` module.
+    * (Import from sibling module): If `pyteal/compiler/compiler.py` needs to import `Expr` defined in `pyteal/ast/expr.py`, it should use `from pyteal.ast import Expr`. **DO NOT** use `from pyteal import Expr`, as this will cause an unnecessary circular dependency, nor `from pyteal.ast.expr import Expr`, as this will bypass the file `pyteal/ast/__init__.py`, which carefully defines the
+    exports for the `pyteal.ast` module.
+
+When this approach is followed properly, circular dependencies can happen in two ways:
+1. **Intra-module circular dependencies**, e.g. `m1/a.py` imports `m1/b.py` which imports `m1/a.py`. 
+   When this happens, normally one of the files only needs to import the other to implement something,
+   so the import statements can be moved from the top of the file to the body of the function that
+   needs them. This breaks the import cycle.
+
+2. **Inter-module circular dependencies**, e.g. `m1/a.py` imports module `m1/m2/__init__.py` which 
+   imports `m1/m2/x.py` which imports `m1/a.py`. To avoid this, make sure that any objects/files in
+   `m1` that need to be exposed to deeper modules do not rely on any objects from that deeper module.
+   If that isn’t possible, then perhaps `m1/a.py` belongs in the `m1/m2/` module.
+
+#### In Test Code
+
+Test code is typically any file that ends with `_test.py` or is in the top-level `tests` folder. In
+order to have a strong guarantee that we are testing in a similar environment to consumers of this
+library, test code is encouraged to import _only_ the top-level PyTeal module, either with
+`from pyteal import X, Y, Z` or `import pyteal as pt`.
+
+This way we can be sure all objects that should be publicly exported are in fact accessible from the top-level module.
+
+The only exception to this should be if the tests are for a non-exported object, in which case it is
+necessary to import the object according to the runtime rules in the previous section.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # PyTeal: Algorand Smart Contracts in Python
 
-[![Build Status](https://travis-ci.com/algorand/pyteal.svg?branch=master)](https://travis-ci.com/algorand/pyteal)
+[![Build Status](https://github.com/algorand/pyteal/actions/workflows/build.yml/badge.svg)](https://github.com/algorand/pyteal/actions)
 [![PyPI version](https://badge.fury.io/py/pyteal.svg)](https://badge.fury.io/py/pyteal)
 [![Documentation Status](https://readthedocs.org/projects/pyteal/badge/?version=latest)](https://pyteal.readthedocs.io/en/latest/?badge=latest)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/pyteal/__init__.py
+++ b/pyteal/__init__.py
@@ -1,8 +1,8 @@
-from .ast import *
-from .ast import __all__ as ast_all
-from .ir import *
-from .ir import __all__ as ir_all
-from .compiler import (
+from pyteal.ast import *
+from pyteal.ast import __all__ as ast_all
+from pyteal.ir import *
+from pyteal.ir import __all__ as ir_all
+from pyteal.compiler import (
     MAX_TEAL_VERSION,
     MIN_TEAL_VERSION,
     DEFAULT_TEAL_VERSION,
@@ -10,9 +10,14 @@ from .compiler import (
     compileTeal,
     OptimizeOptions,
 )
-from .types import TealType
-from .errors import TealInternalError, TealTypeError, TealInputError, TealCompileError
-from .config import MAX_GROUP_SIZE, NUM_SLOTS
+from pyteal.types import TealType
+from pyteal.errors import (
+    TealInternalError,
+    TealTypeError,
+    TealInputError,
+    TealCompileError,
+)
+from pyteal.config import MAX_GROUP_SIZE, NUM_SLOTS
 
 # begin __all__
 __all__ = (

--- a/pyteal/__init__.pyi
+++ b/pyteal/__init__.pyi
@@ -1,11 +1,11 @@
 ## File generated from scripts/generate_init.py.
 ## DO NOT EDIT DIRECTLY
 
-from .ast import *
-from .ast import __all__ as ast_all
-from .ir import *
-from .ir import __all__ as ir_all
-from .compiler import (
+from pyteal.ast import *
+from pyteal.ast import __all__ as ast_all
+from pyteal.ir import *
+from pyteal.ir import __all__ as ir_all
+from pyteal.compiler import (
     MAX_TEAL_VERSION,
     MIN_TEAL_VERSION,
     DEFAULT_TEAL_VERSION,
@@ -13,9 +13,14 @@ from .compiler import (
     compileTeal,
     OptimizeOptions,
 )
-from .types import TealType
-from .errors import TealInternalError, TealTypeError, TealInputError, TealCompileError
-from .config import MAX_GROUP_SIZE, NUM_SLOTS
+from pyteal.types import TealType
+from pyteal.errors import (
+    TealInternalError,
+    TealTypeError,
+    TealInputError,
+    TealCompileError,
+)
+from pyteal.config import MAX_GROUP_SIZE, NUM_SLOTS
 
 __all__ = [
     "AccountParam",

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -1,35 +1,43 @@
 # abstract types
-from .expr import Expr
+from pyteal.ast.expr import Expr
 
 # basic types
-from .leafexpr import LeafExpr
-from .addr import Addr
-from .bytes import Bytes
-from .int import Int, EnumInt
-from .methodsig import MethodSignature
+from pyteal.ast.leafexpr import LeafExpr
+from pyteal.ast.addr import Addr
+from pyteal.ast.bytes import Bytes
+from pyteal.ast.int import Int, EnumInt
+from pyteal.ast.methodsig import MethodSignature
 
 # properties
-from .arg import Arg
-from .txn import TxnType, TxnField, TxnExpr, TxnaExpr, TxnArray, TxnObject, Txn
-from .gtxn import GtxnExpr, GtxnaExpr, TxnGroup, Gtxn
-from .gaid import GeneratedID
-from .gitxn import Gitxn, GitxnExpr, GitxnaExpr, InnerTxnGroup
-from .gload import ImportScratchValue
-from .global_ import Global, GlobalField
-from .app import App, AppField, OnComplete, AppParam
-from .asset import AssetHolding, AssetParam
-from .acct import AccountParam
+from pyteal.ast.arg import Arg
+from pyteal.ast.txn import (
+    TxnType,
+    TxnField,
+    TxnExpr,
+    TxnaExpr,
+    TxnArray,
+    TxnObject,
+    Txn,
+)
+from pyteal.ast.gtxn import GtxnExpr, GtxnaExpr, TxnGroup, Gtxn
+from pyteal.ast.gaid import GeneratedID
+from pyteal.ast.gitxn import Gitxn, GitxnExpr, GitxnaExpr, InnerTxnGroup
+from pyteal.ast.gload import ImportScratchValue
+from pyteal.ast.global_ import Global, GlobalField
+from pyteal.ast.app import App, AppField, OnComplete, AppParam
+from pyteal.ast.asset import AssetHolding, AssetParam
+from pyteal.ast.acct import AccountParam
 
 # inner txns
-from .itxn import InnerTxnBuilder, InnerTxn, InnerTxnAction
+from pyteal.ast.itxn import InnerTxnBuilder, InnerTxn, InnerTxnAction
 
 # meta
-from .array import Array
-from .tmpl import Tmpl
-from .nonce import Nonce
+from pyteal.ast.array import Array
+from pyteal.ast.tmpl import Tmpl
+from pyteal.ast.nonce import Nonce
 
 # unary ops
-from .unaryexpr import (
+from pyteal.ast.unaryexpr import (
     UnaryExpr,
     Btoi,
     Itob,
@@ -51,7 +59,7 @@ from .unaryexpr import (
 )
 
 # binary ops
-from .binaryexpr import (
+from pyteal.ast.binaryexpr import (
     BinaryExpr,
     Add,
     Minus,
@@ -92,44 +100,44 @@ from .binaryexpr import (
 )
 
 # ternary ops
-from .ternaryexpr import Divw, Ed25519Verify, SetBit, SetByte
-from .substring import Substring, Extract, Suffix
+from pyteal.ast.ternaryexpr import Divw, Ed25519Verify, SetBit, SetByte
+from pyteal.ast.substring import Substring, Extract, Suffix
 
 # more ops
-from .naryexpr import NaryExpr, And, Or, Concat
-from .widemath import WideRatio
+from pyteal.ast.naryexpr import NaryExpr, And, Or, Concat
+from pyteal.ast.widemath import WideRatio
 
 # control flow
-from .if_ import If
-from .cond import Cond
-from .seq import Seq
-from .assert_ import Assert
-from .err import Err
-from .return_ import Return, Approve, Reject
-from .subroutine import (
+from pyteal.ast.if_ import If
+from pyteal.ast.cond import Cond
+from pyteal.ast.seq import Seq
+from pyteal.ast.assert_ import Assert
+from pyteal.ast.err import Err
+from pyteal.ast.return_ import Return, Approve, Reject
+from pyteal.ast.subroutine import (
     Subroutine,
     SubroutineDefinition,
     SubroutineDeclaration,
     SubroutineCall,
     SubroutineFnWrapper,
 )
-from .while_ import While
-from .for_ import For
-from .break_ import Break
-from .continue_ import Continue
+from pyteal.ast.while_ import While
+from pyteal.ast.for_ import For
+from pyteal.ast.break_ import Break
+from pyteal.ast.continue_ import Continue
 
 
 # misc
-from .scratch import (
+from pyteal.ast.scratch import (
     ScratchIndex,
     ScratchLoad,
     ScratchSlot,
     ScratchStackStore,
     ScratchStore,
 )
-from .scratchvar import DynamicScratchVar, ScratchVar
-from .maybe import MaybeValue
-from .multi import MultiValue
+from pyteal.ast.scratchvar import DynamicScratchVar, ScratchVar
+from pyteal.ast.maybe import MaybeValue
+from pyteal.ast.multi import MultiValue
 
 __all__ = [
     "Expr",

--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -1,7 +1,7 @@
-from ..types import TealType, require_type
-from ..ir import Op
-from .expr import Expr
-from .maybe import MaybeValue
+from pyteal.types import TealType, require_type
+from pyteal.ir import Op
+from pyteal.ast.expr import Expr
+from pyteal.ast.maybe import MaybeValue
 
 
 class AccountParam:

--- a/pyteal/ast/addr.py
+++ b/pyteal/ast/addr.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType, valid_address
-from ..ir import TealOp, Op, TealBlock
-from .leafexpr import LeafExpr
+from pyteal.types import TealType, valid_address
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Addr(LeafExpr):

--- a/pyteal/ast/app.py
+++ b/pyteal/ast/app.py
@@ -1,16 +1,16 @@
 from typing import TYPE_CHECKING
 from enum import Enum
 
-from ..types import TealType, require_type
-from ..ir import TealOp, Op, TealBlock
-from .leafexpr import LeafExpr
-from .expr import Expr
-from .maybe import MaybeValue
-from .int import EnumInt
-from .global_ import Global
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.leafexpr import LeafExpr
+from pyteal.ast.expr import Expr
+from pyteal.ast.maybe import MaybeValue
+from pyteal.ast.int import EnumInt
+from pyteal.ast.global_ import Global
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class OnComplete:

--- a/pyteal/ast/arg.py
+++ b/pyteal/ast/arg.py
@@ -1,13 +1,13 @@
 from typing import Union, cast, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..ir import TealOp, Op, TealBlock
-from ..errors import TealInputError, verifyTealVersion
-from .expr import Expr
-from .leafexpr import LeafExpr
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.errors import TealInputError, verifyTealVersion
+from pyteal.ast.expr import Expr
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Arg(LeafExpr):

--- a/pyteal/ast/array.py
+++ b/pyteal/ast/array.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from .expr import Expr
+from pyteal.ast.expr import Expr
 
 
 class Array(ABC):

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..ir import TealOp, Op, TealBlock, TealSimpleBlock, TealConditionalBlock
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealOp, Op, TealBlock, TealSimpleBlock, TealConditionalBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Assert(Expr):

--- a/pyteal/ast/asset.py
+++ b/pyteal/ast/asset.py
@@ -1,7 +1,7 @@
-from ..types import TealType, require_type
-from ..ir import Op
-from .expr import Expr
-from .maybe import MaybeValue
+from pyteal.types import TealType, require_type
+from pyteal.ir import Op
+from pyteal.ast.expr import Expr
+from pyteal.ast.maybe import MaybeValue
 
 
 class AssetHolding:

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -1,12 +1,12 @@
 from typing import Union, Tuple, cast, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..errors import verifyTealVersion
-from ..ir import TealOp, Op, TealBlock
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.errors import verifyTealVersion
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class BinaryExpr(Expr):

--- a/pyteal/ast/break_.py
+++ b/pyteal/ast/break_.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType
-from ..errors import TealCompileError
-from .expr import Expr
-from ..ir import TealSimpleBlock
+from pyteal.types import TealType
+from pyteal.errors import TealCompileError
+from pyteal.ast.expr import Expr
+from pyteal.ir import TealSimpleBlock
 
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Break(Expr):

--- a/pyteal/ast/bytes.py
+++ b/pyteal/ast/bytes.py
@@ -1,13 +1,13 @@
 from typing import Union, cast, overload, TYPE_CHECKING
 
-from ..types import TealType, valid_base16, valid_base32, valid_base64
-from ..util import escapeStr
-from ..ir import TealOp, Op, TealBlock
-from ..errors import TealInputError
-from .leafexpr import LeafExpr
+from pyteal.types import TealType, valid_base16, valid_base32, valid_base64
+from pyteal.util import escapeStr
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.errors import TealInputError
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Bytes(LeafExpr):

--- a/pyteal/ast/cond.py
+++ b/pyteal/ast/cond.py
@@ -1,12 +1,12 @@
 from typing import List, cast, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..ir import TealOp, Op, TealSimpleBlock, TealConditionalBlock
-from ..errors import TealInputError
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealOp, Op, TealSimpleBlock, TealConditionalBlock
+from pyteal.errors import TealInputError
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Cond(Expr):

--- a/pyteal/ast/continue_.py
+++ b/pyteal/ast/continue_.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType
-from ..errors import TealCompileError
-from .expr import Expr
-from ..ir import TealSimpleBlock
+from pyteal.types import TealType
+from pyteal.errors import TealCompileError
+from pyteal.ast.expr import Expr
+from pyteal.ir import TealSimpleBlock
 
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Continue(Expr):

--- a/pyteal/ast/err.py
+++ b/pyteal/ast/err.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType
-from ..ir import TealOp, Op, TealBlock
-from .expr import Expr
+from pyteal.types import TealType
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Err(Expr):

--- a/pyteal/ast/expr.py
+++ b/pyteal/ast/expr.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
 from typing import Tuple, List, TYPE_CHECKING
 
-from ..types import TealType
-from ..ir import TealBlock, TealSimpleBlock
+from pyteal.types import TealType
+from pyteal.ir import TealBlock, TealSimpleBlock
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Expr(ABC):
@@ -40,92 +40,92 @@ class Expr(ABC):
         pass
 
     def __lt__(self, other):
-        from .binaryexpr import Lt
+        from pyteal.ast.binaryexpr import Lt
 
         return Lt(self, other)
 
     def __gt__(self, other):
-        from .binaryexpr import Gt
+        from pyteal.ast.binaryexpr import Gt
 
         return Gt(self, other)
 
     def __le__(self, other):
-        from .binaryexpr import Le
+        from pyteal.ast.binaryexpr import Le
 
         return Le(self, other)
 
     def __ge__(self, other):
-        from .binaryexpr import Ge
+        from pyteal.ast.binaryexpr import Ge
 
         return Ge(self, other)
 
     def __eq__(self, other):
-        from .binaryexpr import Eq
+        from pyteal.ast.binaryexpr import Eq
 
         return Eq(self, other)
 
     def __ne__(self, other):
-        from .binaryexpr import Neq
+        from pyteal.ast.binaryexpr import Neq
 
         return Neq(self, other)
 
     def __add__(self, other):
-        from .binaryexpr import Add
+        from pyteal.ast.binaryexpr import Add
 
         return Add(self, other)
 
     def __sub__(self, other):
-        from .binaryexpr import Minus
+        from pyteal.ast.binaryexpr import Minus
 
         return Minus(self, other)
 
     def __mul__(self, other):
-        from .binaryexpr import Mul
+        from pyteal.ast.binaryexpr import Mul
 
         return Mul(self, other)
 
     def __truediv__(self, other):
-        from .binaryexpr import Div
+        from pyteal.ast.binaryexpr import Div
 
         return Div(self, other)
 
     def __mod__(self, other):
-        from .binaryexpr import Mod
+        from pyteal.ast.binaryexpr import Mod
 
         return Mod(self, other)
 
     def __pow__(self, other):
-        from .binaryexpr import Exp
+        from pyteal.ast.binaryexpr import Exp
 
         return Exp(self, other)
 
     def __invert__(self):
-        from .unaryexpr import BitwiseNot
+        from pyteal.ast.unaryexpr import BitwiseNot
 
         return BitwiseNot(self)
 
     def __and__(self, other):
-        from .binaryexpr import BitwiseAnd
+        from pyteal.ast.binaryexpr import BitwiseAnd
 
         return BitwiseAnd(self, other)
 
     def __or__(self, other):
-        from .binaryexpr import BitwiseOr
+        from pyteal.ast.binaryexpr import BitwiseOr
 
         return BitwiseOr(self, other)
 
     def __xor__(self, other):
-        from .binaryexpr import BitwiseXor
+        from pyteal.ast.binaryexpr import BitwiseXor
 
         return BitwiseXor(self, other)
 
     def __lshift__(self, other):
-        from .binaryexpr import ShiftLeft
+        from pyteal.ast.binaryexpr import ShiftLeft
 
         return ShiftLeft(self, other)
 
     def __rshift__(self, other):
-        from .binaryexpr import ShiftRight
+        from pyteal.ast.binaryexpr import ShiftRight
 
         return ShiftRight(self, other)
 
@@ -136,7 +136,7 @@ class Expr(ABC):
 
         This is the same as using :func:`And()` with two arguments.
         """
-        from .naryexpr import And
+        from pyteal.ast.naryexpr import And
 
         return And(self, other)
 
@@ -147,7 +147,7 @@ class Expr(ABC):
 
         This is the same as using :func:`Or()` with two arguments.
         """
-        from .naryexpr import Or
+        from pyteal.ast.naryexpr import Or
 
         return Or(self, other)
 

--- a/pyteal/ast/for_.py
+++ b/pyteal/ast/for_.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING, Optional
 
-from ..types import TealType, require_type
-from ..ir import TealSimpleBlock, TealConditionalBlock
-from ..errors import TealCompileError
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealSimpleBlock, TealConditionalBlock
+from pyteal.errors import TealCompileError
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class For(Expr):

--- a/pyteal/ast/gaid.py
+++ b/pyteal/ast/gaid.py
@@ -1,14 +1,14 @@
 from typing import cast, Union, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..ir import TealOp, Op, TealBlock
-from ..errors import TealInputError, verifyTealVersion
-from ..config import MAX_GROUP_SIZE
-from .expr import Expr
-from .leafexpr import LeafExpr
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.errors import TealInputError, verifyTealVersion
+from pyteal.config import MAX_GROUP_SIZE
+from pyteal.ast.expr import Expr
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class GeneratedID(LeafExpr):

--- a/pyteal/ast/gitxn.py
+++ b/pyteal/ast/gitxn.py
@@ -2,13 +2,13 @@ from typing import TYPE_CHECKING, cast, Union
 
 from pyteal.config import MAX_GROUP_SIZE
 
-from ..errors import TealInputError, verifyFieldVersion, verifyTealVersion
-from ..ir import TealOp, Op, TealBlock
-from .expr import Expr
-from .txn import TxnExpr, TxnField, TxnObject, TxnaExpr
+from pyteal.errors import TealInputError, verifyFieldVersion, verifyTealVersion
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.expr import Expr
+from pyteal.ast.txn import TxnExpr, TxnField, TxnObject, TxnaExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class GitxnExpr(TxnExpr):

--- a/pyteal/ast/gload.py
+++ b/pyteal/ast/gload.py
@@ -1,14 +1,14 @@
 from typing import cast, Union, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..ir import TealOp, Op, TealBlock
-from ..errors import TealInputError, verifyTealVersion
-from ..config import MAX_GROUP_SIZE, NUM_SLOTS
-from .expr import Expr
-from .leafexpr import LeafExpr
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.errors import TealInputError, verifyTealVersion
+from pyteal.config import MAX_GROUP_SIZE, NUM_SLOTS
+from pyteal.ast.expr import Expr
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class ImportScratchValue(LeafExpr):

--- a/pyteal/ast/global_.py
+++ b/pyteal/ast/global_.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
 from enum import Enum
 
-from ..types import TealType
-from ..errors import verifyFieldVersion
-from ..ir import TealOp, Op, TealBlock
-from .leafexpr import LeafExpr
+from pyteal.types import TealType
+from pyteal.errors import verifyFieldVersion
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class GlobalField(Enum):

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -1,14 +1,14 @@
 from typing import Union, cast, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..ir import TealOp, Op, TealBlock
-from ..errors import TealInputError, verifyFieldVersion, verifyTealVersion
-from ..config import MAX_GROUP_SIZE
-from .expr import Expr
-from .txn import TxnField, TxnExpr, TxnaExpr, TxnObject
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.errors import TealInputError, verifyFieldVersion, verifyTealVersion
+from pyteal.config import MAX_GROUP_SIZE
+from pyteal.ast.expr import Expr
+from pyteal.ast.txn import TxnField, TxnExpr, TxnaExpr, TxnObject
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 def validate_txn_index_or_throw(txnIndex: Union[int, Expr]):

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING
 
-from ..errors import TealCompileError, TealInputError
-from ..types import TealType, require_type
-from ..ir import TealSimpleBlock, TealConditionalBlock
-from .expr import Expr
+from pyteal.errors import TealCompileError, TealInputError
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealSimpleBlock, TealConditionalBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class If(Expr):

--- a/pyteal/ast/int.py
+++ b/pyteal/ast/int.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType
-from ..ir import TealOp, Op, TealBlock
-from ..errors import TealInputError
-from .leafexpr import LeafExpr
+from pyteal.types import TealType
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.errors import TealInputError
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Int(LeafExpr):

--- a/pyteal/ast/itxn.py
+++ b/pyteal/ast/itxn.py
@@ -1,15 +1,15 @@
 from enum import Enum
 from typing import Dict, TYPE_CHECKING, List, Union, cast
 
-from ..types import TealType, require_type
-from ..errors import TealInputError, verifyTealVersion
-from ..ir import TealOp, Op, TealBlock
-from .expr import Expr
-from .txn import TxnField, TxnExprBuilder, TxnaExprBuilder, TxnObject
-from .seq import Seq
+from pyteal.types import TealType, require_type
+from pyteal.errors import TealInputError, verifyTealVersion
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.expr import Expr
+from pyteal.ast.txn import TxnField, TxnExprBuilder, TxnaExprBuilder, TxnObject
+from pyteal.ast.seq import Seq
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class InnerTxnAction(Enum):

--- a/pyteal/ast/itxn_test.py
+++ b/pyteal/ast/itxn_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 import pyteal as pt
-from ..types import types_match
+from pyteal.types import types_match
 
 teal4Options = pt.CompileOptions(version=4)
 teal5Options = pt.CompileOptions(version=5)

--- a/pyteal/ast/leafexpr.py
+++ b/pyteal/ast/leafexpr.py
@@ -1,4 +1,4 @@
-from .expr import Expr
+from pyteal.ast.expr import Expr
 
 
 class LeafExpr(Expr):

--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -2,10 +2,10 @@ from typing import List, Union
 
 from pyteal.ast.multi import MultiValue
 
-from ..types import TealType
-from ..ir import Op
-from .expr import Expr
-from .scratch import ScratchLoad, ScratchSlot
+from pyteal.types import TealType
+from pyteal.ir import Op
+from pyteal.ast.expr import Expr
+from pyteal.ast.scratch import ScratchLoad, ScratchSlot
 
 
 class MaybeValue(MultiValue):

--- a/pyteal/ast/methodsig.py
+++ b/pyteal/ast/methodsig.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
 
-from ..errors import TealInputError
-from ..types import TealType
-from ..ir import TealOp, Op, TealBlock
+from pyteal.errors import TealInputError
+from pyteal.types import TealType
+from pyteal.ir import TealOp, Op, TealBlock
 
-from .leafexpr import LeafExpr
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class MethodSignature(LeafExpr):

--- a/pyteal/ast/multi.py
+++ b/pyteal/ast/multi.py
@@ -1,14 +1,14 @@
 from typing import Callable, List, Union, TYPE_CHECKING
 
-from ..types import TealType
-from ..ir import TealOp, Op, TealBlock
-from .expr import Expr
-from .leafexpr import LeafExpr
-from .scratch import ScratchSlot
-from .seq import Seq
+from pyteal.types import TealType
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.expr import Expr
+from pyteal.ast.leafexpr import LeafExpr
+from pyteal.ast.scratch import ScratchSlot
+from pyteal.ast.seq import Seq
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class MultiValue(LeafExpr):

--- a/pyteal/ast/naryexpr.py
+++ b/pyteal/ast/naryexpr.py
@@ -1,12 +1,12 @@
 from typing import Sequence, cast, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..errors import TealInputError
-from ..ir import TealOp, Op, TealSimpleBlock
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.errors import TealInputError
+from pyteal.ir import TealOp, Op, TealSimpleBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class NaryExpr(Expr):

--- a/pyteal/ast/nonce.py
+++ b/pyteal/ast/nonce.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
 
-from ..errors import TealInputError
-from .expr import Expr
-from .seq import Seq
-from .bytes import Bytes
-from .unaryexpr import Pop
+from pyteal.errors import TealInputError
+from pyteal.ast.expr import Expr
+from pyteal.ast.seq import Seq
+from pyteal.ast.bytes import Bytes
+from pyteal.ast.unaryexpr import Pop
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Nonce(Expr):

--- a/pyteal/ast/return_.py
+++ b/pyteal/ast/return_.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType, require_type, types_match
-from ..errors import verifyTealVersion, TealCompileError
-from ..ir import TealOp, Op, TealBlock
-from .expr import Expr
-from .int import Int
+from pyteal.types import TealType, require_type, types_match
+from pyteal.errors import verifyTealVersion, TealCompileError
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.expr import Expr
+from pyteal.ast.int import Int
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Return(Expr):

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -1,12 +1,12 @@
 from typing import cast, TYPE_CHECKING, Optional
 
-from ..types import TealType, require_type
-from ..config import NUM_SLOTS
-from ..errors import TealInputError, TealInternalError
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.config import NUM_SLOTS
+from pyteal.errors import TealInputError, TealInternalError
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class ScratchSlot:
@@ -87,7 +87,7 @@ class ScratchIndex(Expr):
         return False
 
     def __teal__(self, options: "CompileOptions"):
-        from ..ir import TealOp, Op, TealBlock
+        from pyteal.ir import TealOp, Op, TealBlock
 
         op = TealOp(self, Op.int, self.slot)
         return TealBlock.FromOp(options, op)
@@ -143,7 +143,7 @@ class ScratchLoad(Expr):
         return "(Load {})".format(self.slot if self.slot else self.index_expression)
 
     def __teal__(self, options: "CompileOptions"):
-        from ..ir import TealOp, Op, TealBlock
+        from pyteal.ir import TealOp, Op, TealBlock
 
         if self.index_expression is not None:
             op = TealOp(self, Op.loads)
@@ -203,7 +203,7 @@ class ScratchStore(Expr):
         )
 
     def __teal__(self, options: "CompileOptions"):
-        from ..ir import TealOp, Op, TealBlock
+        from pyteal.ir import TealOp, Op, TealBlock
 
         if self.index_expression is not None:
             op = TealOp(self, Op.stores)
@@ -246,7 +246,7 @@ class ScratchStackStore(Expr):
         return "(StackStore {})".format(self.slot)
 
     def __teal__(self, options: "CompileOptions"):
-        from ..ir import TealOp, Op, TealBlock
+        from pyteal.ir import TealOp, Op, TealBlock
 
         op = TealOp(self, Op.store, self.slot)
         return TealBlock.FromOp(options, op)

--- a/pyteal/ast/scratchvar.py
+++ b/pyteal/ast/scratchvar.py
@@ -1,8 +1,8 @@
-from ..errors import TealInputError
-from ..types import TealType, require_type
+from pyteal.errors import TealInputError
+from pyteal.types import TealType, require_type
 
-from .expr import Expr
-from .scratch import ScratchSlot, ScratchLoad, ScratchStore
+from pyteal.ast.expr import Expr
+from pyteal.ast.scratch import ScratchSlot, ScratchLoad, ScratchStore
 
 
 class ScratchVar:

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -1,12 +1,12 @@
 from typing import List, TYPE_CHECKING, overload
 
-from ..types import TealType, require_type
-from ..errors import TealInputError
-from ..ir import TealSimpleBlock
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.errors import TealInputError
+from pyteal.ir import TealSimpleBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Seq(Expr):

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -2,16 +2,16 @@ from collections import OrderedDict
 from inspect import isclass, Parameter, signature
 from typing import Callable, List, Optional, Set, Type, Union, TYPE_CHECKING
 
-from ..errors import TealInputError, verifyTealVersion
-from ..ir import TealOp, Op, TealBlock
-from ..types import TealType
+from pyteal.errors import TealInputError, verifyTealVersion
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.types import TealType
 
-from .expr import Expr
-from .seq import Seq
-from .scratchvar import DynamicScratchVar, ScratchVar
+from pyteal.ast.expr import Expr
+from pyteal.ast.seq import Seq
+from pyteal.ast.scratchvar import DynamicScratchVar, ScratchVar
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class SubroutineDefinition:

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -2,7 +2,7 @@ from typing import List
 import pytest
 
 import pyteal as pt
-from .subroutine import evaluateSubroutine
+from pyteal.ast.subroutine import evaluateSubroutine
 
 options = pt.CompileOptions(version=4)
 

--- a/pyteal/ast/substring.py
+++ b/pyteal/ast/substring.py
@@ -1,14 +1,14 @@
 from typing import cast, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..errors import TealCompileError, verifyTealVersion
-from ..ir import TealOp, Op, TealBlock, TealSimpleBlock
-from .expr import Expr
-from .int import Int
-from .ternaryexpr import TernaryExpr
+from pyteal.types import TealType, require_type
+from pyteal.errors import TealCompileError, verifyTealVersion
+from pyteal.ir import TealOp, Op, TealBlock, TealSimpleBlock
+from pyteal.ast.expr import Expr
+from pyteal.ast.int import Int
+from pyteal.ast.ternaryexpr import TernaryExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class SubstringExpr(Expr):

--- a/pyteal/ast/ternaryexpr.py
+++ b/pyteal/ast/ternaryexpr.py
@@ -1,12 +1,12 @@
 from typing import Tuple, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..errors import verifyTealVersion
-from ..ir import TealOp, Op, TealBlock
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.errors import verifyTealVersion
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class TernaryExpr(Expr):

--- a/pyteal/ast/tmpl.py
+++ b/pyteal/ast/tmpl.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType, valid_tmpl
-from ..ir import TealOp, Op, TealBlock
-from .leafexpr import LeafExpr
+from pyteal.types import TealType, valid_tmpl
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.leafexpr import LeafExpr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class Tmpl(LeafExpr):

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -1,21 +1,21 @@
 from enum import Enum
 from typing import Callable, Optional, Union, cast, TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..errors import (
+from pyteal.types import TealType, require_type
+from pyteal.errors import (
     TealInputError,
     TealCompileError,
     verifyFieldVersion,
     verifyTealVersion,
 )
-from ..ir import TealOp, Op, TealBlock
-from .leafexpr import LeafExpr
-from .expr import Expr
-from .int import EnumInt
-from .array import Array
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.leafexpr import LeafExpr
+from pyteal.ast.expr import Expr
+from pyteal.ast.int import EnumInt
+from pyteal.ast.array import Array
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class TxnType:

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING
 
-from ..types import TealType, require_type
-from ..errors import verifyTealVersion
-from ..ir import TealOp, Op, TealBlock
-from .expr import Expr
+from pyteal.types import TealType, require_type
+from pyteal.errors import verifyTealVersion
+from pyteal.ir import TealOp, Op, TealBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class UnaryExpr(Expr):

--- a/pyteal/ast/while_.py
+++ b/pyteal/ast/while_.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING, Optional
 
-from ..errors import TealCompileError
-from ..types import TealType, require_type
-from ..ir import TealSimpleBlock, TealConditionalBlock
-from .expr import Expr
+from pyteal.errors import TealCompileError
+from pyteal.types import TealType, require_type
+from pyteal.ir import TealSimpleBlock, TealConditionalBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 class While(Expr):

--- a/pyteal/ast/widemath.py
+++ b/pyteal/ast/widemath.py
@@ -1,12 +1,12 @@
 from typing import List, Tuple, TYPE_CHECKING
 
-from ..types import TealType
-from ..errors import TealInternalError, TealCompileError
-from ..ir import TealOp, Op, TealSimpleBlock
-from .expr import Expr
+from pyteal.types import TealType
+from pyteal.errors import TealInternalError, TealCompileError
+from pyteal.ir import TealOp, Op, TealSimpleBlock
+from pyteal.ast.expr import Expr
 
 if TYPE_CHECKING:
-    from ..compiler import CompileOptions
+    from pyteal.compiler import CompileOptions
 
 
 def multiplyFactors(

--- a/pyteal/compiler/__init__.py
+++ b/pyteal/compiler/__init__.py
@@ -1,4 +1,4 @@
-from .compiler import (
+from pyteal.compiler.compiler import (
     MAX_TEAL_VERSION,
     MIN_TEAL_VERSION,
     DEFAULT_TEAL_VERSION,
@@ -6,7 +6,7 @@ from .compiler import (
     compileTeal,
 )
 
-from .optimizer import OptimizeOptions
+from pyteal.compiler.optimizer import OptimizeOptions
 
 __all__ = [
     "MAX_TEAL_VERSION",

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -1,29 +1,29 @@
 from typing import List, Tuple, Set, Dict, Optional, cast
 
-from .optimizer import OptimizeOptions, apply_global_optimizations
+from pyteal.compiler.optimizer import OptimizeOptions, apply_global_optimizations
 
-from ..types import TealType
-from ..ast import (
+from pyteal.types import TealType
+from pyteal.ast import (
     Expr,
     Return,
     Seq,
     SubroutineDefinition,
     SubroutineDeclaration,
 )
-from ..ir import Mode, TealComponent, TealOp, TealBlock, TealSimpleBlock
-from ..errors import TealInputError, TealInternalError
+from pyteal.ir import Mode, TealComponent, TealOp, TealBlock, TealSimpleBlock
+from pyteal.errors import TealInputError, TealInternalError
 
-from .sort import sortBlocks
-from .flatten import flattenBlocks, flattenSubroutines
-from .scratchslots import (
+from pyteal.compiler.sort import sortBlocks
+from pyteal.compiler.flatten import flattenBlocks, flattenSubroutines
+from pyteal.compiler.scratchslots import (
     assignScratchSlotsToSubroutines,
     collect_unoptimized_slots,
 )
-from .subroutines import (
+from pyteal.compiler.subroutines import (
     spillLocalSlotsDuringRecursion,
     resolveSubroutines,
 )
-from .constants import createConstantBlocks
+from pyteal.compiler.constants import createConstantBlocks
 
 MAX_TEAL_VERSION = 6
 MIN_TEAL_VERSION = 2

--- a/pyteal/compiler/constants.py
+++ b/pyteal/compiler/constants.py
@@ -4,13 +4,13 @@ from typing import Union, List, Dict, cast
 from collections import OrderedDict
 from algosdk import encoding
 
-from ..ir import (
+from pyteal.ir import (
     Op,
     TealOp,
     TealComponent,
 )
-from ..util import unescapeStr, correctBase32Padding
-from ..errors import TealInternalError
+from pyteal.util import unescapeStr, correctBase32Padding
+from pyteal.errors import TealInternalError
 
 intEnumValues = {
     # OnComplete values

--- a/pyteal/compiler/constants_test.py
+++ b/pyteal/compiler/constants_test.py
@@ -1,6 +1,6 @@
 import pyteal as pt
 
-from .constants import (
+from pyteal.compiler.constants import (
     extractIntValue,
     extractBytesValue,
     extractAddrValue,

--- a/pyteal/compiler/flatten.py
+++ b/pyteal/compiler/flatten.py
@@ -1,8 +1,8 @@
 from typing import List, Dict, DefaultDict, Optional
 from collections import defaultdict
 
-from ..ast import SubroutineDefinition
-from ..ir import (
+from pyteal.ast import SubroutineDefinition
+from pyteal.ir import (
     Op,
     TealOp,
     TealLabel,
@@ -12,7 +12,7 @@ from ..ir import (
     TealConditionalBlock,
     LabelReference,
 )
-from ..errors import TealInternalError
+from pyteal.errors import TealInternalError
 
 
 def flattenBlocks(blocks: List[TealBlock]) -> List[TealComponent]:

--- a/pyteal/compiler/flatten_test.py
+++ b/pyteal/compiler/flatten_test.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 import pyteal as pt
 
-from .flatten import flattenBlocks, flattenSubroutines
+from pyteal.compiler.flatten import flattenBlocks, flattenSubroutines
 
 
 def test_flattenBlocks_none():

--- a/pyteal/compiler/optimizer/__init__.py
+++ b/pyteal/compiler/optimizer/__init__.py
@@ -1,1 +1,4 @@
-from .optimizer import OptimizeOptions, apply_global_optimizations
+from pyteal.compiler.optimizer.optimizer import (
+    OptimizeOptions,
+    apply_global_optimizations,
+)

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -1,7 +1,7 @@
 from typing import Set
-from ...ast import ScratchSlot
-from ...ir import TealBlock, TealOp, Op
-from ...errors import TealInternalError
+from pyteal.ast import ScratchSlot
+from pyteal.ir import TealBlock, TealOp, Op
+from pyteal.errors import TealInternalError
 
 
 class OptimizeOptions:

--- a/pyteal/compiler/optimizer/optimizer_test.py
+++ b/pyteal/compiler/optimizer/optimizer_test.py
@@ -1,4 +1,4 @@
-from .optimizer import OptimizeOptions, _apply_slot_to_stack
+from pyteal.compiler.optimizer.optimizer import OptimizeOptions, _apply_slot_to_stack
 
 import pyteal as pt
 

--- a/pyteal/compiler/scratchslots.py
+++ b/pyteal/compiler/scratchslots.py
@@ -1,9 +1,9 @@
 from typing import Tuple, Set, Dict, Optional, cast
 
-from ..ast import ScratchSlot, SubroutineDefinition
-from ..ir import TealBlock, Op
-from ..errors import TealInternalError
-from ..config import NUM_SLOTS
+from pyteal.ast import ScratchSlot, SubroutineDefinition
+from pyteal.ir import TealBlock, Op
+from pyteal.errors import TealInternalError
+from pyteal.config import NUM_SLOTS
 
 
 def collect_unoptimized_slots(

--- a/pyteal/compiler/scratchslots_test.py
+++ b/pyteal/compiler/scratchslots_test.py
@@ -2,7 +2,10 @@ import pytest
 
 import pyteal as pt
 
-from .scratchslots import collectScratchSlots, assignScratchSlotsToSubroutines
+from pyteal.compiler.scratchslots import (
+    collectScratchSlots,
+    assignScratchSlotsToSubroutines,
+)
 
 
 def test_collectScratchSlots():

--- a/pyteal/compiler/sort.py
+++ b/pyteal/compiler/sort.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from ..ir import TealBlock
-from ..errors import TealInternalError
+from pyteal.ir import TealBlock
+from pyteal.errors import TealInternalError
 
 
 def sortBlocks(start: TealBlock, end: TealBlock) -> List[TealBlock]:

--- a/pyteal/compiler/sort_test.py
+++ b/pyteal/compiler/sort_test.py
@@ -1,6 +1,6 @@
 import pyteal as pt
 
-from .sort import sortBlocks
+from pyteal.compiler.sort import sortBlocks
 
 
 def test_sort_single():

--- a/pyteal/compiler/subroutines.py
+++ b/pyteal/compiler/subroutines.py
@@ -2,10 +2,10 @@ import re
 from typing import List, Dict, Set, Optional, TypeVar
 from collections import OrderedDict
 
-from ..errors import TealInputError
-from ..types import TealType
-from ..ast import SubroutineDefinition
-from ..ir import TealComponent, TealOp, Op
+from pyteal.errors import TealInputError
+from pyteal.types import TealType
+from pyteal.ast import SubroutineDefinition
+from pyteal.ir import TealComponent, TealOp, Op
 
 # generic type variable
 Node = TypeVar("Node")

--- a/pyteal/compiler/subroutines_test.py
+++ b/pyteal/compiler/subroutines_test.py
@@ -4,7 +4,7 @@ import pytest
 
 import pyteal as pt
 
-from .subroutines import (
+from pyteal.compiler.subroutines import (
     findRecursionPoints,
     spillLocalSlotsDuringRecursion,
     resolveSubroutines,

--- a/pyteal/errors.py
+++ b/pyteal/errors.py
@@ -1,7 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .ast import Expr
+    from pyteal.ast import Expr
 
 
 class TealInternalError(Exception):

--- a/pyteal/ir/__init__.py
+++ b/pyteal/ir/__init__.py
@@ -1,13 +1,13 @@
-from .ops import Op, Mode
+from pyteal.ir.ops import Op, Mode
 
-from .tealcomponent import TealComponent
-from .tealop import TealOp
-from .teallabel import TealLabel
-from .tealblock import TealBlock
-from .tealsimpleblock import TealSimpleBlock
-from .tealconditionalblock import TealConditionalBlock
+from pyteal.ir.tealcomponent import TealComponent
+from pyteal.ir.tealop import TealOp
+from pyteal.ir.teallabel import TealLabel
+from pyteal.ir.tealblock import TealBlock
+from pyteal.ir.tealsimpleblock import TealSimpleBlock
+from pyteal.ir.tealconditionalblock import TealConditionalBlock
 
-from .labelref import LabelReference
+from pyteal.ir.labelref import LabelReference
 
 __all__ = [
     "Op",

--- a/pyteal/ir/tealblock.py
+++ b/pyteal/ir/tealblock.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import List, Tuple, Set, Iterator, cast, TYPE_CHECKING
 
-from .tealop import TealOp, Op
-from ..errors import TealCompileError
+from pyteal.ir.tealop import TealOp, Op
+from pyteal.errors import TealCompileError
 
 if TYPE_CHECKING:
-    from ..ast import Expr, ScratchSlot
-    from ..compiler import CompileOptions
-    from .tealsimpleblock import TealSimpleBlock
+    from pyteal.ast import Expr, ScratchSlot
+    from pyteal.compiler import CompileOptions
+    from pyteal.ir.tealsimpleblock import TealSimpleBlock
 
 
 class TealBlock(ABC):
@@ -140,7 +140,7 @@ class TealBlock(ABC):
         Returns:
             The starting and ending block of the path that encodes the given TealOp and arguments.
         """
-        from .tealsimpleblock import TealSimpleBlock
+        from pyteal.ir.tealsimpleblock import TealSimpleBlock
 
         opBlock = TealSimpleBlock([op])
 

--- a/pyteal/ir/tealcomponent.py
+++ b/pyteal/ir/tealcomponent.py
@@ -3,7 +3,7 @@ from typing import List, Optional, TYPE_CHECKING
 from contextlib import AbstractContextManager
 
 if TYPE_CHECKING:
-    from ..ast import Expr, ScratchSlot, SubroutineDefinition
+    from pyteal.ast import Expr, ScratchSlot, SubroutineDefinition
 
 
 class TealComponent(ABC):

--- a/pyteal/ir/tealconditionalblock.py
+++ b/pyteal/ir/tealconditionalblock.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 
-from .tealop import TealOp
-from .tealblock import TealBlock
+from pyteal.ir.tealop import TealOp
+from pyteal.ir.tealblock import TealBlock
 
 
 class TealConditionalBlock(TealBlock):

--- a/pyteal/ir/teallabel.py
+++ b/pyteal/ir/teallabel.py
@@ -1,10 +1,10 @@
 from typing import Optional, TYPE_CHECKING
 
-from .tealcomponent import TealComponent
-from .labelref import LabelReference
+from pyteal.ir.tealcomponent import TealComponent
+from pyteal.ir.labelref import LabelReference
 
 if TYPE_CHECKING:
-    from ..ast import Expr
+    from pyteal.ast import Expr
 
 
 class TealLabel(TealComponent):

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -1,12 +1,12 @@
 from typing import Union, List, Optional, TYPE_CHECKING
 
-from .tealcomponent import TealComponent
-from .labelref import LabelReference
-from .ops import Op
-from ..errors import TealInternalError
+from pyteal.ir.tealcomponent import TealComponent
+from pyteal.ir.labelref import LabelReference
+from pyteal.ir.ops import Op
+from pyteal.errors import TealInternalError
 
 if TYPE_CHECKING:
-    from ..ast import Expr, ScratchSlot, SubroutineDefinition
+    from pyteal.ast import Expr, ScratchSlot, SubroutineDefinition
 
 
 class TealOp(TealComponent):
@@ -24,7 +24,7 @@ class TealOp(TealComponent):
         return self.op
 
     def getSlots(self) -> List["ScratchSlot"]:
-        from ..ast import ScratchSlot
+        from pyteal.ast import ScratchSlot
 
         return [arg for arg in self.args if isinstance(arg, ScratchSlot)]
 
@@ -34,7 +34,7 @@ class TealOp(TealComponent):
                 self.args[i] = location
 
     def getSubroutines(self) -> List["SubroutineDefinition"]:
-        from ..ast import SubroutineDefinition
+        from pyteal.ast import SubroutineDefinition
 
         return [arg for arg in self.args if isinstance(arg, SubroutineDefinition)]
 
@@ -44,7 +44,7 @@ class TealOp(TealComponent):
                 self.args[i] = label
 
     def assemble(self) -> str:
-        from ..ast import ScratchSlot, SubroutineDefinition
+        from pyteal.ast import ScratchSlot, SubroutineDefinition
 
         parts = [str(self.op)]
         for arg in self.args:

--- a/pyteal/ir/tealsimpleblock.py
+++ b/pyteal/ir/tealsimpleblock.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 
-from .tealop import TealOp
-from .tealblock import TealBlock
+from pyteal.ir.tealop import TealOp
+from pyteal.ir.tealblock import TealBlock
 
 
 class TealSimpleBlock(TealBlock):

--- a/pyteal/types.py
+++ b/pyteal/types.py
@@ -2,7 +2,7 @@ import re
 from enum import Enum
 from typing import Any
 
-from .errors import TealTypeError, TealInputError
+from pyteal.errors import TealTypeError, TealInputError
 
 
 class TealType(Enum):

--- a/pyteal/types_test.py
+++ b/pyteal/types_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 import pyteal as pt
-from .types import require_type
+from pyteal.types import require_type
 
 
 def test_require_type():

--- a/pyteal/util.py
+++ b/pyteal/util.py
@@ -1,4 +1,4 @@
-from .errors import TealInternalError
+from pyteal.errors import TealInternalError
 
 
 def escapeStr(s: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
         "development": [
             "black==22.3.0",
             "flake8==4.0.1",
+            "flake8-tidy-imports==4.6.0",
             "mypy==0.942",
             "pytest==7.1.1",
             "pytest-cov==3.0.0",


### PR DESCRIPTION
Lately our relative imports have been a source of confusion/problems, and as of #273, absolute imports are now used by test code, so we might as well make the switch to absolute imports everywhere for consistency.

Though if there are objections, feel free to voice them.

Of particular note is the `CONTRIBUTING.md` file, in which I documented for the first time in this repo how our module and import conventions should work.