### PR TITLE
Move to pyteal as pt in ABI tests with concise `abi` prefix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,14 +24,4 @@ per-file-ignores =
     pyteal/__init__.py:                             F401, F403
     pyteal/ir/ops.py:                               E221
     tests/module_test.py:                           F401, F403
-    # Temporary ignores while merging
-    pyteal/ast/abi/array_base_test.py:              F403, F405
-    pyteal/ast/abi/array_dynamic_test.py:           F403, F405
-    pyteal/ast/abi/array_static_test.py:            F403, F405
-    pyteal/ast/abi/bool_test.py:                    F403, F405
-    pyteal/ast/abi/method_return_test.py:           F403, F405
-    pyteal/ast/abi/tuple_test.py:                   F403, F405
-    pyteal/ast/abi/type_test.py:                    F403, F405
-    pyteal/ast/abi/uint_test.py:                    F403, F405
-    pyteal/ast/abi/util_test.py:                    F403, F405
-    # End temporary ignores while merging
+

--- a/pyteal/ast/abi/array_base_test.py
+++ b/pyteal/ast/abi/array_base_test.py
@@ -1,9 +1,10 @@
 from typing import List, cast
 import pytest
 
-from ... import *
+import pyteal as pt
+from pyteal import abi
 
-options = CompileOptions(version=5)
+options = pt.CompileOptions(version=5)
 
 STATIC_TYPES: List[abi.TypeSpec] = [
     abi.BoolTypeSpec(),
@@ -53,31 +54,31 @@ DYNAMIC_TYPES: List[abi.TypeSpec] = [
 def test_ArrayElement_init():
     dynamicArrayType = abi.DynamicArrayTypeSpec(abi.Uint64TypeSpec())
     array = dynamicArrayType.new_instance()
-    index = Int(6)
+    index = pt.Int(6)
 
     element = abi.ArrayElement(array, index)
     assert element.array is array
     assert element.index is index
 
-    with pytest.raises(TealTypeError):
-        abi.ArrayElement(array, Bytes("abc"))
+    with pytest.raises(pt.TealTypeError):
+        abi.ArrayElement(array, pt.Bytes("abc"))
 
-    with pytest.raises(TealTypeError):
-        abi.ArrayElement(array, Assert(index))
+    with pytest.raises(pt.TealTypeError):
+        abi.ArrayElement(array, pt.Assert(index))
 
 
 def test_ArrayElement_store_into():
     for elementType in STATIC_TYPES + DYNAMIC_TYPES:
         staticArrayType = abi.StaticArrayTypeSpec(elementType, 100)
         staticArray = staticArrayType.new_instance()
-        index = Int(9)
+        index = pt.Int(9)
 
         element = abi.ArrayElement(staticArray, index)
         output = elementType.new_instance()
         expr = element.store_into(output)
 
         encoded = staticArray.encode()
-        stride = Int(staticArray.type_spec()._stride())
+        stride = pt.Int(staticArray.type_spec()._stride())
         expectedLength = staticArray.length()
         if elementType == abi.BoolTypeSpec():
             expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index)
@@ -88,71 +89,73 @@ def test_ArrayElement_store_into():
         else:
             expectedExpr = output.decode(
                 encoded,
-                startIndex=ExtractUint16(encoded, stride * index),
-                endIndex=If(index + Int(1) == expectedLength)
-                .Then(Len(encoded))
-                .Else(ExtractUint16(encoded, stride * index + Int(2))),
+                startIndex=pt.ExtractUint16(encoded, stride * index),
+                endIndex=pt.If(index + pt.Int(1) == expectedLength)
+                .Then(pt.Len(encoded))
+                .Else(pt.ExtractUint16(encoded, stride * index + pt.Int(2))),
             )
 
         expected, _ = expectedExpr.__teal__(options)
         expected.addIncoming()
-        expected = TealBlock.NormalizeBlocks(expected)
+        expected = pt.TealBlock.NormalizeBlocks(expected)
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             element.store_into(abi.Tuple(elementType))
 
     for elementType in STATIC_TYPES + DYNAMIC_TYPES:
         dynamicArrayType = abi.DynamicArrayTypeSpec(elementType)
         dynamicArray = dynamicArrayType.new_instance()
-        index = Int(9)
+        index = pt.Int(9)
 
         element = abi.ArrayElement(dynamicArray, index)
         output = elementType.new_instance()
         expr = element.store_into(output)
 
         encoded = dynamicArray.encode()
-        stride = Int(dynamicArray.type_spec()._stride())
+        stride = pt.Int(dynamicArray.type_spec()._stride())
         expectedLength = dynamicArray.length()
         if elementType == abi.BoolTypeSpec():
-            expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index + Int(16))
+            expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index + pt.Int(16))
         elif not elementType.is_dynamic():
             expectedExpr = output.decode(
-                encoded, startIndex=stride * index + Int(2), length=stride
+                encoded, startIndex=stride * index + pt.Int(2), length=stride
             )
         else:
             expectedExpr = output.decode(
                 encoded,
-                startIndex=ExtractUint16(encoded, stride * index + Int(2)) + Int(2),
-                endIndex=If(index + Int(1) == expectedLength)
-                .Then(Len(encoded))
+                startIndex=pt.ExtractUint16(encoded, stride * index + pt.Int(2))
+                + pt.Int(2),
+                endIndex=pt.If(index + pt.Int(1) == expectedLength)
+                .Then(pt.Len(encoded))
                 .Else(
-                    ExtractUint16(encoded, stride * index + Int(2) + Int(2)) + Int(2)
+                    pt.ExtractUint16(encoded, stride * index + pt.Int(2) + pt.Int(2))
+                    + pt.Int(2)
                 ),
             )
 
         expected, _ = expectedExpr.__teal__(options)
         expected.addIncoming()
-        expected = TealBlock.NormalizeBlocks(expected)
+        expected = pt.TealBlock.NormalizeBlocks(expected)
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
-            with TealComponent.Context.ignoreScratchSlotEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
+            with pt.TealComponent.Context.ignoreScratchSlotEquality():
                 assert actual == expected
 
-        assert TealBlock.MatchScratchSlotReferences(
-            TealBlock.GetReferencedScratchSlots(actual),
-            TealBlock.GetReferencedScratchSlots(expected),
+        assert pt.TealBlock.MatchScratchSlotReferences(
+            pt.TealBlock.GetReferencedScratchSlots(actual),
+            pt.TealBlock.GetReferencedScratchSlots(expected),
         )
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             element.store_into(abi.Tuple(elementType))

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -1,13 +1,14 @@
 import pytest
 
-from ... import *
+import pyteal as pt
+from pyteal import abi
 from .util import substringForDecoding
 from .tuple import encodeTuple
 from .bool import boolSequenceLength
 from .type_test import ContainerType
 from .array_base_test import STATIC_TYPES, DYNAMIC_TYPES
 
-options = CompileOptions(version=5)
+options = pt.CompileOptions(version=5)
 
 
 def test_StaticArrayTypeSpec_init():
@@ -99,14 +100,14 @@ def test_StaticArrayTypeSpec_byte_length_static():
 
 
 def test_StaticArray_decode():
-    encoded = Bytes("encoded")
-    for startIndex in (None, Int(1)):
-        for endIndex in (None, Int(2)):
-            for length in (None, Int(3)):
+    encoded = pt.Bytes("encoded")
+    for startIndex in (None, pt.Int(1)):
+        for endIndex in (None, pt.Int(2)):
+            for length in (None, pt.Int(3)):
                 value = abi.StaticArray(abi.Uint64TypeSpec(), 10)
 
                 if endIndex is not None and length is not None:
-                    with pytest.raises(TealInputError):
+                    with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
                             startIndex=startIndex,
@@ -118,7 +119,7 @@ def test_StaticArray_decode():
                 expr = value.decode(
                     encoded, startIndex=startIndex, endIndex=endIndex, length=length
                 )
-                assert expr.type_of() == TealType.none
+                assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()
 
                 expectedExpr = value.stored_value.store(
@@ -128,49 +129,49 @@ def test_StaticArray_decode():
                 )
                 expected, _ = expectedExpr.__teal__(options)
                 expected.addIncoming()
-                expected = TealBlock.NormalizeBlocks(expected)
+                expected = pt.TealBlock.NormalizeBlocks(expected)
 
                 actual, _ = expr.__teal__(options)
                 actual.addIncoming()
-                actual = TealBlock.NormalizeBlocks(actual)
+                actual = pt.TealBlock.NormalizeBlocks(actual)
 
-                with TealComponent.Context.ignoreExprEquality():
+                with pt.TealComponent.Context.ignoreExprEquality():
                     assert actual == expected
 
 
 def test_StaticArray_set_values():
     value = abi.StaticArray(abi.Uint64TypeSpec(), 10)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set([])
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set([abi.Uint64()] * 9)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set([abi.Uint64()] * 11)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set([abi.Uint16()] * 10)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set([abi.Uint64()] * 9 + [abi.Uint16()])
 
     values = [abi.Uint64() for _ in range(10)]
     expr = value.set(values)
-    assert expr.type_of() == TealType.none
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
     expectedExpr = value.stored_value.store(encodeTuple(values))
     expected, _ = expectedExpr.__teal__(options)
     expected.addIncoming()
-    expected = TealBlock.NormalizeBlocks(expected)
+    expected = pt.TealBlock.NormalizeBlocks(expected)
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 
@@ -178,61 +179,61 @@ def test_StaticArray_set_copy():
     value = abi.StaticArray(abi.Uint64TypeSpec(), 10)
     otherArray = abi.StaticArray(abi.Uint64TypeSpec(), 10)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set(abi.StaticArray(abi.Uint64TypeSpec(), 11))
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set(abi.StaticArray(abi.Uint8TypeSpec(), 10))
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set(abi.Uint64())
 
     expr = value.set(otherArray)
-    assert expr.type_of() == TealType.none
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expected = TealSimpleBlock(
+    expected = pt.TealSimpleBlock(
         [
-            TealOp(None, Op.load, otherArray.stored_value.slot),
-            TealOp(None, Op.store, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.load, otherArray.stored_value.slot),
+            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
         ]
     )
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 
 def test_StaticArray_set_computed():
     value = abi.StaticArray(abi.Uint64TypeSpec(), 10)
     computed = ContainerType(
-        value.type_spec(), Bytes("indeed this is hard to simulate")
+        value.type_spec(), pt.Bytes("indeed this is hard to simulate")
     )
     expr = value.set(computed)
-    assert expr.type_of() == TealType.none
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expected = TealSimpleBlock(
+    expected = pt.TealSimpleBlock(
         [
-            TealOp(None, Op.byte, '"indeed this is hard to simulate"'),
-            TealOp(None, Op.store, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.byte, '"indeed this is hard to simulate"'),
+            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
         ]
     )
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
     actual = actual.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set(
             ContainerType(
                 abi.StaticArrayTypeSpec(abi.Uint16TypeSpec(), 40),
-                Bytes("well i am trolling"),
+                pt.Bytes("well i am trolling"),
             )
         )
 
@@ -240,16 +241,18 @@ def test_StaticArray_set_computed():
 def test_StaticArray_encode():
     value = abi.StaticArray(abi.Uint64TypeSpec(), 10)
     expr = value.encode()
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == pt.TealType.bytes
     assert not expr.has_return()
 
-    expected = TealSimpleBlock([TealOp(None, Op.load, value.stored_value.slot)])
+    expected = pt.TealSimpleBlock(
+        [pt.TealOp(None, pt.Op.load, value.stored_value.slot)]
+    )
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 
@@ -257,16 +260,16 @@ def test_StaticArray_length():
     for length in (0, 1, 2, 3, 1000):
         value = abi.StaticArray(abi.Uint64TypeSpec(), length)
         expr = value.length()
-        assert expr.type_of() == TealType.uint64
+        assert expr.type_of() == pt.TealType.uint64
         assert not expr.has_return()
 
-        expected = TealSimpleBlock([TealOp(None, Op.int, length)])
+        expected = pt.TealSimpleBlock([pt.TealOp(None, pt.Op.int, length)])
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected
 
 
@@ -276,7 +279,7 @@ def test_StaticArray_getitem():
 
         for index in range(length):
             # dynamic indexes
-            indexExpr = Int(index)
+            indexExpr = pt.Int(index)
             element = value[indexExpr]
             assert type(element) is abi.ArrayElement
             assert element.array is value
@@ -287,11 +290,11 @@ def test_StaticArray_getitem():
             element = value[index]
             assert type(element) is abi.ArrayElement
             assert element.array is value
-            assert type(element.index) is Int
+            assert type(element.index) is pt.Int
             assert element.index.value == index
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             value[-1]
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             value[length]

--- a/pyteal/ast/abi/bool_test.py
+++ b/pyteal/ast/abi/bool_test.py
@@ -1,7 +1,8 @@
 from typing import NamedTuple, List
 import pytest
 
-from ... import *
+import pyteal as pt
+from pyteal import abi
 from .type_test import ContainerType
 from .bool import (
     boolAwareStaticByteLength,
@@ -11,10 +12,7 @@ from .bool import (
     encodeBoolSequence,
 )
 
-# this is not necessary but mypy complains if it's not included
-from ... import CompileOptions
-
-options = CompileOptions(version=5)
+options = pt.CompileOptions(version=5)
 
 
 def test_BoolTypeSpec_str():
@@ -49,48 +47,48 @@ def test_Bool_set_static():
     value = abi.Bool()
     for value_to_set in (True, False):
         expr = value.set(value_to_set)
-        assert expr.type_of() == TealType.none
+        assert expr.type_of() == pt.TealType.none
         assert not expr.has_return()
 
-        expected = TealSimpleBlock(
+        expected = pt.TealSimpleBlock(
             [
-                TealOp(None, Op.int, 1 if value_to_set else 0),
-                TealOp(None, Op.store, value.stored_value.slot),
+                pt.TealOp(None, pt.Op.int, 1 if value_to_set else 0),
+                pt.TealOp(None, pt.Op.store, value.stored_value.slot),
             ]
         )
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected
 
 
 def test_Bool_set_expr():
     value = abi.Bool()
-    expr = value.set(Int(0).Or(Int(1)))
-    assert expr.type_of() == TealType.none
+    expr = value.set(pt.Int(0).Or(pt.Int(1)))
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expected = TealSimpleBlock(
+    expected = pt.TealSimpleBlock(
         [
-            TealOp(None, Op.int, 0),
-            TealOp(None, Op.int, 1),
-            TealOp(None, Op.logic_or),
-            TealOp(None, Op.store, value.stored_value.slot),
-            TealOp(None, Op.load, value.stored_value.slot),
-            TealOp(None, Op.int, 2),
-            TealOp(None, Op.lt),
-            TealOp(None, Op.assert_),
+            pt.TealOp(None, pt.Op.int, 0),
+            pt.TealOp(None, pt.Op.int, 1),
+            pt.TealOp(None, pt.Op.logic_or),
+            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.load, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.int, 2),
+            pt.TealOp(None, pt.Op.lt),
+            pt.TealOp(None, pt.Op.assert_),
         ]
     )
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 
@@ -98,59 +96,61 @@ def test_Bool_set_copy():
     other = abi.Bool()
     value = abi.Bool()
     expr = value.set(other)
-    assert expr.type_of() == TealType.none
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expected = TealSimpleBlock(
+    expected = pt.TealSimpleBlock(
         [
-            TealOp(None, Op.load, other.stored_value.slot),
-            TealOp(None, Op.store, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.load, other.stored_value.slot),
+            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
         ]
     )
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         value.set(abi.Uint16())
 
 
 def test_Bool_set_computed():
     value = abi.Bool()
-    computed = ContainerType(abi.BoolTypeSpec(), Int(0x80))
+    computed = ContainerType(abi.BoolTypeSpec(), pt.Int(0x80))
     expr = value.set(computed)
-    assert expr.type_of() == TealType.none
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expected = TealSimpleBlock(
+    expected = pt.TealSimpleBlock(
         [
-            TealOp(None, Op.int, 0x80),
-            TealOp(None, Op.store, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.int, 0x80),
+            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
         ]
     )
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-    with pytest.raises(TealInputError):
-        value.set(ContainerType(abi.Uint32TypeSpec(), Int(65537)))
+    with pytest.raises(pt.TealInputError):
+        value.set(ContainerType(abi.Uint32TypeSpec(), pt.Int(65537)))
 
 
 def test_Bool_get():
     value = abi.Bool()
     expr = value.get()
-    assert expr.type_of() == TealType.uint64
+    assert expr.type_of() == pt.TealType.uint64
     assert not expr.has_return()
 
-    expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
+    expected = pt.TealSimpleBlock(
+        [pt.TealOp(expr, pt.Op.load, value.stored_value.slot)]
+    )
 
     actual, _ = expr.__teal__(options)
 
@@ -159,80 +159,80 @@ def test_Bool_get():
 
 def test_Bool_decode():
     value = abi.Bool()
-    encoded = Bytes("encoded")
-    for startIndex in (None, Int(1)):
-        for endIndex in (None, Int(2)):
-            for length in (None, Int(3)):
+    encoded = pt.Bytes("encoded")
+    for startIndex in (None, pt.Int(1)):
+        for endIndex in (None, pt.Int(2)):
+            for length in (None, pt.Int(3)):
                 expr = value.decode(
                     encoded, startIndex=startIndex, endIndex=endIndex, length=length
                 )
-                assert expr.type_of() == TealType.none
+                assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()
 
-                expected = TealSimpleBlock(
+                expected = pt.TealSimpleBlock(
                     [
-                        TealOp(None, Op.byte, '"encoded"'),
-                        TealOp(None, Op.int, 0 if startIndex is None else 1),
-                        TealOp(None, Op.int, 8),
-                        TealOp(None, Op.mul),
-                        TealOp(None, Op.getbit),
-                        TealOp(None, Op.store, value.stored_value.slot),
+                        pt.TealOp(None, pt.Op.byte, '"encoded"'),
+                        pt.TealOp(None, pt.Op.int, 0 if startIndex is None else 1),
+                        pt.TealOp(None, pt.Op.int, 8),
+                        pt.TealOp(None, pt.Op.mul),
+                        pt.TealOp(None, pt.Op.getbit),
+                        pt.TealOp(None, pt.Op.store, value.stored_value.slot),
                     ]
                 )
 
                 actual, _ = expr.__teal__(options)
                 actual.addIncoming()
-                actual = TealBlock.NormalizeBlocks(actual)
+                actual = pt.TealBlock.NormalizeBlocks(actual)
 
-                with TealComponent.Context.ignoreExprEquality():
+                with pt.TealComponent.Context.ignoreExprEquality():
                     assert actual == expected
 
 
 def test_Bool_decodeBit():
     value = abi.Bool()
-    bitIndex = Int(17)
-    encoded = Bytes("encoded")
+    bitIndex = pt.Int(17)
+    encoded = pt.Bytes("encoded")
     expr = value.decodeBit(encoded, bitIndex)
-    assert expr.type_of() == TealType.none
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expected = TealSimpleBlock(
+    expected = pt.TealSimpleBlock(
         [
-            TealOp(None, Op.byte, '"encoded"'),
-            TealOp(None, Op.int, 17),
-            TealOp(None, Op.getbit),
-            TealOp(None, Op.store, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.byte, '"encoded"'),
+            pt.TealOp(None, pt.Op.int, 17),
+            pt.TealOp(None, pt.Op.getbit),
+            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
         ]
     )
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 
 def test_Bool_encode():
     value = abi.Bool()
     expr = value.encode()
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == pt.TealType.bytes
     assert not expr.has_return()
 
-    expected = TealSimpleBlock(
+    expected = pt.TealSimpleBlock(
         [
-            TealOp(None, Op.byte, "0x00"),
-            TealOp(None, Op.int, 0),
-            TealOp(None, Op.load, value.stored_value.slot),
-            TealOp(None, Op.setbit),
+            pt.TealOp(None, pt.Op.byte, "0x00"),
+            pt.TealOp(None, pt.Op.int, 0),
+            pt.TealOp(None, pt.Op.load, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.setbit),
         ]
     )
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 
@@ -397,28 +397,28 @@ def test_encodeBoolSequence():
 
     for i, test in enumerate(tests):
         expr = encodeBoolSequence(test.types)
-        assert expr.type_of() == TealType.bytes
+        assert expr.type_of() == pt.TealType.bytes
         assert not expr.has_return()
 
         setBits = [
             [
-                TealOp(None, Op.int, j),
-                TealOp(None, Op.load, testType.stored_value.slot),
-                TealOp(None, Op.setbit),
+                pt.TealOp(None, pt.Op.int, j),
+                pt.TealOp(None, pt.Op.load, testType.stored_value.slot),
+                pt.TealOp(None, pt.Op.setbit),
             ]
             for j, testType in enumerate(test.types)
         ]
 
-        expected = TealSimpleBlock(
+        expected = pt.TealSimpleBlock(
             [
-                TealOp(None, Op.byte, "0x" + ("00" * test.expectedLength)),
+                pt.TealOp(None, pt.Op.byte, "0x" + ("00" * test.expectedLength)),
             ]
             + [expr for setBit in setBits for expr in setBit]
         )
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected, "Test at index {} failed".format(i)

--- a/pyteal/ast/abi/method_return_test.py
+++ b/pyteal/ast/abi/method_return_test.py
@@ -1,35 +1,33 @@
 import pytest
 
-from . import *
-from .. import Int, Bytes
-from ...types import TealType
-from ...errors import TealInputError
+import pyteal as pt
+from pyteal import abi
 
 
 POSITIVE_CASES = [
-    Uint16(),
-    Uint32(),
-    StaticArray(BoolTypeSpec(), 12),
+    abi.Uint16(),
+    abi.Uint32(),
+    abi.StaticArray(abi.BoolTypeSpec(), 12),
 ]
 
 
 @pytest.mark.parametrize("case", POSITIVE_CASES)
 def test_method_return(case):
-    m_ret = MethodReturn(case)
-    assert m_ret.type_of() == TealType.none
+    m_ret = abi.MethodReturn(case)
+    assert m_ret.type_of() == pt.TealType.none
     assert not m_ret.has_return()
     assert str(m_ret) == f"(MethodReturn {case.type_spec()})"
 
 
 NEGATIVE_CASES = [
-    Int(0),
-    Bytes("aaaaaaa"),
-    Uint16,
-    Uint32,
+    pt.Int(0),
+    pt.Bytes("aaaaaaa"),
+    abi.Uint16,
+    abi.Uint32,
 ]
 
 
 @pytest.mark.parametrize("case", NEGATIVE_CASES)
 def test_method_return_error(case):
-    with pytest.raises(TealInputError):
-        MethodReturn(case)
+    with pytest.raises(pt.TealInputError):
+        abi.MethodReturn(case)

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -1,19 +1,20 @@
 from typing import NamedTuple, List, Callable
 import pytest
 
-from ... import *
+import pyteal as pt
+from pyteal import abi
 from .tuple import encodeTuple, indexTuple, TupleElement
 from .bool import encodeBoolSequence
 from .util import substringForDecoding
 from .type_test import ContainerType
 
-options = CompileOptions(version=5)
+options = pt.CompileOptions(version=5)
 
 
 def test_encodeTuple():
     class EncodeTest(NamedTuple):
         types: List[abi.BaseType]
-        expected: Expr
+        expected: pt.Expr
 
     # variables used to construct the tests
     uint64_a = abi.Uint64()
@@ -26,15 +27,15 @@ def test_encodeTuple():
     dynamic_array_a = abi.DynamicArray(abi.Uint64TypeSpec())
     dynamic_array_b = abi.DynamicArray(abi.Uint16TypeSpec())
     dynamic_array_c = abi.DynamicArray(abi.BoolTypeSpec())
-    tail_holder = ScratchVar()
-    encoded_tail = ScratchVar()
+    tail_holder = pt.ScratchVar()
+    encoded_tail = pt.ScratchVar()
 
     tests: List[EncodeTest] = [
-        EncodeTest(types=[], expected=Bytes("")),
+        EncodeTest(types=[], expected=pt.Bytes("")),
         EncodeTest(types=[uint64_a], expected=uint64_a.encode()),
         EncodeTest(
             types=[uint64_a, uint64_b],
-            expected=Concat(uint64_a.encode(), uint64_b.encode()),
+            expected=pt.Concat(uint64_a.encode(), uint64_b.encode()),
         ),
         EncodeTest(types=[bool_a], expected=bool_a.encode()),
         EncodeTest(
@@ -42,15 +43,15 @@ def test_encodeTuple():
         ),
         EncodeTest(
             types=[bool_a, bool_b, uint64_a],
-            expected=Concat(encodeBoolSequence([bool_a, bool_b]), uint64_a.encode()),
+            expected=pt.Concat(encodeBoolSequence([bool_a, bool_b]), uint64_a.encode()),
         ),
         EncodeTest(
             types=[uint64_a, bool_a, bool_b],
-            expected=Concat(uint64_a.encode(), encodeBoolSequence([bool_a, bool_b])),
+            expected=pt.Concat(uint64_a.encode(), encodeBoolSequence([bool_a, bool_b])),
         ),
         EncodeTest(
             types=[uint64_a, bool_a, bool_b, uint64_b],
-            expected=Concat(
+            expected=pt.Concat(
                 uint64_a.encode(),
                 encodeBoolSequence([bool_a, bool_b]),
                 uint64_b.encode(),
@@ -58,14 +59,14 @@ def test_encodeTuple():
         ),
         EncodeTest(
             types=[uint64_a, bool_a, uint64_b, bool_b],
-            expected=Concat(
+            expected=pt.Concat(
                 uint64_a.encode(), bool_a.encode(), uint64_b.encode(), bool_b.encode()
             ),
         ),
         EncodeTest(types=[tuple_a], expected=tuple_a.encode()),
         EncodeTest(
             types=[uint64_a, tuple_a, bool_a, bool_b],
-            expected=Concat(
+            expected=pt.Concat(
                 uint64_a.encode(),
                 tuple_a.encode(),
                 encodeBoolSequence([bool_a, bool_b]),
@@ -73,8 +74,8 @@ def test_encodeTuple():
         ),
         EncodeTest(
             types=[dynamic_array_a],
-            expected=Concat(
-                Seq(
+            expected=pt.Concat(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_a.encode()),
                     tail_holder.store(encoded_tail.load()),
                     uint16_a.set(2),
@@ -85,9 +86,9 @@ def test_encodeTuple():
         ),
         EncodeTest(
             types=[uint64_a, dynamic_array_a],
-            expected=Concat(
+            expected=pt.Concat(
                 uint64_a.encode(),
-                Seq(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_a.encode()),
                     tail_holder.store(encoded_tail.load()),
                     uint16_a.set(8 + 2),
@@ -98,9 +99,9 @@ def test_encodeTuple():
         ),
         EncodeTest(
             types=[uint64_a, dynamic_array_a, uint64_b],
-            expected=Concat(
+            expected=pt.Concat(
                 uint64_a.encode(),
-                Seq(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_a.encode()),
                     tail_holder.store(encoded_tail.load()),
                     uint16_a.set(8 + 2 + 8),
@@ -112,9 +113,9 @@ def test_encodeTuple():
         ),
         EncodeTest(
             types=[uint64_a, dynamic_array_a, bool_a, bool_b],
-            expected=Concat(
+            expected=pt.Concat(
                 uint64_a.encode(),
-                Seq(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_a.encode()),
                     tail_holder.store(encoded_tail.load()),
                     uint16_a.set(8 + 2 + 1),
@@ -126,19 +127,21 @@ def test_encodeTuple():
         ),
         EncodeTest(
             types=[uint64_a, dynamic_array_a, uint64_b, dynamic_array_b],
-            expected=Concat(
+            expected=pt.Concat(
                 uint64_a.encode(),
-                Seq(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_a.encode()),
                     tail_holder.store(encoded_tail.load()),
                     uint16_a.set(8 + 2 + 8 + 2),
-                    uint16_b.set(uint16_a.get() + Len(encoded_tail.load())),
+                    uint16_b.set(uint16_a.get() + pt.Len(encoded_tail.load())),
                     uint16_a.encode(),
                 ),
                 uint64_b.encode(),
-                Seq(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_b.encode()),
-                    tail_holder.store(Concat(tail_holder.load(), encoded_tail.load())),
+                    tail_holder.store(
+                        pt.Concat(tail_holder.load(), encoded_tail.load())
+                    ),
                     uint16_a.set(uint16_b),
                     uint16_a.encode(),
                 ),
@@ -155,27 +158,31 @@ def test_encodeTuple():
                 bool_b,
                 dynamic_array_c,
             ],
-            expected=Concat(
+            expected=pt.Concat(
                 uint64_a.encode(),
-                Seq(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_a.encode()),
                     tail_holder.store(encoded_tail.load()),
                     uint16_a.set(8 + 2 + 8 + 2 + 1 + 2),
-                    uint16_b.set(uint16_a.get() + Len(encoded_tail.load())),
+                    uint16_b.set(uint16_a.get() + pt.Len(encoded_tail.load())),
                     uint16_a.encode(),
                 ),
                 uint64_b.encode(),
-                Seq(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_b.encode()),
-                    tail_holder.store(Concat(tail_holder.load(), encoded_tail.load())),
+                    tail_holder.store(
+                        pt.Concat(tail_holder.load(), encoded_tail.load())
+                    ),
                     uint16_a.set(uint16_b),
-                    uint16_b.set(uint16_a.get() + Len(encoded_tail.load())),
+                    uint16_b.set(uint16_a.get() + pt.Len(encoded_tail.load())),
                     uint16_a.encode(),
                 ),
                 encodeBoolSequence([bool_a, bool_b]),
-                Seq(
+                pt.Seq(
                     encoded_tail.store(dynamic_array_c.encode()),
-                    tail_holder.store(Concat(tail_holder.load(), encoded_tail.load())),
+                    tail_holder.store(
+                        pt.Concat(tail_holder.load(), encoded_tail.load())
+                    ),
                     uint16_a.set(uint16_b),
                     uint16_a.encode(),
                 ),
@@ -186,29 +193,29 @@ def test_encodeTuple():
 
     for i, test in enumerate(tests):
         expr = encodeTuple(test.types)
-        assert expr.type_of() == TealType.bytes
+        assert expr.type_of() == pt.TealType.bytes
         assert not expr.has_return()
 
         expected, _ = test.expected.__teal__(options)
         expected.addIncoming()
-        expected = TealBlock.NormalizeBlocks(expected)
+        expected = pt.TealBlock.NormalizeBlocks(expected)
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
         if any(t.type_spec().is_dynamic() for t in test.types):
-            with TealComponent.Context.ignoreExprEquality():
-                with TealComponent.Context.ignoreScratchSlotEquality():
+            with pt.TealComponent.Context.ignoreExprEquality():
+                with pt.TealComponent.Context.ignoreScratchSlotEquality():
                     assert actual == expected, "Test at index {} failed".format(i)
 
-            assert TealBlock.MatchScratchSlotReferences(
-                TealBlock.GetReferencedScratchSlots(actual),
-                TealBlock.GetReferencedScratchSlots(expected),
+            assert pt.TealBlock.MatchScratchSlotReferences(
+                pt.TealBlock.GetReferencedScratchSlots(actual),
+                pt.TealBlock.GetReferencedScratchSlots(expected),
             )
             continue
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected, "Test at index {} failed".format(i)
 
 
@@ -216,7 +223,7 @@ def test_indexTuple():
     class IndexTest(NamedTuple):
         types: List[abi.TypeSpec]
         typeIndex: int
-        expected: Callable[[abi.BaseType], Expr]
+        expected: Callable[[abi.BaseType], pt.Expr]
 
     # variables used to construct the tests
     uint64_t = abi.Uint64TypeSpec()
@@ -226,7 +233,7 @@ def test_indexTuple():
     dynamic_array_t1 = abi.DynamicArrayTypeSpec(abi.Uint64TypeSpec())
     dynamic_array_t2 = abi.DynamicArrayTypeSpec(abi.Uint16TypeSpec())
 
-    encoded = Bytes("encoded")
+    encoded = pt.Bytes("encoded")
 
     tests: List[IndexTest] = [
         IndexTest(
@@ -237,81 +244,81 @@ def test_indexTuple():
         IndexTest(
             types=[uint64_t, uint64_t],
             typeIndex=0,
-            expected=lambda output: output.decode(encoded, length=Int(8)),
+            expected=lambda output: output.decode(encoded, length=pt.Int(8)),
         ),
         IndexTest(
             types=[uint64_t, uint64_t],
             typeIndex=1,
-            expected=lambda output: output.decode(encoded, startIndex=Int(8)),
+            expected=lambda output: output.decode(encoded, startIndex=pt.Int(8)),
         ),
         IndexTest(
             types=[uint64_t, byte_t, uint64_t],
             typeIndex=1,
             expected=lambda output: output.decode(
-                encoded, startIndex=Int(8), length=Int(1)
+                encoded, startIndex=pt.Int(8), length=pt.Int(1)
             ),
         ),
         IndexTest(
             types=[uint64_t, byte_t, uint64_t],
             typeIndex=2,
             expected=lambda output: output.decode(
-                encoded, startIndex=Int(9), length=Int(8)
+                encoded, startIndex=pt.Int(9), length=pt.Int(8)
             ),
         ),
         IndexTest(
             types=[bool_t],
             typeIndex=0,
-            expected=lambda output: output.decodeBit(encoded, Int(0)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(0)),
         ),
         IndexTest(
             types=[bool_t, bool_t],
             typeIndex=0,
-            expected=lambda output: output.decodeBit(encoded, Int(0)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(0)),
         ),
         IndexTest(
             types=[bool_t, bool_t],
             typeIndex=1,
-            expected=lambda output: output.decodeBit(encoded, Int(1)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(1)),
         ),
         IndexTest(
             types=[uint64_t, bool_t],
             typeIndex=1,
-            expected=lambda output: output.decodeBit(encoded, Int(8 * 8)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(8 * 8)),
         ),
         IndexTest(
             types=[uint64_t, bool_t, bool_t],
             typeIndex=1,
-            expected=lambda output: output.decodeBit(encoded, Int(8 * 8)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(8 * 8)),
         ),
         IndexTest(
             types=[uint64_t, bool_t, bool_t],
             typeIndex=2,
-            expected=lambda output: output.decodeBit(encoded, Int(8 * 8 + 1)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(8 * 8 + 1)),
         ),
         IndexTest(
             types=[bool_t, uint64_t],
             typeIndex=0,
-            expected=lambda output: output.decodeBit(encoded, Int(0)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(0)),
         ),
         IndexTest(
             types=[bool_t, uint64_t],
             typeIndex=1,
-            expected=lambda output: output.decode(encoded, startIndex=Int(1)),
+            expected=lambda output: output.decode(encoded, startIndex=pt.Int(1)),
         ),
         IndexTest(
             types=[bool_t, bool_t, uint64_t],
             typeIndex=0,
-            expected=lambda output: output.decodeBit(encoded, Int(0)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(0)),
         ),
         IndexTest(
             types=[bool_t, bool_t, uint64_t],
             typeIndex=1,
-            expected=lambda output: output.decodeBit(encoded, Int(1)),
+            expected=lambda output: output.decodeBit(encoded, pt.Int(1)),
         ),
         IndexTest(
             types=[bool_t, bool_t, uint64_t],
             typeIndex=2,
-            expected=lambda output: output.decode(encoded, startIndex=Int(1)),
+            expected=lambda output: output.decode(encoded, startIndex=pt.Int(1)),
         ),
         IndexTest(
             types=[tuple_t], typeIndex=0, expected=lambda output: output.decode(encoded)
@@ -319,48 +326,52 @@ def test_indexTuple():
         IndexTest(
             types=[byte_t, tuple_t],
             typeIndex=1,
-            expected=lambda output: output.decode(encoded, startIndex=Int(1)),
+            expected=lambda output: output.decode(encoded, startIndex=pt.Int(1)),
         ),
         IndexTest(
             types=[tuple_t, byte_t],
             typeIndex=0,
             expected=lambda output: output.decode(
-                encoded, startIndex=Int(0), length=Int(tuple_t.byte_length_static())
+                encoded,
+                startIndex=pt.Int(0),
+                length=pt.Int(tuple_t.byte_length_static()),
             ),
         ),
         IndexTest(
             types=[byte_t, tuple_t, byte_t],
             typeIndex=1,
             expected=lambda output: output.decode(
-                encoded, startIndex=Int(1), length=Int(tuple_t.byte_length_static())
+                encoded,
+                startIndex=pt.Int(1),
+                length=pt.Int(tuple_t.byte_length_static()),
             ),
         ),
         IndexTest(
             types=[dynamic_array_t1],
             typeIndex=0,
             expected=lambda output: output.decode(
-                encoded, startIndex=ExtractUint16(encoded, Int(0))
+                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(0))
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1],
             typeIndex=1,
             expected=lambda output: output.decode(
-                encoded, startIndex=ExtractUint16(encoded, Int(1))
+                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(1))
             ),
         ),
         IndexTest(
             types=[dynamic_array_t1, byte_t],
             typeIndex=0,
             expected=lambda output: output.decode(
-                encoded, startIndex=ExtractUint16(encoded, Int(0))
+                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(0))
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1, byte_t],
             typeIndex=1,
             expected=lambda output: output.decode(
-                encoded, startIndex=ExtractUint16(encoded, Int(1))
+                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(1))
             ),
         ),
         IndexTest(
@@ -368,15 +379,15 @@ def test_indexTuple():
             typeIndex=1,
             expected=lambda output: output.decode(
                 encoded,
-                startIndex=ExtractUint16(encoded, Int(1)),
-                endIndex=ExtractUint16(encoded, Int(4)),
+                startIndex=pt.ExtractUint16(encoded, pt.Int(1)),
+                endIndex=pt.ExtractUint16(encoded, pt.Int(4)),
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1, byte_t, dynamic_array_t2],
             typeIndex=3,
             expected=lambda output: output.decode(
-                encoded, startIndex=ExtractUint16(encoded, Int(4))
+                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(4))
             ),
         ),
         IndexTest(
@@ -384,15 +395,15 @@ def test_indexTuple():
             typeIndex=1,
             expected=lambda output: output.decode(
                 encoded,
-                startIndex=ExtractUint16(encoded, Int(1)),
-                endIndex=ExtractUint16(encoded, Int(4)),
+                startIndex=pt.ExtractUint16(encoded, pt.Int(1)),
+                endIndex=pt.ExtractUint16(encoded, pt.Int(4)),
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1, tuple_t, dynamic_array_t2],
             typeIndex=3,
             expected=lambda output: output.decode(
-                encoded, startIndex=ExtractUint16(encoded, Int(4))
+                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(4))
             ),
         ),
         IndexTest(
@@ -400,15 +411,15 @@ def test_indexTuple():
             typeIndex=1,
             expected=lambda output: output.decode(
                 encoded,
-                startIndex=ExtractUint16(encoded, Int(1)),
-                endIndex=ExtractUint16(encoded, Int(4)),
+                startIndex=pt.ExtractUint16(encoded, pt.Int(1)),
+                endIndex=pt.ExtractUint16(encoded, pt.Int(4)),
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1, bool_t, bool_t, dynamic_array_t2],
             typeIndex=4,
             expected=lambda output: output.decode(
-                encoded, startIndex=ExtractUint16(encoded, Int(4))
+                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(4))
             ),
         ),
     ]
@@ -416,18 +427,18 @@ def test_indexTuple():
     for i, test in enumerate(tests):
         output = test.types[test.typeIndex].new_instance()
         expr = indexTuple(test.types, encoded, test.typeIndex, output)
-        assert expr.type_of() == TealType.none
+        assert expr.type_of() == pt.TealType.none
         assert not expr.has_return()
 
         expected, _ = test.expected(output).__teal__(options)
         expected.addIncoming()
-        expected = TealBlock.NormalizeBlocks(expected)
+        expected = pt.TealBlock.NormalizeBlocks(expected)
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected, "Test at index {} failed".format(i)
 
         with pytest.raises(ValueError):
@@ -587,13 +598,13 @@ def test_TupleTypeSpec_byte_length_static():
 
 
 def test_Tuple_decode():
-    encoded = Bytes("encoded")
+    encoded = pt.Bytes("encoded")
     tupleValue = abi.Tuple(abi.Uint64TypeSpec())
-    for startIndex in (None, Int(1)):
-        for endIndex in (None, Int(2)):
-            for length in (None, Int(3)):
+    for startIndex in (None, pt.Int(1)):
+        for endIndex in (None, pt.Int(2)):
+            for length in (None, pt.Int(3)):
                 if endIndex is not None and length is not None:
-                    with pytest.raises(TealInputError):
+                    with pytest.raises(pt.TealInputError):
                         tupleValue.decode(
                             encoded,
                             startIndex=startIndex,
@@ -605,7 +616,7 @@ def test_Tuple_decode():
                 expr = tupleValue.decode(
                     encoded, startIndex=startIndex, endIndex=endIndex, length=length
                 )
-                assert expr.type_of() == TealType.none
+                assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()
 
                 expectedExpr = tupleValue.stored_value.store(
@@ -615,13 +626,13 @@ def test_Tuple_decode():
                 )
                 expected, _ = expectedExpr.__teal__(options)
                 expected.addIncoming()
-                expected = TealBlock.NormalizeBlocks(expected)
+                expected = pt.TealBlock.NormalizeBlocks(expected)
 
                 actual, _ = expr.__teal__(options)
                 actual.addIncoming()
-                actual = TealBlock.NormalizeBlocks(actual)
+                actual = pt.TealBlock.NormalizeBlocks(actual)
 
-                with TealComponent.Context.ignoreExprEquality():
+                with pt.TealComponent.Context.ignoreExprEquality():
                     assert actual == expected
 
 
@@ -633,35 +644,35 @@ def test_Tuple_set():
     uint16 = abi.Uint16()
     uint32 = abi.Uint32()
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         tupleValue.set()
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         tupleValue.set(uint8, uint16)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         tupleValue.set(uint8, uint16, uint32, uint32)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         tupleValue.set(uint8, uint32, uint16)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         tupleValue.set(uint8, uint16, uint16)
 
     expr = tupleValue.set(uint8, uint16, uint32)
-    assert expr.type_of() == TealType.none
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
     expectedExpr = tupleValue.stored_value.store(encodeTuple([uint8, uint16, uint32]))
     expected, _ = expectedExpr.__teal__(options)
     expected.addIncoming()
-    expected = TealBlock.NormalizeBlocks(expected)
+    expected = pt.TealBlock.NormalizeBlocks(expected)
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 
@@ -669,46 +680,50 @@ def test_Tuple_set_Computed():
     tupleValue = abi.Tuple(
         abi.Uint8TypeSpec(), abi.Uint16TypeSpec(), abi.Uint32TypeSpec()
     )
-    computed = ContainerType(tupleValue.type_spec(), Bytes("internal representation"))
+    computed = ContainerType(
+        tupleValue.type_spec(), pt.Bytes("internal representation")
+    )
     expr = tupleValue.set(computed)
-    assert expr.type_of() == TealType.none
+    assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expected = TealSimpleBlock(
+    expected = pt.TealSimpleBlock(
         [
-            TealOp(None, Op.byte, '"internal representation"'),
-            TealOp(None, Op.store, tupleValue.stored_value.slot),
+            pt.TealOp(None, pt.Op.byte, '"internal representation"'),
+            pt.TealOp(None, pt.Op.store, tupleValue.stored_value.slot),
         ]
     )
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         tupleValue.set(computed, computed)
 
-    with pytest.raises(TealInputError):
+    with pytest.raises(pt.TealInputError):
         tupleValue.set(
-            ContainerType(abi.TupleTypeSpec(abi.ByteTypeSpec()), Bytes(b"a"))
+            ContainerType(abi.TupleTypeSpec(abi.ByteTypeSpec()), pt.Bytes(b"a"))
         )
 
 
 def test_Tuple_encode():
     tupleValue = abi.Tuple(abi.Uint64TypeSpec())
     expr = tupleValue.encode()
-    assert expr.type_of() == TealType.bytes
+    assert expr.type_of() == pt.TealType.bytes
     assert not expr.has_return()
 
-    expected = TealSimpleBlock([TealOp(None, Op.load, tupleValue.stored_value.slot)])
+    expected = pt.TealSimpleBlock(
+        [pt.TealOp(None, pt.Op.load, tupleValue.stored_value.slot)]
+    )
 
     actual, _ = expr.__teal__(options)
     actual.addIncoming()
-    actual = TealBlock.NormalizeBlocks(actual)
+    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-    with TealComponent.Context.ignoreExprEquality():
+    with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
 
@@ -726,17 +741,17 @@ def test_Tuple_length():
     for i, test in enumerate(tests):
         tupleValue = abi.Tuple(*test)
         expr = tupleValue.length()
-        assert expr.type_of() == TealType.uint64
+        assert expr.type_of() == pt.TealType.uint64
         assert not expr.has_return()
 
         expectedLength = len(test)
-        expected = TealSimpleBlock([TealOp(None, Op.int, expectedLength)])
+        expected = pt.TealSimpleBlock([pt.TealOp(None, pt.Op.int, expectedLength)])
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected, "Test at index {} failed".format(i)
 
 
@@ -759,10 +774,10 @@ def test_Tuple_getitem():
             assert element.tuple is tupleValue, "Test at index {} failed".format(i)
             assert element.index == j, "Test at index {} failed".format(i)
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             tupleValue[-1]
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             tupleValue[len(test)]
 
 
@@ -784,17 +799,17 @@ def test_TupleElement_store_into():
             output = test[j].new_instance()
 
             expr = element.store_into(output)
-            assert expr.type_of() == TealType.none
+            assert expr.type_of() == pt.TealType.none
             assert not expr.has_return()
 
             expectedExpr = indexTuple(test, tupleValue.encode(), j, output)
             expected, _ = expectedExpr.__teal__(options)
             expected.addIncoming()
-            expected = TealBlock.NormalizeBlocks(expected)
+            expected = pt.TealBlock.NormalizeBlocks(expected)
 
             actual, _ = expr.__teal__(options)
             actual.addIncoming()
-            actual = TealBlock.NormalizeBlocks(actual)
+            actual = pt.TealBlock.NormalizeBlocks(actual)
 
-            with TealComponent.Context.ignoreExprEquality():
+            with pt.TealComponent.Context.ignoreExprEquality():
                 assert actual == expected, "Test at index {} failed".format(i)

--- a/pyteal/ast/abi/type_test.py
+++ b/pyteal/ast/abi/type_test.py
@@ -1,19 +1,20 @@
-from ... import *
+import pyteal as pt
+from pyteal import abi
 
-options = CompileOptions(version=5)
+options = pt.CompileOptions(version=5)
 
 
 class ContainerType(abi.ComputedValue):
-    def __init__(self, type_spec: abi.TypeSpec, encodings: Expr):
+    def __init__(self, type_spec: abi.TypeSpec, encodings: pt.Expr):
         self.type_spec = type_spec
         self.encodings = encodings
 
     def produced_type_spec(self) -> abi.TypeSpec:
         return self.type_spec
 
-    def store_into(self, output: abi.BaseType) -> Expr:
+    def store_into(self, output: abi.BaseType) -> pt.Expr:
         if output.type_spec() != self.type_spec:
-            raise TealInputError(
+            raise pt.TealInputError(
                 f"expected type_spec {self.type_spec} but get {output.type_spec()}"
             )
         return output.stored_value.store(self.encodings)
@@ -21,29 +22,29 @@ class ContainerType(abi.ComputedValue):
 
 def test_ComputedType_use():
     for value in (0, 1, 2, 3, 12345):
-        dummyComputedType = ContainerType(abi.Uint64TypeSpec(), Int(value))
-        expr = dummyComputedType.use(lambda output: Int(2) * output.get())
-        assert expr.type_of() == TealType.uint64
+        dummyComputedType = ContainerType(abi.Uint64TypeSpec(), pt.Int(value))
+        expr = dummyComputedType.use(lambda output: pt.Int(2) * output.get())
+        assert expr.type_of() == pt.TealType.uint64
         assert not expr.has_return()
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        assert type(actual) is TealSimpleBlock
-        assert actual.ops[1].op == Op.store
-        assert type(actual.ops[1].args[0]) is ScratchSlot
+        assert type(actual) is pt.TealSimpleBlock
+        assert actual.ops[1].op == pt.Op.store
+        assert type(actual.ops[1].args[0]) is pt.ScratchSlot
         actualSlot = actual.ops[1].args[0]
 
-        expected = TealSimpleBlock(
+        expected = pt.TealSimpleBlock(
             [
-                TealOp(None, Op.int, value),
-                TealOp(None, Op.store, actualSlot),
-                TealOp(None, Op.int, 2),
-                TealOp(None, Op.load, actualSlot),
-                TealOp(None, Op.mul),
+                pt.TealOp(None, pt.Op.int, value),
+                pt.TealOp(None, pt.Op.store, actualSlot),
+                pt.TealOp(None, pt.Op.int, 2),
+                pt.TealOp(None, pt.Op.load, actualSlot),
+                pt.TealOp(None, pt.Op.mul),
             ]
         )
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected

--- a/pyteal/ast/abi/uint_test.py
+++ b/pyteal/ast/abi/uint_test.py
@@ -1,10 +1,11 @@
 from typing import List, Tuple, NamedTuple, Callable, Union, Optional
 from .type_test import ContainerType
-from ... import *
+import pyteal as pt
+from pyteal import abi
 
 import pytest
 
-options = CompileOptions(version=5)
+options = pt.CompileOptions(version=5)
 
 
 class UintTestData(NamedTuple):
@@ -14,14 +15,14 @@ class UintTestData(NamedTuple):
     maxValue: int
     checkUpperBound: bool
     expectedDecoding: Callable[
-        [Expr, Optional[Expr], Optional[Expr], Optional[Expr]], Expr
+        [pt.Expr, Optional[pt.Expr], Optional[pt.Expr], Optional[pt.Expr]], pt.Expr
     ]
-    expectedEncoding: Callable[[abi.Uint], Expr]
+    expectedEncoding: Callable[[abi.Uint], pt.Expr]
 
 
-def noneToInt0(value: Union[None, Expr]):
+def noneToInt0(value: Union[None, pt.Expr]):
     if value is None:
-        return Int(0)
+        return pt.Int(0)
     return value
 
 
@@ -32,11 +33,11 @@ testData = [
         expectedBits=8,
         maxValue=2**8 - 1,
         checkUpperBound=True,
-        expectedDecoding=lambda encoded, startIndex, endIndex, length: GetByte(
+        expectedDecoding=lambda encoded, startIndex, endIndex, length: pt.GetByte(
             encoded, noneToInt0(startIndex)
         ),
-        expectedEncoding=lambda uintType: SetByte(
-            Bytes(b"\x00"), Int(0), uintType.get()
+        expectedEncoding=lambda uintType: pt.SetByte(
+            pt.Bytes(b"\x00"), pt.Int(0), uintType.get()
         ),
     ),
     UintTestData(
@@ -45,10 +46,10 @@ testData = [
         expectedBits=16,
         maxValue=2**16 - 1,
         checkUpperBound=True,
-        expectedDecoding=lambda encoded, startIndex, endIndex, length: ExtractUint16(
+        expectedDecoding=lambda encoded, startIndex, endIndex, length: pt.ExtractUint16(
             encoded, noneToInt0(startIndex)
         ),
-        expectedEncoding=lambda uintType: Suffix(Itob(uintType.get()), Int(6)),
+        expectedEncoding=lambda uintType: pt.Suffix(pt.Itob(uintType.get()), pt.Int(6)),
     ),
     UintTestData(
         uintType=abi.Uint32TypeSpec(),
@@ -56,10 +57,10 @@ testData = [
         expectedBits=32,
         maxValue=2**32 - 1,
         checkUpperBound=True,
-        expectedDecoding=lambda encoded, startIndex, endIndex, length: ExtractUint32(
+        expectedDecoding=lambda encoded, startIndex, endIndex, length: pt.ExtractUint32(
             encoded, noneToInt0(startIndex)
         ),
-        expectedEncoding=lambda uintType: Suffix(Itob(uintType.get()), Int(4)),
+        expectedEncoding=lambda uintType: pt.Suffix(pt.Itob(uintType.get()), pt.Int(4)),
     ),
     UintTestData(
         uintType=abi.Uint64TypeSpec(),
@@ -67,10 +68,10 @@ testData = [
         expectedBits=64,
         maxValue=2**64 - 1,
         checkUpperBound=False,
-        expectedDecoding=lambda encoded, startIndex, endIndex, length: Btoi(encoded)
+        expectedDecoding=lambda encoded, startIndex, endIndex, length: pt.Btoi(encoded)
         if startIndex is None and endIndex is None and length is None
-        else ExtractUint64(encoded, noneToInt0(startIndex)),
-        expectedEncoding=lambda uintType: Itob(uintType.get()),
+        else pt.ExtractUint64(encoded, noneToInt0(startIndex)),
+        expectedEncoding=lambda uintType: pt.Itob(uintType.get()),
     ),
 ]
 
@@ -115,8 +116,8 @@ def test_UintTypeSpec_eq():
 
 def test_UintTypeSpec_storage_type():
     for test in testData:
-        assert test.uintType.storage_type() == TealType.uint64
-    assert abi.BoolTypeSpec().storage_type() == TealType.uint64
+        assert test.uintType.storage_type() == pt.TealType.uint64
+    assert abi.BoolTypeSpec().storage_type() == pt.TealType.uint64
 
 
 def test_UintTypeSpec_new_instance():
@@ -130,61 +131,61 @@ def test_Uint_set_static():
         for value_to_set in (0, 1, 100, test.maxValue):
             value = test.uintType.new_instance()
             expr = value.set(value_to_set)
-            assert expr.type_of() == TealType.none
+            assert expr.type_of() == pt.TealType.none
             assert not expr.has_return()
 
-            expected = TealSimpleBlock(
+            expected = pt.TealSimpleBlock(
                 [
-                    TealOp(None, Op.int, value_to_set),
-                    TealOp(None, Op.store, value.stored_value.slot),
+                    pt.TealOp(None, pt.Op.int, value_to_set),
+                    pt.TealOp(None, pt.Op.store, value.stored_value.slot),
                 ]
             )
 
             actual, _ = expr.__teal__(options)
             actual.addIncoming()
-            actual = TealBlock.NormalizeBlocks(actual)
+            actual = pt.TealBlock.NormalizeBlocks(actual)
 
-            with TealComponent.Context.ignoreExprEquality():
+            with pt.TealComponent.Context.ignoreExprEquality():
                 assert actual == expected
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             value.set(test.maxValue + 1)
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             value.set(-1)
 
 
 def test_Uint_set_expr():
     for test in testData:
         value = test.uintType.new_instance()
-        expr = value.set(Int(10) + Int(1))
-        assert expr.type_of() == TealType.none
+        expr = value.set(pt.Int(10) + pt.Int(1))
+        assert expr.type_of() == pt.TealType.none
         assert not expr.has_return()
 
         upperBoundCheck = []
         if test.checkUpperBound:
             upperBoundCheck = [
-                TealOp(None, Op.load, value.stored_value.slot),
-                TealOp(None, Op.int, test.maxValue + 1),
-                TealOp(None, Op.lt),
-                TealOp(None, Op.assert_),
+                pt.TealOp(None, pt.Op.load, value.stored_value.slot),
+                pt.TealOp(None, pt.Op.int, test.maxValue + 1),
+                pt.TealOp(None, pt.Op.lt),
+                pt.TealOp(None, pt.Op.assert_),
             ]
 
-        expected = TealSimpleBlock(
+        expected = pt.TealSimpleBlock(
             [
-                TealOp(None, Op.int, 10),
-                TealOp(None, Op.int, 1),
-                TealOp(None, Op.add),
-                TealOp(None, Op.store, value.stored_value.slot),
+                pt.TealOp(None, pt.Op.int, 10),
+                pt.TealOp(None, pt.Op.int, 1),
+                pt.TealOp(None, pt.Op.add),
+                pt.TealOp(None, pt.Op.store, value.stored_value.slot),
             ]
             + upperBoundCheck
         )
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected
 
 
@@ -193,52 +194,52 @@ def test_Uint_set_copy():
         value = test.uintType.new_instance()
         other = test.uintType.new_instance()
         expr = value.set(other)
-        assert expr.type_of() == TealType.none
+        assert expr.type_of() == pt.TealType.none
         assert not expr.has_return()
 
-        expected = TealSimpleBlock(
+        expected = pt.TealSimpleBlock(
             [
-                TealOp(None, Op.load, other.stored_value.slot),
-                TealOp(None, Op.store, value.stored_value.slot),
+                pt.TealOp(None, pt.Op.load, other.stored_value.slot),
+                pt.TealOp(None, pt.Op.store, value.stored_value.slot),
             ]
         )
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             value.set(abi.Bool())
 
 
 def test_Uint_set_computed():
-    byte_computed_value = ContainerType(abi.ByteTypeSpec(), Int(0x22))
+    byte_computed_value = ContainerType(abi.ByteTypeSpec(), pt.Int(0x22))
 
     for test in testData:
-        computed_value = ContainerType(test.uintType, Int(0x44))
+        computed_value = ContainerType(test.uintType, pt.Int(0x44))
         value = test.uintType.new_instance()
         expr = value.set(computed_value)
-        assert expr.type_of() == TealType.none
+        assert expr.type_of() == pt.TealType.none
         assert not expr.has_return()
 
-        expected = TealSimpleBlock(
+        expected = pt.TealSimpleBlock(
             [
-                TealOp(None, Op.int, 0x44),
-                TealOp(None, Op.store, value.stored_value.slot),
+                pt.TealOp(None, pt.Op.int, 0x44),
+                pt.TealOp(None, pt.Op.store, value.stored_value.slot),
             ]
         )
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected
 
-        with pytest.raises(TealInputError):
+        with pytest.raises(pt.TealInputError):
             value.set(byte_computed_value)
 
 
@@ -246,10 +247,12 @@ def test_Uint_get():
     for test in testData:
         value = test.uintType.new_instance()
         expr = value.get()
-        assert expr.type_of() == TealType.uint64
+        assert expr.type_of() == pt.TealType.uint64
         assert not expr.has_return()
 
-        expected = TealSimpleBlock([TealOp(expr, Op.load, value.stored_value.slot)])
+        expected = pt.TealSimpleBlock(
+            [pt.TealOp(expr, pt.Op.load, value.stored_value.slot)]
+        )
 
         actual, _ = expr.__teal__(options)
 
@@ -257,16 +260,16 @@ def test_Uint_get():
 
 
 def test_Uint_decode():
-    encoded = Bytes("encoded")
+    encoded = pt.Bytes("encoded")
     for test in testData:
-        for startIndex in (None, Int(1)):
-            for endIndex in (None, Int(2)):
-                for length in (None, Int(3)):
+        for startIndex in (None, pt.Int(1)):
+            for endIndex in (None, pt.Int(2)):
+                for length in (None, pt.Int(3)):
                     value = test.uintType.new_instance()
                     expr = value.decode(
                         encoded, startIndex=startIndex, endIndex=endIndex, length=length
                     )
-                    assert expr.type_of() == TealType.none
+                    assert expr.type_of() == pt.TealType.none
                     assert not expr.has_return()
 
                     expectedDecoding = value.stored_value.store(
@@ -274,13 +277,13 @@ def test_Uint_decode():
                     )
                     expected, _ = expectedDecoding.__teal__(options)
                     expected.addIncoming()
-                    expected = TealBlock.NormalizeBlocks(expected)
+                    expected = pt.TealBlock.NormalizeBlocks(expected)
 
                     actual, _ = expr.__teal__(options)
                     actual.addIncoming()
-                    actual = TealBlock.NormalizeBlocks(actual)
+                    actual = pt.TealBlock.NormalizeBlocks(actual)
 
-                    with TealComponent.Context.ignoreExprEquality():
+                    with pt.TealComponent.Context.ignoreExprEquality():
                         assert actual == expected
 
 
@@ -288,18 +291,18 @@ def test_Uint_encode():
     for test in testData:
         value = test.uintType.new_instance()
         expr = value.encode()
-        assert expr.type_of() == TealType.bytes
+        assert expr.type_of() == pt.TealType.bytes
         assert not expr.has_return()
 
         expected, _ = test.expectedEncoding(value).__teal__(options)
         expected.addIncoming()
-        expected = TealBlock.NormalizeBlocks(expected)
+        expected = pt.TealBlock.NormalizeBlocks(expected)
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected
 
 
@@ -313,19 +316,19 @@ def test_ByteUint8_mutual_conversion():
         other = type_a.new_instance()
         expr = type_b_instance.set(other)
 
-        assert expr.type_of() == TealType.none
+        assert expr.type_of() == pt.TealType.none
         assert not expr.has_return()
 
-        expected = TealSimpleBlock(
+        expected = pt.TealSimpleBlock(
             [
-                TealOp(None, Op.load, other.stored_value.slot),
-                TealOp(None, Op.store, type_b_instance.stored_value.slot),
+                pt.TealOp(None, pt.Op.load, other.stored_value.slot),
+                pt.TealOp(None, pt.Op.store, type_b_instance.stored_value.slot),
             ]
         )
 
         actual, _ = expr.__teal__(options)
         actual.addIncoming()
-        actual = TealBlock.NormalizeBlocks(actual)
+        actual = pt.TealBlock.NormalizeBlocks(actual)
 
-        with TealComponent.Context.ignoreExprEquality():
+        with pt.TealComponent.Context.ignoreExprEquality():
             assert actual == expected


### PR DESCRIPTION
Provides an alternative to #285 that retains `abi.X` instead of `pt.abi.X` as discussed in https://github.com/algorand/pyteal/pull/285#discussion_r854421497.

Provided we can reach a conclusion with minimal back-and-forth, I'm happy with either style.  Since I realize that we want to pick 1 style and stick with it, I'm opting to spend the time now to perform an assessment.

The PR's changes are mostly made mechanically via:
* `for f in `ls -1a pyteal/ast/abi/*_test.py`; do sh /tmp/pyteal-as-pt.sh $f; done`
* Script source (rename extension to `.sh`):  [pyteal-as-pt.txt](https://github.com/algorand/pyteal/files/8524652/pyteal-as-pt.txt)

After running the above script, I hand-edited to address these lint errors:
```
pyteal/ast/abi/method_return_test.py:4:1: F401 'pyteal.abi' imported but unused
pyteal/ast/abi/method_return_test.py:8:5: F821 undefined name 'Uint16'
pyteal/ast/abi/method_return_test.py:9:5: F821 undefined name 'Uint32'
pyteal/ast/abi/method_return_test.py:10:5: F821 undefined name 'StaticArray'
pyteal/ast/abi/method_return_test.py:10:17: F821 undefined name 'BoolTypeSpec'
pyteal/ast/abi/method_return_test.py:16:13: F821 undefined name 'MethodReturn'
pyteal/ast/abi/method_return_test.py:25:5: F821 undefined name 'Uint16'
pyteal/ast/abi/method_return_test.py:26:5: F821 undefined name 'Uint32'
pyteal/ast/abi/method_return_test.py:33:9: F821 undefined name 'MethodReturn'
pyteal/ast/abi/bool_test.py:16:1: F401 '...CompileOptions' imported but unused
pyteal/ast/abi/type_test.py:36:47: F821 undefined name 'ScratchSlot'
```