### PR TITLE
Use deferred subroutine expression for ABI returns

### DIFF
--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -11,7 +11,6 @@ from typing import (
 
 from pyteal.ast import abi
 from pyteal.ast.expr import Expr
-from pyteal.ast.return_ import Return
 from pyteal.ast.seq import Seq
 from pyteal.ast.scratchvar import DynamicScratchVar, ScratchVar
 from pyteal.errors import TealInputError, verifyTealVersion

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -731,10 +731,6 @@ def evaluate_subroutine(subroutine: SubroutineDefinition) -> SubroutineDeclarati
 
     # if there is an output keyword argument for ABI, place the storing on the stack
     if output_carrying_abi:
-        if subroutine_body.has_return():
-            raise TealInputError(
-                "ABI returning subroutine definition should have no return"
-            )
         if subroutine_body.type_of() != TealType.none:
             raise TealInputError(
                 f"ABI returning subroutine definition should evaluate to TealType.none, "

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -302,10 +302,16 @@ SubroutineDefinition.__module__ = "pyteal"
 
 
 class SubroutineDeclaration(Expr):
-    def __init__(self, subroutine: SubroutineDefinition, body: Expr) -> None:
+    def __init__(
+        self,
+        subroutine: SubroutineDefinition,
+        body: Expr,
+        deferred_expr: Optional[Expr] = None,
+    ) -> None:
         super().__init__()
         self.subroutine = subroutine
         self.body = body
+        self.deferred_expr = deferred_expr
 
     def __teal__(self, options: "CompileOptions"):
         return self.body.__teal__(options)
@@ -720,6 +726,9 @@ def evaluate_subroutine(subroutine: SubroutineDefinition) -> SubroutineDeclarati
         raise TealInputError(
             f"Subroutine function does not return a PyTeal expression. Got type {type(subroutine_body)}."
         )
+
+    deferred_expr: Optional[Expr] = None
+
     # if there is an output keyword argument for ABI, place the storing on the stack
     if output_carrying_abi:
         if subroutine_body.has_return():
@@ -731,13 +740,11 @@ def evaluate_subroutine(subroutine: SubroutineDefinition) -> SubroutineDeclarati
                 f"ABI returning subroutine definition should evaluate to TealType.none, "
                 f"while evaluate to {subroutine_body.type_of()}."
             )
-        subroutine_body = Seq(
-            subroutine_body, Return(output_carrying_abi.stored_value.load())
-        )
+        deferred_expr = output_carrying_abi.stored_value.load()
 
     # Arg usage "A" to be pick up and store in scratch parameters that have been placed on the stack
     # need to reverse order of argumentVars because the last argument will be on top of the stack
     body_ops = [var.slot.store() for var in arg_vars[::-1]]
     body_ops.append(subroutine_body)
 
-    return SubroutineDeclaration(subroutine, Seq(body_ops))
+    return SubroutineDeclaration(subroutine, Seq(body_ops), deferred_expr)

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -145,12 +145,6 @@ def compileSubroutine(
         # this represents code that should be inserted before each retsub op
         deferred_expr = cast(Expr, currentSubroutine.get_declaration().deferred_expr)
 
-        # creating a function so that we can have a new copy of the blocks every time we want to
-        # insert them -- you cannot have the same block in two different places in the control flow
-        # graph
-        def get_deferred_blocks():
-            return deferred_expr.__teal__(options)
-
         for block in TealBlock.Iterate(start):
             if not any(op.getOp() == Op.retsub for op in block.ops):
                 continue
@@ -162,7 +156,9 @@ def compileSubroutine(
                     f"Expected retsub to be the only op in the block, but there are {len(block.ops)} ops"
                 )
 
-            deferred_start, deferred_end = get_deferred_blocks()
+            # we invoke __teal__ here and not outside of this loop because the same block cannot be
+            # added in multiple places to the control flow graph
+            deferred_start, deferred_end = deferred_expr.__teal__(options)
             deferred_start.addIncoming()
             deferred_start.validateTree()
 

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Tuple, Set, Dict, Optional, cast
+from typing import List, Tuple, Set, Dict, Optional, cast
 
 from pyteal.compiler.optimizer import OptimizeOptions, apply_global_optimizations
 
@@ -144,7 +144,7 @@ def compileSubroutine(
     ):
         deferred_expr = cast(Expr, currentSubroutine.get_declaration().deferred_expr)
         # these blocks represent a path of code that should be inserted before each retsub op
-        get_deferred_blocks = lambda: deferred_expr.__teal__(options)
+        get_deferred_blocks = lambda: deferred_expr.__teal__(options)  # noqa: E731
 
         # insert deferred blocks where needed
         for block in TealBlock.Iterate(start):

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -1683,7 +1683,7 @@ retsub
 
     # manually add deferred expression to SubroutineDefinition
     declaration = deferredExample.subroutine.get_declaration()
-    declaration.deferred_expr = pt.Bytes("deferred")
+    declaration.deferred_expr = pt.Pop(pt.Bytes("deferred"))
 
     expected_deferred = """#pragma version 6
 int 10
@@ -1719,9 +1719,11 @@ int 1
 return
 deferredExample_0_l7:
 byte "deferred"
+pop
 retsub
 deferredExample_0_l8:
 byte "deferred"
+pop
 retsub
     """.strip()
     actual_deferred = pt.compileTeal(

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -1732,6 +1732,48 @@ retsub
     assert actual_deferred == expected_deferred
 
 
+def test_compile_subroutine_deferred_expr_empty():
+    @pt.Subroutine(pt.TealType.none)
+    def empty() -> pt.Expr:
+        return pt.Return()
+
+    program = pt.Seq(empty(), pt.Approve())
+
+    expected_no_deferred = """#pragma version 6
+callsub empty_0
+int 1
+return
+
+// empty
+empty_0:
+retsub
+    """.strip()
+    actual_no_deferred = pt.compileTeal(
+        program, pt.Mode.Application, version=6, assembleConstants=False
+    )
+    assert actual_no_deferred == expected_no_deferred
+
+    # manually add deferred expression to SubroutineDefinition
+    declaration = empty.subroutine.get_declaration()
+    declaration.deferred_expr = pt.Pop(pt.Bytes("deferred"))
+
+    expected_deferred = """#pragma version 6
+callsub empty_0
+int 1
+return
+
+// empty
+empty_0:
+byte "deferred"
+pop
+retsub
+    """.strip()
+    actual_deferred = pt.compileTeal(
+        program, pt.Mode.Application, version=6, assembleConstants=False
+    )
+    assert actual_deferred == expected_deferred
+
+
 def test_compile_wide_ratio():
     cases = (
         (


### PR DESCRIPTION
Inspired by Go's `defer` feature, this PR adds the ability for subroutines to have a deferred expression that will be inserted by the compiler before every instance of `retsub` in that subroutine.

Note that it's only added before `retsub` ops, not program ending ops like `return` or `err`. Why not? Because we cannot insert code before _every_ program ending operation, for two reasons:
* Some ops will fail the program if they are given invalid inputs, e.g. adding two ints that overflow. We can't know ahead of time what will fail and insert code before them.
* The subroutine can call another subroutine which (either conditionally or always) invokes a `return` op. Our subroutine has no visibility into this, so we can't insert code before it.

This feature is only used to implement ABI return value subroutines and is not directly exposed to users.