### PR TITLE
Add convenience `make` method for ABI types

### DIFF
--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -35,8 +35,8 @@ from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
 from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray
 from pyteal.ast.abi.array_dynamic import DynamicArrayTypeSpec, DynamicArray
 
-from pyteal.ast.abi.util import type_spec_from_annotation, make
 from pyteal.ast.abi.method_return import MethodReturn
+from pyteal.ast.abi.util import type_spec_from_annotation, make
 
 __all__ = [
     "String",
@@ -77,7 +77,7 @@ __all__ = [
     "StaticArray",
     "DynamicArrayTypeSpec",
     "DynamicArray",
+    "MethodReturn",
     "type_spec_from_annotation",
     "make",
-    "MethodReturn",
 ]

--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -34,7 +34,8 @@ from pyteal.ast.abi.tuple import (
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
 from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray
 from pyteal.ast.abi.array_dynamic import DynamicArrayTypeSpec, DynamicArray
-from pyteal.ast.abi.util import type_spec_from_annotation
+
+from pyteal.ast.abi.util import type_spec_from_annotation, make
 from pyteal.ast.abi.method_return import MethodReturn
 
 __all__ = [
@@ -77,5 +78,6 @@ __all__ = [
     "DynamicArrayTypeSpec",
     "DynamicArray",
     "type_spec_from_annotation",
+    "make",
     "MethodReturn",
 ]

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -1,10 +1,10 @@
-from typing import Any, Literal, get_origin, get_args
+from typing import TypeVar, Any, Literal, get_origin, get_args, cast
 
 from pyteal.errors import TealInputError
 from pyteal.ast.expr import Expr
 from pyteal.ast.int import Int
 from pyteal.ast.substring import Extract, Substring, Suffix
-from pyteal.ast.abi.type import TypeSpec
+from pyteal.ast.abi.type import TypeSpec, BaseType
 
 
 def substringForDecoding(
@@ -205,3 +205,30 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         return TupleTypeSpec(*(type_spec_from_annotation(arg) for arg in args))
 
     raise TypeError("Unknown annotation origin: {}".format(origin))
+
+
+T = TypeVar("T", bound=BaseType)
+
+
+def make(t: type[T]) -> T:
+    """Create a new instance of an ABI type. The type to create is determined by the input argument,
+    which must be a fully-specified annotation of type's class.
+
+    For example:
+        .. code-block:: python
+
+                # both of these are equivalent
+                myTuple = abi.make(abi.Tuple2[abi.Uint64, abi.DynamicArray[abi.Bool]])
+                myTuple = abi.Tuple(abi.TupleTypeSpec(abi.Uint64TypeSpec(), abi.DynamicArrayTypeSpec(abi.BoolTypeSpec())))
+
+    This is purely a convenience method over instantiating the type directly, which can be cumbersome
+    due to the lengthy TypeSpec class names.
+
+    Args:
+        t: A fully-specified annotation of a subclass of abi.BaseType, meaning all generic parameters
+            must be given values.
+
+    Returns:
+        A new instance of the given type class.
+    """
+    return cast(T, type_spec_from_annotation(t).new_instance())

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -212,21 +212,21 @@ T = TypeVar("T", bound=BaseType)
 
 def make(t: type[T]) -> T:
     """Create a new instance of an ABI type. The type to create is determined by the input argument,
-    which must be a fully-specified annotation of type's class.
+    which must be a fully-specified type's class. Fully-specified means that every generic argument
+    is given a value.
 
     For example:
         .. code-block:: python
 
                 # both of these are equivalent
-                myTuple = abi.make(abi.Tuple2[abi.Uint64, abi.DynamicArray[abi.Bool]])
-                myTuple = abi.Tuple(abi.TupleTypeSpec(abi.Uint64TypeSpec(), abi.DynamicArrayTypeSpec(abi.BoolTypeSpec())))
+                a = abi.make(abi.Tuple2[abi.Uint64, abi.StaticArray[abi.Bool, Literal[8]]])
+                b = abi.TupleTypeSpec(abi.Uint64TypeSpec(), abi.StaticArrayTypeSpec(abi.BoolTypeSpec(), 8))
 
     This is purely a convenience method over instantiating the type directly, which can be cumbersome
     due to the lengthy TypeSpec class names.
 
     Args:
-        t: A fully-specified annotation of a subclass of abi.BaseType, meaning all generic parameters
-            must be given values.
+        t: A fully-specified subclass of abi.BaseType.
 
     Returns:
         A new instance of the given type class.

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -303,3 +303,13 @@ def test_type_spec_from_annotation_is_exhaustive():
         except TypeError as e:
             # if subclass is generic, we should get an error that is NOT "Unknown annotation origin"
             assert "Unknown annotation origin" not in str(e)
+
+
+def test_make():
+    actual = abi.make(abi.Tuple2[abi.Uint64, abi.StaticArray[abi.Bool, Literal[8]]])
+    expected_type_spec = abi.TupleTypeSpec(
+        abi.Uint64TypeSpec(), abi.StaticArrayTypeSpec(abi.BoolTypeSpec(), 8)
+    )
+
+    assert actual.type_spec() == expected_type_spec
+    assert type(actual) is abi.Tuple


### PR DESCRIPTION
As described in https://github.com/algorand/pyteal/pull/289#discussion_r862178354, add a convenience method to instantiate ABI types.

Example usage:

```python
myTuple = abi.make(abi.Tuple2[abi.Uint64, abi.DynamicArray[abi.Bool]])
```

The above produces the same as:
```python
myTuple = abi.Tuple(abi.TupleTypeSpec(abi.Uint64TypeSpec(), abi.DynamicArrayTypeSpec(abi.BoolTypeSpec())))
```