### PR TITLE
Static decode

### DIFF
--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -76,7 +76,7 @@ def test_Address_decode():
                     substringForDecoding(
                         encoded,
                         startIndex=startIndex,
-                        length=value.length(),
+                        length=pt.Int(value.type_spec().byte_length_static()),
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -1,6 +1,7 @@
 import pytest
 import pyteal as pt
 from pyteal import abi
+from pyteal.ast.abi.address import AddressLength
 
 from pyteal.ast.abi.type_test import ContainerType
 from pyteal.ast.abi.util import substringForDecoding
@@ -68,15 +69,15 @@ def test_Address_decode():
                         )
                     continue
 
-                expr = value.decode(
-                    encoded, startIndex=startIndex, endIndex=endIndex, length=length
-                )
+                expr = value.decode(encoded, startIndex=startIndex)
                 assert expr.type_of() == pt.TealType.none
                 assert expr.has_return() is False
 
                 expectedExpr = value.stored_value.store(
                     substringForDecoding(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded,
+                        startIndex=startIndex,
+                        length=pt.Int(int(AddressLength.Bytes)),
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -1,7 +1,6 @@
 import pytest
 import pyteal as pt
 from pyteal import abi
-from pyteal.ast.abi.address import AddressLength
 
 from pyteal.ast.abi.type_test import ContainerType
 from pyteal.ast.abi.util import substringForDecoding
@@ -77,7 +76,7 @@ def test_Address_decode():
                     substringForDecoding(
                         encoded,
                         startIndex=startIndex,
-                        length=pt.Int(int(AddressLength.Bytes)),
+                        length=value.length(),
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/array_base.py
+++ b/pyteal/ast/abi/array_base.py
@@ -270,12 +270,7 @@ class ArrayElement(ComputedValue[T]):
 
             return output.decode(encodedArray, startIndex=valueStart, endIndex=valueEnd)
 
-        # Handling case for array elements are static:
-        # since array._stride() is element's static byte length
-        # we partition the substring for array element.
-        valueStart = byteIndex
-        valueLength = Int(arrayType._stride())
-        return output.decode(encodedArray, startIndex=valueStart, length=valueLength)
+        return output.decode(encodedArray, startIndex=byteIndex)
 
 
 ArrayElement.__module__ = "pyteal"

--- a/pyteal/ast/abi/array_base_test.py
+++ b/pyteal/ast/abi/array_base_test.py
@@ -48,6 +48,8 @@ DYNAMIC_TYPES: List[abi.TypeSpec] = [
             10,
         )
     ),
+    abi.StaticArrayTypeSpec(abi.StringTypeSpec(), 10),
+    abi.StaticArrayTypeSpec(abi.DynamicArrayTypeSpec(abi.Uint64TypeSpec()), 10),
 ]
 
 

--- a/pyteal/ast/abi/array_base_test.py
+++ b/pyteal/ast/abi/array_base_test.py
@@ -79,7 +79,6 @@ def test_ArrayElement_store_into():
 
         encoded = staticArray.encode()
         stride = pt.Int(staticArray.type_spec()._stride())
-        expectedLength = staticArray.length()
         if elementType == abi.BoolTypeSpec():
             expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index)
         elif not elementType.is_dynamic():
@@ -90,9 +89,9 @@ def test_ArrayElement_store_into():
             expectedExpr = output.decode(
                 encoded,
                 startIndex=pt.ExtractUint16(encoded, stride * index),
-                endIndex=pt.If(index + pt.Int(1) == expectedLength)
-                .Then(pt.Len(encoded))
-                .Else(pt.ExtractUint16(encoded, stride * index + pt.Int(2))),
+                # endIndex=pt.If(index + pt.Int(1) == expectedLength)
+                # .Then(pt.Len(encoded))
+                # .Else(pt.ExtractUint16(encoded, stride * index + pt.Int(2))),
             )
 
         expected, _ = expectedExpr.__teal__(options)
@@ -120,7 +119,6 @@ def test_ArrayElement_store_into():
 
         encoded = dynamicArray.encode()
         stride = pt.Int(dynamicArray.type_spec()._stride())
-        expectedLength = dynamicArray.length()
         if elementType == abi.BoolTypeSpec():
             expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index + pt.Int(16))
         elif not elementType.is_dynamic():
@@ -132,12 +130,12 @@ def test_ArrayElement_store_into():
                 encoded,
                 startIndex=pt.ExtractUint16(encoded, stride * index + pt.Int(2))
                 + pt.Int(2),
-                endIndex=pt.If(index + pt.Int(1) == expectedLength)
-                .Then(pt.Len(encoded))
-                .Else(
-                    pt.ExtractUint16(encoded, stride * index + pt.Int(2) + pt.Int(2))
-                    + pt.Int(2)
-                ),
+                # endIndex=pt.If(index + pt.Int(1) == expectedLength)
+                # .Then(pt.Len(encoded))
+                # .Else(
+                #    pt.ExtractUint16(encoded, stride * index + pt.Int(2) + pt.Int(2))
+                #    + pt.Int(2)
+                # ),
             )
 
         expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/array_base_test.py
+++ b/pyteal/ast/abi/array_base_test.py
@@ -79,19 +79,18 @@ def test_ArrayElement_store_into():
 
         encoded = staticArray.encode()
         stride = pt.Int(staticArray.type_spec()._stride())
+        expectedLength = staticArray.length()
         if elementType == abi.BoolTypeSpec():
             expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index)
         elif not elementType.is_dynamic():
-            expectedExpr = output.decode(
-                encoded, startIndex=stride * index, length=stride
-            )
+            expectedExpr = output.decode(encoded, startIndex=stride * index)
         else:
             expectedExpr = output.decode(
                 encoded,
                 startIndex=pt.ExtractUint16(encoded, stride * index),
-                # endIndex=pt.If(index + pt.Int(1) == expectedLength)
-                # .Then(pt.Len(encoded))
-                # .Else(pt.ExtractUint16(encoded, stride * index + pt.Int(2))),
+                endIndex=pt.If(index + pt.Int(1) == expectedLength)
+                .Then(pt.Len(encoded))
+                .Else(pt.ExtractUint16(encoded, stride * index + pt.Int(2))),
             )
 
         expected, _ = expectedExpr.__teal__(options)
@@ -119,23 +118,22 @@ def test_ArrayElement_store_into():
 
         encoded = dynamicArray.encode()
         stride = pt.Int(dynamicArray.type_spec()._stride())
+        expectedLength = dynamicArray.length()
         if elementType == abi.BoolTypeSpec():
             expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index + pt.Int(16))
         elif not elementType.is_dynamic():
-            expectedExpr = output.decode(
-                encoded, startIndex=stride * index + pt.Int(2), length=stride
-            )
+            expectedExpr = output.decode(encoded, startIndex=stride * index + pt.Int(2))
         else:
             expectedExpr = output.decode(
                 encoded,
                 startIndex=pt.ExtractUint16(encoded, stride * index + pt.Int(2))
                 + pt.Int(2),
-                # endIndex=pt.If(index + pt.Int(1) == expectedLength)
-                # .Then(pt.Len(encoded))
-                # .Else(
-                #    pt.ExtractUint16(encoded, stride * index + pt.Int(2) + pt.Int(2))
-                #    + pt.Int(2)
-                # ),
+                endIndex=pt.If(index + pt.Int(1) == expectedLength)
+                .Then(pt.Len(encoded))
+                .Else(
+                    pt.ExtractUint16(encoded, stride * index + pt.Int(2) + pt.Int(2))
+                    + pt.Int(2)
+                ),
             )
 
         expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -92,11 +92,6 @@ class StaticArray(Array[T], Generic[T, N]):
                 encoded, startIndex=startIndex, endIndex=endIndex, length=length
             )
 
-        if length is not None:
-            raise TealInputError(
-                "Expected None for endIndex and length on static array"
-            )
-
         return super().decode(
             encoded,
             startIndex=startIndex,

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -152,7 +152,7 @@ class StaticArray(Array[T], Generic[T, N]):
         Returns:
             A PyTeal expression that represents the static array length.
         """
-        return Int(int(self.type_spec().length_static()))
+        return Int(self.type_spec().length_static())
 
     def __getitem__(self, index: Union[int, Expr]) -> "ArrayElement[T]":
         if type(index) is int and index >= self.type_spec().length_static():

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -78,6 +78,21 @@ class StaticArray(Array[T], Generic[T, N]):
     def type_spec(self) -> StaticArrayTypeSpec[T, N]:
         return cast(StaticArrayTypeSpec[T, N], super().type_spec())
 
+    def decode(
+        self,
+        encoded: Expr,
+        *,
+        startIndex: Expr = None,
+        endIndex: Expr = None,
+        length: Expr = None,
+    ) -> Expr:
+        if endIndex is not None or length is not None:
+            raise TealInputError(
+                "Expected None for endIndex and length on static array"
+            )
+
+        return super().decode(encoded, startIndex=startIndex, length=self.length())
+
     def set(
         self,
         values: Union[
@@ -127,7 +142,7 @@ class StaticArray(Array[T], Generic[T, N]):
         Returns:
             A PyTeal expression that represents the static array length.
         """
-        return Int(self.type_spec().length_static())
+        return Int(int(self.type_spec().length_static()))
 
     def __getitem__(self, index: Union[int, Expr]) -> "ArrayElement[T]":
         if type(index) is int and index >= self.type_spec().length_static():

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -92,7 +92,7 @@ class StaticArray(Array[T], Generic[T, N]):
                 encoded, startIndex=startIndex, endIndex=endIndex, length=length
             )
 
-        if endIndex is not None or length is not None:
+        if length is not None:
             raise TealInputError(
                 "Expected None for endIndex and length on static array"
             )
@@ -100,6 +100,7 @@ class StaticArray(Array[T], Generic[T, N]):
         return super().decode(
             encoded,
             startIndex=startIndex,
+            endIndex=endIndex,
             length=Int(self.type_spec().byte_length_static()),
         )
 

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -91,7 +91,7 @@ class StaticArray(Array[T], Generic[T, N]):
                 "Expected None for endIndex and length on static array"
             )
 
-        return super().decode(encoded, startIndex=startIndex, length=self.length())
+        return super().decode(encoded, startIndex=startIndex, length=self.byte_length())
 
     def set(
         self,

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -86,6 +86,12 @@ class StaticArray(Array[T], Generic[T, N]):
         endIndex: Expr = None,
         length: Expr = None,
     ) -> Expr:
+
+        if self.type_spec().is_dynamic():
+            return super().decode(
+                encoded, startIndex=startIndex, endIndex=endIndex, length=length
+            )
+
         if endIndex is not None or length is not None:
             raise TealInputError(
                 "Expected None for endIndex and length on static array"

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -91,7 +91,11 @@ class StaticArray(Array[T], Generic[T, N]):
                 "Expected None for endIndex and length on static array"
             )
 
-        return super().decode(encoded, startIndex=startIndex, length=self.byte_length())
+        return super().decode(
+            encoded,
+            startIndex=startIndex,
+            length=Int(self.type_spec().byte_length_static()),
+        )
 
     def set(
         self,

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -124,7 +124,9 @@ def test_StaticArray_decode():
 
                 expectedExpr = value.stored_value.store(
                     substringForDecoding(
-                        encoded, startIndex=startIndex, length=value.length()
+                        encoded,
+                        startIndex=startIndex,
+                        length=pt.Int(value.type_spec().byte_length_static()),
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -108,7 +108,7 @@ def test_StaticArray_decode():
                     abi.StaticArrayTypeSpec(abi.Uint64TypeSpec(), 10)
                 )
 
-                if endIndex is not None or length is not None:
+                if endIndex is not None and length is not None:
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -108,7 +108,7 @@ def test_StaticArray_decode():
                     abi.StaticArrayTypeSpec(abi.Uint64TypeSpec(), 10)
                 )
 
-                if endIndex is not None and length is not None:
+                if endIndex is not None or length is not None:
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
@@ -118,15 +118,13 @@ def test_StaticArray_decode():
                         )
                     continue
 
-                expr = value.decode(
-                    encoded, startIndex=startIndex, endIndex=endIndex, length=length
-                )
+                expr = value.decode(encoded, startIndex=startIndex)
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()
 
                 expectedExpr = value.stored_value.store(
                     substringForDecoding(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded, startIndex=startIndex, length=value.length()
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)


### PR DESCRIPTION
When decoding a static array we should know ahead of time what the length is.

Here we override the decode method from Array to set the length manually to the length computed from `length()` method on StaticArray type.

This _does_ make the output teal longer during decode since it applies an extra Extract operation