### PR TITLE
Reference Type  `deref`

### DIFF
--- a/pyteal/ast/abi/reference_type.py
+++ b/pyteal/ast/abi/reference_type.py
@@ -1,4 +1,6 @@
 from pyteal.ast.abi.uint import Uint, UintTypeSpec
+from pyteal.ast.expr import Expr
+from pyteal.ast.txn import Txn
 
 
 class AccountTypeSpec(UintTypeSpec):
@@ -24,6 +26,9 @@ AccountTypeSpec.__module__ = "pyteal"
 class Account(Uint):
     def __init__(self) -> None:
         super().__init__(AccountTypeSpec())
+
+    def deref(self) -> Expr:
+        return Txn.accounts[self.stored_value.load()]
 
 
 Account.__module__ = "pyteal"
@@ -53,6 +58,9 @@ class Asset(Uint):
     def __init__(self) -> None:
         super().__init__(AssetTypeSpec())
 
+    def deref(self) -> Expr:
+        return Txn.assets[self.stored_value.load()]
+
 
 Asset.__module__ = "pyteal"
 
@@ -80,6 +88,9 @@ ApplicationTypeSpec.__module__ = "pyteal"
 class Application(Uint):
     def __init__(self) -> None:
         super().__init__(ApplicationTypeSpec())
+
+    def deref(self) -> Expr:
+        return Txn.applications[self.stored_value.load()]
 
 
 Application.__module__ = "pyteal"

--- a/pyteal/ast/abi/reference_type_test.py
+++ b/pyteal/ast/abi/reference_type_test.py
@@ -90,6 +90,28 @@ def test_Account_set():
         assert actual == expected
 
 
+def test_Account_deref():
+    val_to_set = 2
+    value = abi.Account()
+    value.set(val_to_set)
+    expr = value.deref()
+    assert expr.type_of() == pt.TealType.bytes
+    assert expr.has_return() is False
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(None, pt.Op.load, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.txnas, "Accounts"),
+        ]
+    )
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+
 def test_Asset_str():
     assert str(abi.AssetTypeSpec()) == "asset"
 
@@ -176,6 +198,28 @@ def test_Asset_set():
         assert actual == expected
 
 
+def test_Asset_deref():
+    val_to_set = 2
+    value = abi.Asset()
+    value.set(val_to_set)
+    expr = value.deref()
+    assert expr.type_of() == pt.TealType.uint64
+    assert expr.has_return() is False
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(None, pt.Op.load, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.txnas, "Assets"),
+        ]
+    )
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+
 def test_Application_str():
     assert str(abi.ApplicationTypeSpec()) == "application"
 
@@ -252,6 +296,28 @@ def test_Application_set():
         [
             pt.TealOp(expr, pt.Op.int, val_to_set),
             pt.TealOp(None, pt.Op.store, value.stored_value.slot),
+        ]
+    )
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+
+def test_Application_deref():
+    val_to_set = 2
+    value = abi.Application()
+    value.set(val_to_set)
+    expr = value.deref()
+    assert expr.type_of() == pt.TealType.uint64
+    assert expr.has_return() is False
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(None, pt.Op.load, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.txnas, "Applications"),
         ]
     )
     actual, _ = expr.__teal__(options)


### PR DESCRIPTION
Adding a reference type method `deref` to allow easily getting the underlying value referred to by the reference type.