### PR TITLE
Blackbox testing unifying abi-return-subroutine and subroutine input handling

### DIFF
--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -130,7 +130,7 @@ class OnCompleteAction:
     def __post_init__(self):
         if bool(self.call_config) ^ bool(self.action):
             raise TealInputError(
-                f"action {self.action} and call_config {str(self.call_config)} contradicts"
+                f"action {self.action} and call_config {self.call_config!r} contradicts"
             )
 
     @staticmethod
@@ -216,7 +216,7 @@ class BareCallActions:
                     )
                 case _:
                     raise TealInternalError(
-                        f"Unexpected CallConfig: {str(oca.call_config)}"
+                        f"Unexpected CallConfig: {oca.call_config!r}"
                     )
             conditions_n_branches.append(
                 CondNode(
@@ -251,7 +251,7 @@ class BareCallActions:
                 )
             case _:
                 raise TealInternalError(
-                    f"Unexpected CallConfig: {str(self.clear_state.call_config)}"
+                    f"Unexpected CallConfig: {self.clear_state.call_config!r}"
                 )
 
 

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -121,6 +121,11 @@ def Blackbox(input_types: list[TealType | None]):
     def string_mult(x: abi.String, y):
         ...
 
+    @Blackbox([None])
+    @Subroutine(TealType.uint64)
+    def cubed(n: abi.Uint64):
+        ...
+
     """
 
     def decorator_blackbox(func: SubroutineFnWrapper | ABIReturnSubroutine):
@@ -237,11 +242,11 @@ class PyTealDryRunExecutor:
                 read arg and pass to subroutine as is
             * Expr arg of TealType.uint64:
                 convert arg to int using Btoi() when received
-            * pass-by-ref ScratchVar arguments (Subroutine case only):
+            * pass-by-ref ScratchVar arguments:
                 in addition to the above -
                     o store the arg (or converted arg) in a ScratchVar
                     o invoke the subroutine using this ScratchVar instead of the arg (or converted arg)
-            * ABI arguments (ABIReturnSubroutine case only):
+            * ABI arguments:
                 in addition to the above -
                     o store the decoded arg into the ScratchVar of an ABI Type instance
                     o invoke the subroutine using this ABI Type instead of the arg

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -292,14 +292,16 @@ class PyTealDryRunExecutor:
         arg_expr = Txn.application_args[i] if self.mode == Mode.Application else Arg(i)
         if p == TealType.uint64:
             arg_expr = Btoi(arg_expr)
-        prep = None
-        arg_var = arg_expr
+
         if name in subdef.by_ref_args:
             arg_var = ScratchVar(p)
             prep = arg_var.store(arg_expr)
         elif name in subdef.abi_args:
             arg_var = p.new_instance()
             prep = arg_var.decode(arg_expr)
+        else:
+            arg_var = arg_expr
+            prep = None
         return prep, arg_var
 
     def _prepare_n_calls(self):

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -829,6 +829,34 @@ def blackbox_pyteal_example4():
     report("lsig")
 
 
+def blackbox_pyteal_example5():
+    from pyteal import (
+        abi,
+        Sqrt,
+        Seq,
+        Subroutine,
+        TealType,
+        ScratchVar,
+        Assert,
+        Int,
+        For,
+    )
+
+    @Blackbox([TealType.uint64])
+    @Subroutine(TealType.uint64)
+    def primality_from_sieve(n: abi.Uint64):
+        i = ScratchVar(TealType.uint64)
+        return Seq(
+            Assert(n > Int(1)),
+            For(
+                i.store(Int(2)), i.load() <= Sqrt(n.get()), i.store(i.load() + Int(1))
+            ).Do(Seq()),
+        )
+        pass
+
+    pass
+
+
 def blackbox_pyteal_while_continue_test():
     from tests.blackbox import Blackbox
     from pyteal import (

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -830,31 +830,38 @@ def blackbox_pyteal_example4():
 
 
 def blackbox_pyteal_example5():
-    from pyteal import (
-        abi,
-        Sqrt,
-        Seq,
-        Subroutine,
-        TealType,
-        ScratchVar,
-        Assert,
-        Int,
-        For,
-    )
+    from graviton.blackbox import DryRunEncoder
 
-    @Blackbox([TealType.uint64])
+    from pyteal import abi, Subroutine, TealType, Int, Mode
+    from tests.blackbox import Blackbox
+
+    @Blackbox([None])
     @Subroutine(TealType.uint64)
-    def primality_from_sieve(n: abi.Uint64):
-        i = ScratchVar(TealType.uint64)
-        return Seq(
-            Assert(n > Int(1)),
-            For(
-                i.store(Int(2)), i.load() <= Sqrt(n.get()), i.store(i.load() + Int(1))
-            ).Do(Seq()),
-        )
-        pass
+    def cubed(n: abi.Uint64):
+        return n.get() ** Int(3)
 
-    pass
+    app_pytealer = PyTealDryRunExecutor(cubed, Mode.Application)
+    lsig_pytealer = PyTealDryRunExecutor(cubed, Mode.Signature)
+
+    inputs = [[i] for i in range(1, 11)]
+
+    app_inspect = app_pytealer.dryrun_on_sequence(inputs)
+    lsig_inspect = lsig_pytealer.dryrun_on_sequence(inputs)
+
+    for index, inspect in enumerate(app_inspect):
+        input_var = inputs[index][0]
+        assert inspect.stack_top() == input_var**3, inspect.report(
+            args=inputs[index], msg="stack_top() gave unexpected results from app"
+        )
+        assert inspect.last_log() == DryRunEncoder.hex(input_var**3), inspect.report(
+            args=inputs[index], msg="last_log() gave unexpected results from app"
+        )
+
+    for index, inspect in enumerate(lsig_inspect):
+        input_var = inputs[index][0]
+        assert inspect.stack_top() == input_var**3, inspect.report(
+            args=inputs[index], msg="stack_top() gave unexpected results from app"
+        )
 
 
 def blackbox_pyteal_while_continue_test():
@@ -908,6 +915,7 @@ def blackbox_pyteal_while_continue_test():
         blackbox_pyteal_example2,
         blackbox_pyteal_example3,
         blackbox_pyteal_example4,
+        blackbox_pyteal_example5,
         blackbox_pyteal_while_continue_test,
     ],
 )


### PR DESCRIPTION
## Description

For both `SubroutineFnWrapper` and `ABIReturnSubroutine`, all of the following input types `Expr/ScratchVar/abi.Type` are supported.

This PR improved a little on previous `Blackbox` decorator and semantic testing, on the aspect of:
- unifying input handling for `SubroutineFnWrapper` and `ABIReturnSubroutine` cases, for they can be captured by same set of logic.