### PR TITLE
Refactor ABIRoundtrip to always use annotation_type

### DIFF
--- a/tests/integration/abi_roundtrip_test.py
+++ b/tests/integration/abi_roundtrip_test.py
@@ -70,7 +70,11 @@ def roundtrip_setup(abi_type):
     if isinstance(abi_type, tuple):
         abi_type, dynamic_length = abi_type
 
-    return abi_type, dynamic_length, ABIRoundtrip(abi_type, dynamic_length).pytealer()
+    return (
+        abi_type,
+        dynamic_length,
+        ABIRoundtrip(abi.make(abi_type), length=dynamic_length).pytealer(),
+    )
 
 
 @pytest.mark.parametrize("abi_type", ABI_TYPES)


### PR DESCRIPTION
Optionally refactors `ABIRoundtrip` to remove branching during construction.

The PR stems from my attempt to understand why #322 requires `annotation_type`.  As a by-product of the investigation, I realized `ABIRoundtrip` branches because unlike all other usages, `tests/integration/abi_roundtrip_test.py` supplies `GenericAlias` instead of an equivalent instance.

From my review, I felt removing the branching produces a better tradeoff.  Though I present the PR optionally in case I've miss understood usage patterns.

