### PR TITLE
adding byte type hint to DyanamicArray parent class

### DIFF
--- a/pyteal/ast/abi/string.py
+++ b/pyteal/ast/abi/string.py
@@ -1,6 +1,7 @@
 from typing import Union, TypeVar, Sequence
 from collections.abc import Sequence as CollectionSequence
 
+from pyteal.ast.abi.uint import Byte
 from pyteal.ast.abi.type import ComputedValue, BaseType
 from pyteal.ast.abi.array_dynamic import DynamicArray, DynamicArrayTypeSpec
 from pyteal.ast.abi.uint import ByteTypeSpec, Uint16TypeSpec
@@ -39,7 +40,7 @@ class StringTypeSpec(DynamicArrayTypeSpec):
 StringTypeSpec.__module__ = "pyteal"
 
 
-class String(DynamicArray):
+class String(DynamicArray[Byte]):
     def __init__(self) -> None:
         super().__init__(StringTypeSpec())
 


### PR DESCRIPTION
I noticed I was getting `Any` as the type hint on the argument to the lambda function in something like this:

```py
a[idx.load()].use(lambda v: buff.store(Concat(buff.load(), v.encode())))
```
Where `a` is a String.

This seems to give the correct type hint