### PR TITLE
Fix `If` type bug

### DIFF
--- a/pyteal/ast/if_test.py
+++ b/pyteal/ast/if_test.py
@@ -252,7 +252,14 @@ def test_if_invalid_alt_syntax():
         expr = pt.If(pt.Int(0)).Then(pt.Int(1)).ElseIf(pt.Int(2))
         expr.__teal__(options)
 
-    with pytest.raises(pt.TealCompileError):
+    with pytest.raises(pt.TealTypeError):
+        expr = pt.If(pt.Int(0)).Then(pt.Int(2))
+        expr.type_of()
+
+    with pytest.raises(pt.TealInputError):
+        pt.If(pt.Int(0)).Else(pt.Int(1)).Then(pt.Int(2))
+
+    with pytest.raises(pt.TealInputError):
         expr = pt.If(pt.Int(0)).Else(pt.Int(1))
         expr.__teal__(options)
 

--- a/pyteal/ast/multi_test.py
+++ b/pyteal/ast/multi_test.py
@@ -37,7 +37,7 @@ def __test_single_conditional(
     ifExpr = (
         pt.If(expr.output_slots[1].load())
         .Then(expr.output_slots[0].load())
-        .Else(pt.Bytes("None"))
+        .Else(pt.App.globalGet(pt.Bytes("None")))
     )
     ifBlockStart, _ = ifExpr.__teal__(options)
 
@@ -165,7 +165,7 @@ def test_multi_value():
                     reducer = (
                         lambda value, hasValue: pt.If(hasValue)
                         .Then(value)
-                        .Else(pt.Bytes("None"))
+                        .Else(pt.App.globalGet(pt.Bytes("None")))
                     )
                     expr = pt.MultiValue(
                         op, [type, pt.TealType.uint64], immediate_args=iargs, args=args


### PR DESCRIPTION
PyTeal `If` statements have the following rules:
1. If a then branch (what executes when the condition is true) and an else branch (what executes when the condition is false) exist, then both must return the same `TealType`.
2. If a then branch exists and an else branch does not, then the then branch must return `TealType.none`, since in this case the else branch is essentially `Seq()` (a noop expression that returns nothing).

These rules are properly enforced for the original `If` syntax (`If(<condition>, <then>, <else>)`), but the new syntax (`If(<condition>).Then(<then>).Else(<else>)`) unfortunately does not enforce these rules. This PR fixes that.