### PR TITLE
Reorder _validate_parameter_type to avoid isclass check

### DIFF
--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from dataclasses import dataclass
-from inspect import isclass, Parameter, signature, Signature
+from inspect import Parameter, signature, Signature
 from typing import (
     Callable,
     Optional,
@@ -105,13 +105,6 @@ class SubroutineDefinition:
             # * `invoke` type checks provided arguments against parameter types to catch mismatches.
             return Expr
         else:
-            if not isclass(ptype) and not SubroutineDefinition._is_abi_annotation(
-                ptype
-            ):
-                raise TealInputError(
-                    f"Function has parameter {parameter_name} of declared type {ptype} which is not a class"
-                )
-
             if ptype in (Expr, ScratchVar):
                 return ptype
             elif SubroutineDefinition._is_abi_annotation(ptype):

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -595,8 +595,8 @@ def test_subroutine_definition_invalid():
         ),
         (
             fnWithNonExprParamAnnotation,
-            "Function has parameter b of declared type TealType.uint64 which is not a class",
-            "Function has parameter b of declared type TealType.uint64 which is not a class",
+            f"Function has parameter b of disallowed type TealType.uint64. Only the types {(pt.Expr, pt.ScratchVar, 'ABI')} are allowed",
+            f"Function has parameter b of disallowed type TealType.uint64. Only the types {(pt.Expr, pt.ScratchVar, 'ABI')} are allowed",
         ),
         (
             fnWithScratchVarSubclass,


### PR DESCRIPTION
Reorders checks in `Reorder _validate_parameter_type` to avoid `isclass` check.

Rationale:  Since there was some discussion on the topic in https://github.com/algorand/pyteal/pull/256#discussion_r861330174, I paired with @tzaffi to better understand the runtime type system checks.  While pairing, we observed that it's possible to remove a check and retain equivalent functionality _provided_ we're _OK_ with a different granularity error message.

Treat as optional.  I'll happily close if you'd prefer to keep as is. 