### PR TITLE
Bundle optional refactorings to subroutine.py

### DIFF
--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -193,13 +193,14 @@ class SubroutineDefinition:
                         f"Function keyword parameter {name} has type {expected_arg_type}"
                     )
                 abi_output_kwarg[name] = expected_arg_type
-            else:
-                expected_arg_types.append(expected_arg_type)
+                continue
 
-                if expected_arg_type is ScratchVar:
-                    by_ref_args.add(name)
-                if isinstance(expected_arg_type, abi.TypeSpec):
-                    abi_args[name] = expected_arg_type
+            expected_arg_types.append(expected_arg_type)
+
+            if expected_arg_type is ScratchVar:
+                by_ref_args.add(name)
+            if isinstance(expected_arg_type, abi.TypeSpec):
+                abi_args[name] = expected_arg_type
 
         return expected_arg_types, by_ref_args, abi_args, abi_output_kwarg
 

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -79,7 +79,7 @@ class SubroutineDefinition:
         self.__name = self.implementation.__name__ if name_str is None else name_str
 
     @staticmethod
-    def is_abi_annotation(obj: Any) -> bool:
+    def _is_abi_annotation(obj: Any) -> bool:
         try:
             abi.type_spec_from_annotation(obj)
             return True
@@ -105,14 +105,16 @@ class SubroutineDefinition:
             # * `invoke` type checks provided arguments against parameter types to catch mismatches.
             return Expr
         else:
-            if not isclass(ptype) and not SubroutineDefinition.is_abi_annotation(ptype):
+            if not isclass(ptype) and not SubroutineDefinition._is_abi_annotation(
+                ptype
+            ):
                 raise TealInputError(
                     f"Function has parameter {parameter_name} of declared type {ptype} which is not a class"
                 )
 
             if ptype in (Expr, ScratchVar):
                 return ptype
-            elif SubroutineDefinition.is_abi_annotation(ptype):
+            elif SubroutineDefinition._is_abi_annotation(ptype):
                 return abi.type_spec_from_annotation(ptype)
             else:
                 raise TealInputError(
@@ -191,14 +193,13 @@ class SubroutineDefinition:
                         f"Function keyword parameter {name} has type {expected_arg_type}"
                     )
                 abi_output_kwarg[name] = expected_arg_type
-                continue
             else:
                 expected_arg_types.append(expected_arg_type)
 
-            if expected_arg_type is ScratchVar:
-                by_ref_args.add(name)
-            if isinstance(expected_arg_type, abi.TypeSpec):
-                abi_args[name] = expected_arg_type
+                if expected_arg_type is ScratchVar:
+                    by_ref_args.add(name)
+                if isinstance(expected_arg_type, abi.TypeSpec):
+                    abi_args[name] = expected_arg_type
 
         return expected_arg_types, by_ref_args, abi_args, abi_output_kwarg
 
@@ -299,15 +300,15 @@ class _OutputKwArgInfo:
 
     @staticmethod
     def from_dict(kwarg_info: dict[str, abi.TypeSpec]) -> Optional["_OutputKwArgInfo"]:
-        if kwarg_info is None or len(kwarg_info) == 0:
-            return None
-        elif len(kwarg_info) == 1:
-            key = list(kwarg_info.keys())[0]
-            return _OutputKwArgInfo(key, kwarg_info[key])
-        else:
-            raise TealInputError(
-                f"illegal conversion kwarg_info length {len(kwarg_info)}."
-            )
+        match list(kwarg_info.keys()):
+            case []:
+                return None
+            case [k]:
+                return _OutputKwArgInfo(k, kwarg_info[k])
+            case _:
+                raise TealInputError(
+                    f"illegal conversion kwarg_info length {len(kwarg_info)}."
+                )
 
 
 _OutputKwArgInfo.__module__ = "pyteal"


### PR DESCRIPTION
Optionally bundles the following refactorings to #256:
* Rename `is_abi_annotation` to `_is_abi_annotation` because its intent appears to be private.
* Refactor `from_dict` to pattern match statements.  The change is minor though subjectively, I feel it's easier to interpret.
  * I confirmed  `kwarg_info` isn't supplied as `None`.  I presume it's _safe_ to remove the null check because we don't elsewhere rigorously check for nulls when parameter isn't optional.
  * Refactor `_arg_types_and_by_refs` to remove `continue` statement usage.  Subjectively, I find it difficult to follow jumps with `continue` statements.

Feel welcomed to tell me that you'd prefer to keep as is and I'll happily close the PR.  If some of the changes are desirable, feel welcomed to ask me to itemize discrete changesets.