### PR TITLE
Optional refactorings to #322

### DIFF
--- a/tests/unit/blackbox_test.py
+++ b/tests/unit/blackbox_test.py
@@ -166,7 +166,9 @@ def test_blackbox_pyteal(subr: BlackboxWrapper, mode: pt.Mode):
 
 
 @pytest.mark.parametrize("subr_abi, mode", product(ABI_UNITS, pt.Mode))
-def test_abi_blackbox_pyteal(subr_abi: Tuple[BlackboxWrapper, Optional[pt.ast.abi.BaseType]], mode: pt.Mode):
+def test_abi_blackbox_pyteal(
+    subr_abi: Tuple[BlackboxWrapper, Optional[pt.ast.abi.BaseType]], mode: pt.Mode
+):
     subr, abi_return_type = subr_abi
     name = f"{'app' if mode == pt.Mode.Application else 'lsig'}_{subr.name()}"
     print(f"Case {subr.name()=}, {abi_return_type=}, {mode=} ------> {name=}")

--- a/tests/unit/blackbox_test.py
+++ b/tests/unit/blackbox_test.py
@@ -1,7 +1,7 @@
 from itertools import product
 from pathlib import Path
 import pytest
-from typing import Literal
+from typing import Literal, Optional, Tuple
 
 import pyteal as pt
 
@@ -151,7 +151,7 @@ ABI_UNITS = [
 
 
 @pytest.mark.parametrize("subr, mode", product(UNITS, pt.Mode))
-def test_blackbox_pyteal(subr, mode):
+def test_blackbox_pyteal(subr: BlackboxWrapper, mode: pt.Mode):
     is_app = mode == pt.Mode.Application
     name = f"{'app' if is_app else 'lsig'}_{subr.name()}"
 
@@ -166,7 +166,7 @@ def test_blackbox_pyteal(subr, mode):
 
 
 @pytest.mark.parametrize("subr_abi, mode", product(ABI_UNITS, pt.Mode))
-def test_abi_blackbox_pyteal(subr_abi, mode):
+def test_abi_blackbox_pyteal(subr_abi: Tuple[BlackboxWrapper, Optional[pt.ast.abi.BaseType]], mode: pt.Mode):
     subr, abi_return_type = subr_abi
     name = f"{'app' if mode == pt.Mode.Application else 'lsig'}_{subr.name()}"
     print(f"Case {subr.name()=}, {abi_return_type=}, {mode=} ------> {name=}")

--- a/tests/unit/user_guide_test.py
+++ b/tests/unit/user_guide_test.py
@@ -75,17 +75,17 @@ def user_guide_snippet_ABIReturnSubroutine():
 
     # --- BEGIN doc-comment --- #
     @ABIReturnSubroutine
-    def abi_sum(toSum: abi.DynamicArray[abi.Uint64], *, output: abi.Uint64) -> Expr:
+    def abi_sum(to_sum: abi.DynamicArray[abi.Uint64], *, output: abi.Uint64) -> Expr:
         i = ScratchVar(TealType.uint64)
-        valueAtIndex = abi.Uint64()
+        value_at_index = abi.Uint64()
         return Seq(
             output.set(0),
             For(
-                i.store(Int(0)), i.load() < toSum.length(), i.store(i.load() + Int(1))
+                i.store(Int(0)), i.load() < to_sum.length(), i.store(i.load() + Int(1))
             ).Do(
                 Seq(
-                    toSum[i.load()].store_into(valueAtIndex),
-                    output.set(output.get() + valueAtIndex.get()),
+                    to_sum[i.load()].store_into(value_at_index),
+                    output.set(output.get() + value_at_index.get()),
                 )
             ),
         )


### PR DESCRIPTION
Proposes optional refactorings to #322 considered during PR review.

Proposed changes:
* Add types to several test parameters in `tests/unit/blackbox_test.py`.  Intent is to simplify following test construction.
* Adhere more closely to PEP8 naming conventions in a user guide snippet:  `abi_sum`.  Intent is to make a best-effort to conform to PEP8 for code that's likely to appear on readthedocs.

Feel welcomed to request only part of the PR or none of it.  I don't feel strongly.