### PR TITLE
Adding some improved trace messaging

### DIFF
--- a/pyteal/ast/return_.py
+++ b/pyteal/ast/return_.py
@@ -37,6 +37,7 @@ class Return(Expr):
                 "TEAL version too low to use subroutines",
             )
             returnType = options.currentSubroutine.returnType
+
             if returnType == TealType.none:
                 if self.value is not None:
                     raise TealCompileError(

--- a/pyteal/ast/return_.py
+++ b/pyteal/ast/return_.py
@@ -42,13 +42,13 @@ class Return(Expr):
                 if self.value is not None:
                     raise TealCompileError(
                         "Cannot return a value from a subroutine with return type TealType.none",
-                        self,
+                        options,
                     )
             else:
                 if self.value is None:
                     raise TealCompileError(
                         "A subroutine declares it returns a value, but no value is being returned",
-                        self,
+                        options,
                     )
                 actualType = self.value.type_of()
                 if not types_match(actualType, returnType):
@@ -56,13 +56,13 @@ class Return(Expr):
                         "Incompatible return type from subroutine, expected {} but got {}".format(
                             returnType, actualType
                         ),
-                        self,
+                        options,
                     )
             op = Op.retsub
         else:
             if self.value is None:
                 raise TealCompileError(
-                    "Return from main program must have an argument", self
+                    "Return from main program must have an argument", options
                 )
             actualType = self.value.type_of()
             if not types_match(actualType, TealType.uint64):
@@ -70,7 +70,7 @@ class Return(Expr):
                     "Incompatible return type from main program, expected {} but got {}".format(
                         TealType.uint64, actualType
                     ),
-                    self,
+                    options,
                 )
             op = Op.return_
 

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -1816,3 +1816,27 @@ return
             program, pt.Mode.Application, version=5, assembleConstants=False
         )
         assert actual == expected.strip()
+
+
+def test_compile_error_trace_with_subr():
+    @pt.Subroutine(pt.TealType.none)
+    def tst():
+        return pt.Int(1)
+
+    program = pt.Seq(tst(), pt.Int(1))
+
+    with pytest.raises(pt.TealCompileError, match="compiler_test.py"):
+        pt.compileTeal(program, pt.Mode.Application, version=5, assembleConstants=False)
+
+
+def test_compile_error_trace_no_subr():
+    @pt.Subroutine(pt.TealType.uint64)
+    def tst():
+        return pt.Bytes("asdf")
+
+    program = pt.Seq(
+        tst(),
+    )
+
+    with pytest.raises(pt.TealCompileError, match="compiler_test.py"):
+        pt.compileTeal(program, pt.Mode.Application, version=5, assembleConstants=False)

--- a/pyteal/errors.py
+++ b/pyteal/errors.py
@@ -64,7 +64,7 @@ class TealCompileError(Exception):
 TealCompileError.__module__ = "pyteal"
 
 
-def getSourceTrace(impl):
+def get_source_trace(impl):
     source_file = inspect.getabsfile(impl)
     _, source_line = inspect.getsourcelines(impl)
     return f": File {source_file}, line {source_line}"


### PR DESCRIPTION
I think if we change TealCompileError to accept the compile options we can inspect the current subroutine implementation for its source information.

This would require changing all the current TealCompileErrors in methods other than `__teal__` to be converted to some other error type