### PR TITLE
Optionally refactor handling of array_length int subclasses in StaticArrayTypeSpec

### DIFF
--- a/pyteal/ast/abi/address.py
+++ b/pyteal/ast/abi/address.py
@@ -22,7 +22,7 @@ AddressLength.__module__ = "pyteal"
 
 class AddressTypeSpec(StaticArrayTypeSpec):
     def __init__(self) -> None:
-        super().__init__(ByteTypeSpec(), int(AddressLength.Bytes))
+        super().__init__(ByteTypeSpec(), AddressLength.Bytes)
 
     def new_instance(self) -> "Address":
         return Address()
@@ -67,7 +67,7 @@ class Address(StaticArray[Byte, Literal[AddressLength.Bytes]]):
             case ComputedValue():
                 pts = value.produced_type_spec()
                 if pts == AddressTypeSpec() or pts == StaticArrayTypeSpec(
-                    ByteTypeSpec(), int(AddressLength.Bytes)
+                    ByteTypeSpec(), AddressLength.Bytes
                 ):
                     return value.store_into(self)
 
@@ -78,7 +78,7 @@ class Address(StaticArray[Byte, Literal[AddressLength.Bytes]]):
                 if (
                     value.type_spec() == AddressTypeSpec()
                     or value.type_spec()
-                    == StaticArrayTypeSpec(ByteTypeSpec(), int(AddressLength.Bytes))
+                    == StaticArrayTypeSpec(ByteTypeSpec(), AddressLength.Bytes)
                 ):
                     return self.stored_value.store(value.stored_value.load())
 

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -18,7 +18,9 @@ class StaticArrayTypeSpec(ArrayTypeSpec[T], Generic[T, N]):
         super().__init__(value_type_spec)
         if not isinstance(array_length, int) or array_length < 0:
             raise TypeError(f"Unsupported StaticArray length: {array_length}")
-        self.array_length: Final = array_length
+
+        # Casts to `int` to handle downstream usage where value is a subclass of int like `IntEnum`.
+        self.array_length: Final = int(array_length)
 
     def new_instance(self) -> "StaticArray[T, N]":
         return StaticArray(self)


### PR DESCRIPTION
Optionally proposes a refactoring to the question raised in https://github.com/algorand/pyteal/pull/322#discussion_r873197158.

Rationale:  It's less error prone to centralize the subclass check in `StaticArrayTypeSpec` rather than have the downstream user remember to cast.

Assumption:  It's _safe_ to treat any `int` subclass as int.  The intuition feels reasonable though it should be double checked.