### PR TITLE
Make build-docset act-compatible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,12 +85,8 @@ jobs:
         run: make setup-docs
       - name: Make docs
         run: make bundle-docs
-      - name: Local ACT Only - Install nodejs
-        if: ${{ env.ACT }}
-        run: |
-          sudo apt update -y
-          sudo apt install -y nodejs
       - name: Archive docset
+        if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v2
         with:
           name: pyteal.docset

--- a/docs/opup.rst
+++ b/docs/opup.rst
@@ -1,7 +1,7 @@
 .. _opup:
 
 OpUp:  Budget Increase Utility
-========================
+=================================
 
 Some opcode budget is consumed during execution of every Algorand Smart Contract because every TEAL
 instruction has a corresponding cost. In order for the evaluation to succeed, the budget consumed must not


### PR DESCRIPTION
Makes `build-docset` job act-compatible to address https://github.com/algorand/pyteal/pull/299#issuecomment-1110296347.

Provides compatibility by marking the _upload-artifact_ step as Github-only.  Act does not have access to Github's storage system.

Additionally, fixes the following warning observed during `build-docset`:
```
| /Users/michael/dev/pyteal/docs/opup.rst:4: WARNING: Title underline too short.
|
| OpUp:  Budget Increase Utility
| ========================
```