### PR TITLE
abi_roundtrip_test::test_abi_types_comprehensive()

### DIFF
--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte).teal
@@ -1,0 +1,87 @@
+#pragma version 6
+txna ApplicationArgs 0
+store 3
+load 3
+callsub roundtripper_1
+store 2
+byte 0x151F7C75
+load 2
+concat
+log
+int 1
+return
+
+// tuple_complement
+tuplecomplement_0:
+store 8
+load 8
+int 0
+getbit
+store 0
+load 8
+int 1
+getbyte
+store 1
+load 0
+callsub boolcomp_2
+store 0
+load 1
+callsub numericalcomp_3
+store 1
+byte 0x00
+int 0
+load 0
+setbit
+byte 0x00
+int 0
+load 1
+setbyte
+concat
+store 9
+load 9
+retsub
+
+// round_tripper
+roundtripper_1:
+store 4
+load 4
+callsub tuplecomplement_0
+store 6
+load 6
+callsub tuplecomplement_0
+store 7
+load 4
+load 6
+concat
+load 7
+concat
+store 5
+load 5
+retsub
+
+// bool_comp
+boolcomp_2:
+store 10
+load 10
+!
+store 11
+load 11
+int 2
+<
+assert
+load 11
+retsub
+
+// numerical_comp
+numericalcomp_3:
+store 12
+int 255
+load 12
+-
+store 13
+load 13
+int 256
+<
+assert
+load 13
+retsub

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string).teal
@@ -1,0 +1,685 @@
+#pragma version 6
+txna ApplicationArgs 0
+store 5
+load 5
+callsub roundtripper_1
+store 4
+byte 0x151F7C75
+load 4
+concat
+log
+int 1
+return
+
+// tuple_complement
+tuplecomplement_0:
+store 10
+load 10
+int 0
+getbit
+store 0
+load 10
+int 1
+getbyte
+store 1
+load 10
+extract 2 32
+store 2
+load 10
+load 10
+int 34
+extract_uint16
+dig 1
+len
+substring3
+store 3
+load 0
+callsub boolcomp_2
+store 0
+load 1
+callsub numericalcomp_3
+store 1
+load 2
+callsub arraycomplement_5
+store 2
+load 3
+callsub stringreverse_6
+store 3
+byte 0x00
+int 0
+load 0
+setbit
+byte 0x00
+int 0
+load 1
+setbyte
+concat
+load 2
+concat
+load 3
+store 60
+load 60
+store 59
+int 36
+store 58
+load 58
+itob
+extract 6 0
+concat
+load 59
+concat
+store 11
+load 11
+retsub
+
+// round_tripper
+roundtripper_1:
+store 6
+load 6
+callsub tuplecomplement_0
+store 8
+load 8
+callsub tuplecomplement_0
+store 9
+load 6
+store 64
+load 64
+store 63
+int 6
+store 61
+load 61
+load 64
+len
++
+store 62
+load 62
+int 65536
+<
+assert
+load 61
+itob
+extract 6 0
+load 8
+store 64
+load 63
+load 64
+concat
+store 63
+load 62
+store 61
+load 61
+load 64
+len
++
+store 62
+load 62
+int 65536
+<
+assert
+load 61
+itob
+extract 6 0
+concat
+load 9
+store 64
+load 63
+load 64
+concat
+store 63
+load 62
+store 61
+load 61
+itob
+extract 6 0
+concat
+load 63
+concat
+store 7
+load 7
+retsub
+
+// bool_comp
+boolcomp_2:
+store 12
+load 12
+!
+store 13
+load 13
+int 2
+<
+assert
+load 13
+retsub
+
+// numerical_comp
+numericalcomp_3:
+store 14
+int 255
+load 14
+-
+store 15
+load 15
+int 256
+<
+assert
+load 15
+retsub
+
+// numerical_comp
+numericalcomp_4:
+store 50
+int 255
+load 50
+-
+store 51
+load 51
+int 256
+<
+assert
+load 51
+retsub
+
+// array_complement
+arraycomplement_5:
+store 16
+load 16
+int 1
+int 0
+*
+getbyte
+store 18
+load 16
+int 1
+int 1
+*
+getbyte
+store 19
+load 16
+int 1
+int 2
+*
+getbyte
+store 20
+load 16
+int 1
+int 3
+*
+getbyte
+store 21
+load 16
+int 1
+int 4
+*
+getbyte
+store 22
+load 16
+int 1
+int 5
+*
+getbyte
+store 23
+load 16
+int 1
+int 6
+*
+getbyte
+store 24
+load 16
+int 1
+int 7
+*
+getbyte
+store 25
+load 16
+int 1
+int 8
+*
+getbyte
+store 26
+load 16
+int 1
+int 9
+*
+getbyte
+store 27
+load 16
+int 1
+int 10
+*
+getbyte
+store 28
+load 16
+int 1
+int 11
+*
+getbyte
+store 29
+load 16
+int 1
+int 12
+*
+getbyte
+store 30
+load 16
+int 1
+int 13
+*
+getbyte
+store 31
+load 16
+int 1
+int 14
+*
+getbyte
+store 32
+load 16
+int 1
+int 15
+*
+getbyte
+store 33
+load 16
+int 1
+int 16
+*
+getbyte
+store 34
+load 16
+int 1
+int 17
+*
+getbyte
+store 35
+load 16
+int 1
+int 18
+*
+getbyte
+store 36
+load 16
+int 1
+int 19
+*
+getbyte
+store 37
+load 16
+int 1
+int 20
+*
+getbyte
+store 38
+load 16
+int 1
+int 21
+*
+getbyte
+store 39
+load 16
+int 1
+int 22
+*
+getbyte
+store 40
+load 16
+int 1
+int 23
+*
+getbyte
+store 41
+load 16
+int 1
+int 24
+*
+getbyte
+store 42
+load 16
+int 1
+int 25
+*
+getbyte
+store 43
+load 16
+int 1
+int 26
+*
+getbyte
+store 44
+load 16
+int 1
+int 27
+*
+getbyte
+store 45
+load 16
+int 1
+int 28
+*
+getbyte
+store 46
+load 16
+int 1
+int 29
+*
+getbyte
+store 47
+load 16
+int 1
+int 30
+*
+getbyte
+store 48
+load 16
+int 1
+int 31
+*
+getbyte
+store 49
+load 18
+callsub numericalcomp_4
+store 18
+load 19
+callsub numericalcomp_4
+store 19
+load 20
+callsub numericalcomp_4
+store 20
+load 21
+callsub numericalcomp_4
+store 21
+load 22
+callsub numericalcomp_4
+store 22
+load 23
+callsub numericalcomp_4
+store 23
+load 24
+callsub numericalcomp_4
+store 24
+load 25
+callsub numericalcomp_4
+store 25
+load 26
+callsub numericalcomp_4
+store 26
+load 27
+callsub numericalcomp_4
+store 27
+load 28
+callsub numericalcomp_4
+store 28
+load 29
+callsub numericalcomp_4
+store 29
+load 30
+callsub numericalcomp_4
+store 30
+load 31
+callsub numericalcomp_4
+store 31
+load 32
+callsub numericalcomp_4
+store 32
+load 33
+callsub numericalcomp_4
+store 33
+load 34
+callsub numericalcomp_4
+store 34
+load 35
+callsub numericalcomp_4
+store 35
+load 36
+callsub numericalcomp_4
+store 36
+load 37
+callsub numericalcomp_4
+store 37
+load 38
+callsub numericalcomp_4
+store 38
+load 39
+callsub numericalcomp_4
+store 39
+load 40
+callsub numericalcomp_4
+store 40
+load 41
+callsub numericalcomp_4
+store 41
+load 42
+callsub numericalcomp_4
+store 42
+load 43
+callsub numericalcomp_4
+store 43
+load 44
+callsub numericalcomp_4
+store 44
+load 45
+callsub numericalcomp_4
+store 45
+load 46
+callsub numericalcomp_4
+store 46
+load 47
+callsub numericalcomp_4
+store 47
+load 48
+callsub numericalcomp_4
+store 48
+load 49
+callsub numericalcomp_4
+store 49
+byte 0x00
+int 0
+load 18
+setbyte
+byte 0x00
+int 0
+load 19
+setbyte
+concat
+byte 0x00
+int 0
+load 20
+setbyte
+concat
+byte 0x00
+int 0
+load 21
+setbyte
+concat
+byte 0x00
+int 0
+load 22
+setbyte
+concat
+byte 0x00
+int 0
+load 23
+setbyte
+concat
+byte 0x00
+int 0
+load 24
+setbyte
+concat
+byte 0x00
+int 0
+load 25
+setbyte
+concat
+byte 0x00
+int 0
+load 26
+setbyte
+concat
+byte 0x00
+int 0
+load 27
+setbyte
+concat
+byte 0x00
+int 0
+load 28
+setbyte
+concat
+byte 0x00
+int 0
+load 29
+setbyte
+concat
+byte 0x00
+int 0
+load 30
+setbyte
+concat
+byte 0x00
+int 0
+load 31
+setbyte
+concat
+byte 0x00
+int 0
+load 32
+setbyte
+concat
+byte 0x00
+int 0
+load 33
+setbyte
+concat
+byte 0x00
+int 0
+load 34
+setbyte
+concat
+byte 0x00
+int 0
+load 35
+setbyte
+concat
+byte 0x00
+int 0
+load 36
+setbyte
+concat
+byte 0x00
+int 0
+load 37
+setbyte
+concat
+byte 0x00
+int 0
+load 38
+setbyte
+concat
+byte 0x00
+int 0
+load 39
+setbyte
+concat
+byte 0x00
+int 0
+load 40
+setbyte
+concat
+byte 0x00
+int 0
+load 41
+setbyte
+concat
+byte 0x00
+int 0
+load 42
+setbyte
+concat
+byte 0x00
+int 0
+load 43
+setbyte
+concat
+byte 0x00
+int 0
+load 44
+setbyte
+concat
+byte 0x00
+int 0
+load 45
+setbyte
+concat
+byte 0x00
+int 0
+load 46
+setbyte
+concat
+byte 0x00
+int 0
+load 47
+setbyte
+concat
+byte 0x00
+int 0
+load 48
+setbyte
+concat
+byte 0x00
+int 0
+load 49
+setbyte
+concat
+store 17
+load 17
+retsub
+
+// string_reverse
+stringreverse_6:
+store 52
+load 52
+int 1
+int 0
+*
+int 2
++
+getbyte
+store 56
+load 52
+int 1
+int 1
+*
+int 2
++
+getbyte
+store 55
+load 52
+int 1
+int 2
+*
+int 2
++
+getbyte
+store 54
+int 3
+store 57
+load 57
+itob
+extract 6 0
+byte 0x00
+int 0
+load 54
+setbyte
+byte 0x00
+int 0
+load 55
+setbyte
+concat
+byte 0x00
+int 0
+load 56
+setbyte
+concat
+concat
+store 53
+load 53
+retsub

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,uint64).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,uint64).teal
@@ -1,0 +1,705 @@
+#pragma version 6
+txna ApplicationArgs 0
+store 6
+load 6
+callsub roundtripper_1
+store 5
+byte 0x151F7C75
+load 5
+concat
+log
+int 1
+return
+
+// tuple_complement
+tuplecomplement_0:
+store 11
+load 11
+int 0
+getbit
+store 0
+load 11
+int 1
+getbyte
+store 1
+load 11
+extract 2 32
+store 2
+load 11
+load 11
+int 34
+extract_uint16
+dig 1
+len
+substring3
+store 3
+load 11
+int 36
+extract_uint64
+store 4
+load 0
+callsub boolcomp_2
+store 0
+load 1
+callsub numericalcomp_3
+store 1
+load 2
+callsub arraycomplement_5
+store 2
+load 3
+callsub stringreverse_6
+store 3
+load 4
+callsub numericalcomp_7
+store 4
+byte 0x00
+int 0
+load 0
+setbit
+byte 0x00
+int 0
+load 1
+setbyte
+concat
+load 2
+concat
+load 3
+store 63
+load 63
+store 62
+int 44
+store 61
+load 61
+itob
+extract 6 0
+concat
+load 4
+itob
+concat
+load 62
+concat
+store 12
+load 12
+retsub
+
+// round_tripper
+roundtripper_1:
+store 7
+load 7
+callsub tuplecomplement_0
+store 9
+load 9
+callsub tuplecomplement_0
+store 10
+load 7
+store 67
+load 67
+store 66
+int 6
+store 64
+load 64
+load 67
+len
++
+store 65
+load 65
+int 65536
+<
+assert
+load 64
+itob
+extract 6 0
+load 9
+store 67
+load 66
+load 67
+concat
+store 66
+load 65
+store 64
+load 64
+load 67
+len
++
+store 65
+load 65
+int 65536
+<
+assert
+load 64
+itob
+extract 6 0
+concat
+load 10
+store 67
+load 66
+load 67
+concat
+store 66
+load 65
+store 64
+load 64
+itob
+extract 6 0
+concat
+load 66
+concat
+store 8
+load 8
+retsub
+
+// bool_comp
+boolcomp_2:
+store 13
+load 13
+!
+store 14
+load 14
+int 2
+<
+assert
+load 14
+retsub
+
+// numerical_comp
+numericalcomp_3:
+store 15
+int 255
+load 15
+-
+store 16
+load 16
+int 256
+<
+assert
+load 16
+retsub
+
+// numerical_comp
+numericalcomp_4:
+store 51
+int 255
+load 51
+-
+store 52
+load 52
+int 256
+<
+assert
+load 52
+retsub
+
+// array_complement
+arraycomplement_5:
+store 17
+load 17
+int 1
+int 0
+*
+getbyte
+store 19
+load 17
+int 1
+int 1
+*
+getbyte
+store 20
+load 17
+int 1
+int 2
+*
+getbyte
+store 21
+load 17
+int 1
+int 3
+*
+getbyte
+store 22
+load 17
+int 1
+int 4
+*
+getbyte
+store 23
+load 17
+int 1
+int 5
+*
+getbyte
+store 24
+load 17
+int 1
+int 6
+*
+getbyte
+store 25
+load 17
+int 1
+int 7
+*
+getbyte
+store 26
+load 17
+int 1
+int 8
+*
+getbyte
+store 27
+load 17
+int 1
+int 9
+*
+getbyte
+store 28
+load 17
+int 1
+int 10
+*
+getbyte
+store 29
+load 17
+int 1
+int 11
+*
+getbyte
+store 30
+load 17
+int 1
+int 12
+*
+getbyte
+store 31
+load 17
+int 1
+int 13
+*
+getbyte
+store 32
+load 17
+int 1
+int 14
+*
+getbyte
+store 33
+load 17
+int 1
+int 15
+*
+getbyte
+store 34
+load 17
+int 1
+int 16
+*
+getbyte
+store 35
+load 17
+int 1
+int 17
+*
+getbyte
+store 36
+load 17
+int 1
+int 18
+*
+getbyte
+store 37
+load 17
+int 1
+int 19
+*
+getbyte
+store 38
+load 17
+int 1
+int 20
+*
+getbyte
+store 39
+load 17
+int 1
+int 21
+*
+getbyte
+store 40
+load 17
+int 1
+int 22
+*
+getbyte
+store 41
+load 17
+int 1
+int 23
+*
+getbyte
+store 42
+load 17
+int 1
+int 24
+*
+getbyte
+store 43
+load 17
+int 1
+int 25
+*
+getbyte
+store 44
+load 17
+int 1
+int 26
+*
+getbyte
+store 45
+load 17
+int 1
+int 27
+*
+getbyte
+store 46
+load 17
+int 1
+int 28
+*
+getbyte
+store 47
+load 17
+int 1
+int 29
+*
+getbyte
+store 48
+load 17
+int 1
+int 30
+*
+getbyte
+store 49
+load 17
+int 1
+int 31
+*
+getbyte
+store 50
+load 19
+callsub numericalcomp_4
+store 19
+load 20
+callsub numericalcomp_4
+store 20
+load 21
+callsub numericalcomp_4
+store 21
+load 22
+callsub numericalcomp_4
+store 22
+load 23
+callsub numericalcomp_4
+store 23
+load 24
+callsub numericalcomp_4
+store 24
+load 25
+callsub numericalcomp_4
+store 25
+load 26
+callsub numericalcomp_4
+store 26
+load 27
+callsub numericalcomp_4
+store 27
+load 28
+callsub numericalcomp_4
+store 28
+load 29
+callsub numericalcomp_4
+store 29
+load 30
+callsub numericalcomp_4
+store 30
+load 31
+callsub numericalcomp_4
+store 31
+load 32
+callsub numericalcomp_4
+store 32
+load 33
+callsub numericalcomp_4
+store 33
+load 34
+callsub numericalcomp_4
+store 34
+load 35
+callsub numericalcomp_4
+store 35
+load 36
+callsub numericalcomp_4
+store 36
+load 37
+callsub numericalcomp_4
+store 37
+load 38
+callsub numericalcomp_4
+store 38
+load 39
+callsub numericalcomp_4
+store 39
+load 40
+callsub numericalcomp_4
+store 40
+load 41
+callsub numericalcomp_4
+store 41
+load 42
+callsub numericalcomp_4
+store 42
+load 43
+callsub numericalcomp_4
+store 43
+load 44
+callsub numericalcomp_4
+store 44
+load 45
+callsub numericalcomp_4
+store 45
+load 46
+callsub numericalcomp_4
+store 46
+load 47
+callsub numericalcomp_4
+store 47
+load 48
+callsub numericalcomp_4
+store 48
+load 49
+callsub numericalcomp_4
+store 49
+load 50
+callsub numericalcomp_4
+store 50
+byte 0x00
+int 0
+load 19
+setbyte
+byte 0x00
+int 0
+load 20
+setbyte
+concat
+byte 0x00
+int 0
+load 21
+setbyte
+concat
+byte 0x00
+int 0
+load 22
+setbyte
+concat
+byte 0x00
+int 0
+load 23
+setbyte
+concat
+byte 0x00
+int 0
+load 24
+setbyte
+concat
+byte 0x00
+int 0
+load 25
+setbyte
+concat
+byte 0x00
+int 0
+load 26
+setbyte
+concat
+byte 0x00
+int 0
+load 27
+setbyte
+concat
+byte 0x00
+int 0
+load 28
+setbyte
+concat
+byte 0x00
+int 0
+load 29
+setbyte
+concat
+byte 0x00
+int 0
+load 30
+setbyte
+concat
+byte 0x00
+int 0
+load 31
+setbyte
+concat
+byte 0x00
+int 0
+load 32
+setbyte
+concat
+byte 0x00
+int 0
+load 33
+setbyte
+concat
+byte 0x00
+int 0
+load 34
+setbyte
+concat
+byte 0x00
+int 0
+load 35
+setbyte
+concat
+byte 0x00
+int 0
+load 36
+setbyte
+concat
+byte 0x00
+int 0
+load 37
+setbyte
+concat
+byte 0x00
+int 0
+load 38
+setbyte
+concat
+byte 0x00
+int 0
+load 39
+setbyte
+concat
+byte 0x00
+int 0
+load 40
+setbyte
+concat
+byte 0x00
+int 0
+load 41
+setbyte
+concat
+byte 0x00
+int 0
+load 42
+setbyte
+concat
+byte 0x00
+int 0
+load 43
+setbyte
+concat
+byte 0x00
+int 0
+load 44
+setbyte
+concat
+byte 0x00
+int 0
+load 45
+setbyte
+concat
+byte 0x00
+int 0
+load 46
+setbyte
+concat
+byte 0x00
+int 0
+load 47
+setbyte
+concat
+byte 0x00
+int 0
+load 48
+setbyte
+concat
+byte 0x00
+int 0
+load 49
+setbyte
+concat
+byte 0x00
+int 0
+load 50
+setbyte
+concat
+store 18
+load 18
+retsub
+
+// string_reverse
+stringreverse_6:
+store 53
+load 53
+int 1
+int 0
+*
+int 2
++
+getbyte
+store 57
+load 53
+int 1
+int 1
+*
+int 2
++
+getbyte
+store 56
+load 53
+int 1
+int 2
+*
+int 2
++
+getbyte
+store 55
+int 3
+store 58
+load 58
+itob
+extract 6 0
+byte 0x00
+int 0
+load 55
+setbyte
+byte 0x00
+int 0
+load 56
+setbyte
+concat
+byte 0x00
+int 0
+load 57
+setbyte
+concat
+concat
+store 54
+load 54
+retsub
+
+// numerical_comp
+numericalcomp_7:
+store 59
+int 18446744073709551615
+load 59
+-
+store 60
+load 60
+retsub


### PR DESCRIPTION
Adding unit test to ensure that all concrete subclasses of `abi.BaseType` have roundtrip tests.