### PR TITLE
mypy --show-error-codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,9 @@ black:
 flake8:
 	flake8 $(ALLPY)
 
-# TODO: add `tests` to $MYPY when graviton respects mypy (version 🐗) 
 MYPY = pyteal scripts
 mypy:
-	mypy $(MYPY)
+	mypy --show-error-codes $(MYPY)
 
 lint: black flake8 mypy
 


### PR DESCRIPTION
# Output error code in `mypy` errors

This PR adds the error code into mypy's error outputs. For example, an error that was formerly shown as:

```sh
examples/application/vote_deploy.py:9: error: Cannot find implementation or library stub for module named "vote"
```

becomes
```sh
examples/application/vote_deploy.py:9: error: Cannot find implementation or library stub for module named "vote"  [import]
```

so that it's easier to ignore specific errors without then ignoring other mypy errors on the same line. In the above example (you really wouldn't want to do this because it's a true error) you could ignore the error with the following comment on line 9 of `vote_deploy.py`:

```python
... # type: ignore[import]
```