### PR TITLE
v0.12.1b2: back to requirements.txt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
   upload-to-pypi:
     runs-on: ubuntu-20.04
     container: python:3.10
-    needs: ['build-test']
+    needs: ['build-test', 'run-integration-tests', 'build-docset']
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     steps:
       - name: Check out code

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # ---- Setup ---- #
 
 setup-development:
-	pip install -e .[development]
+	pip install -e .
+	pip install -r requirements.txt
 
 setup-docs: setup-development
 	pip install -r docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ Pip install PyTeal in editable state with dependencies:
 
 * `make setup-development`
 * OR if you don't have `make` installed:
-  * `pip install -e.[development]`
-  * Note, that if you're using `zsh` you'll need to escape the brackets: `pip install -e.\[development\]`
+  * `pip install -e . && pip install -r requirements.txt`
 
 Format code:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+black==22.3.0
+flake8==4.0.1
+flake8-tidy-imports==4.6.0
+graviton@git+https://github.com/algorand/graviton@5549e6227a819b9f6d346f407aed32f4976ec0b2
+mypy==0.950
+pytest==7.1.1
+pytest-cov==3.0.0
+pytest-timeout==2.1.0
+pytest-xdist==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 flake8==4.0.1
 flake8-tidy-imports==4.6.0
-graviton@git+https://github.com/algorand/graviton@5549e6227a819b9f6d346f407aed32f4976ec0b2
+graviton@git+https://github.com/algorand/graviton@v0.1.0
 mypy==0.950
 pytest==7.1.1
 pytest-cov==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyteal",
-    version="0.12.1b1",
+    version="0.12.1b2",
     author="Algorand",
     author_email="pypiservice@algorand.com",
     description="Algorand Smart Contracts in Python",

--- a/setup.py
+++ b/setup.py
@@ -16,19 +16,6 @@ setuptools.setup(
     url="https://github.com/algorand/pyteal",
     packages=setuptools.find_packages(),
     install_requires=["py-algorand-sdk"],
-    extras_require={
-        "development": [
-            "black==22.3.0",
-            "flake8==4.0.1",
-            "flake8-tidy-imports==4.6.0",
-            "graviton@git+https://github.com/algorand/graviton@5549e6227a819b9f6d346f407aed32f4976ec0b2",
-            "mypy==0.950",
-            "pytest==7.1.1",
-            "pytest-cov==3.0.0",
-            "pytest-timeout==2.1.0",
-            "pytest-xdist==2.5.0",
-        ],
-    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
# Fix the problems that prevented `v0.12.0` from getting to `PyPi` 

* Adding `requirements.txt` for development builds (because of the graviton [dependency as a non-PyPi resource](https://stackoverflow.com/questions/54887301/how-can-i-use-git-repos-as-dependencies-for-my-pypi-package/54894359#54894359))

## Also making publication depend on all tests passing:

<img width="644" alt="image" src="https://user-images.githubusercontent.com/291133/166341038-192a4f45-50c2-4481-a2ac-63590932fd88.png">

