### PR TITLE
Unsuccessfully experiment with paritial

### DIFF
--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -408,3 +408,38 @@ class BlackboxPyTealer:
                 )
             case _:
                 raise Exception(f"Unknown mode {self.mode} of type {type(self.mode)}")
+
+    # Does not work - provided for illustration.  Error is:
+    # E       TypeError: DryRunExecutor.dryrun_app_on_sequence() got multiple values for argument 'cls'
+    #
+    # Relates to https://stackoverflow.com/questions/16626789/functools-partial-on-class-method.
+    def dryrun_on_sequence_partial(
+        self,
+        compiler_version=6,
+    ) -> Callable[[List[Sequence[Union[str, int]]]], List[DryRunInspector]]:
+        from functools import partial
+
+        match self.mode:
+            case Mode.Application:
+                return partial(
+                    DryRunExecutor.dryrun_app_on_sequence,
+                    algod=algod_with_assertion(),
+                    teal=compileTeal(
+                        self.program(), Mode.Application, version=compiler_version
+                    ),
+                    abi_argument_types=self.abi_argument_types(),
+                    abi_return_type=self.abi_return_type(),
+                    sender=ZERO_ADDRESS,
+                )
+
+            case Mode.Signature:
+                return partial(
+                    DryRunExecutor.dryrun_app_on_sequence,
+                    algod=algod_with_assertion(),
+                    teal=compileTeal(
+                        self.program(), Mode.Signature, version=compiler_version
+                    ),
+                    abi_argument_types=self.abi_argument_types(),
+                    abi_return_type=self.abi_return_type(),
+                    sender=ZERO_ADDRESS,
+                )


### PR DESCRIPTION
Snapshots an unsuccessful attempt to use `functools.partial` as an alternative to #335.

Since the approach doesn't appear to work, I'm opening + closing the PR for illustrative purposes.
* Based on the ~30min I spent here, it seems partial functions added _outside_ of a class is less well supported.  Or at least I don't quite grok how to do it.
* I attempted several variations on what's shown here.  I think the crux of the problem is capturing the `cls` instance when outside the scope of the referred-to-class. 

Since partial function application didn't work as intended, I also spent a few minutes considering a _monkey patching_ solution to preserve invoking a method against `DryrunExecutor`.  That also didn't exactly pan out and I ended up aborting.

I suspect there _is_ a path here.  Though I felt it was taking longer than warranted for the problem at-hand.  I plan to reconsider the topic over time.