### PR TITLE
Change Router contract obj from `Contract` to `Interface`

### DIFF
--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -573,7 +573,7 @@ class Router:
             return wrap
         return wrap(func)
 
-    def contract_construct(self) -> sdk_abi.Contract:
+    def contract_construct(self) -> sdk_abi.Interface:
         """A helper function in constructing contract JSON object.
 
         It takes out the method signatures from approval program `ProgramNode`'s,
@@ -588,9 +588,9 @@ class Router:
             for sig in self.method_sig_to_selector
             if isinstance(sig, str)
         ]
-        return sdk_abi.Contract(self.name, method_collections)
+        return sdk_abi.Interface(self.name, method_collections)
 
-    def build_program(self) -> tuple[Expr, Expr, sdk_abi.Contract]:
+    def build_program(self) -> tuple[Expr, Expr, sdk_abi.Interface]:
         """
         Constructs ASTs for approval and clear-state programs from the registered methods in the router,
         also generates a JSON object of contract to allow client read and call the methods easily.
@@ -612,7 +612,7 @@ class Router:
         version: int = DEFAULT_TEAL_VERSION,
         assemble_constants: bool = False,
         optimize: OptimizeOptions = None,
-    ) -> tuple[str, str, sdk_abi.Contract]:
+    ) -> tuple[str, str, sdk_abi.Interface]:
         """
         Combining `build_program` and `compileTeal`, compiles built Approval and ClearState programs
         and returns Contract JSON object for off-chain calling.

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -530,6 +530,6 @@ def test_contract_json_obj():
     for subroutine in abi_subroutines:
         router.add_method_handler(subroutine)
         method_list.append(sdk_abi.Method.from_signature(subroutine.method_signature()))
-    sdk_contract = sdk_abi.Contract(contract_name, method_list)
+    sdk_contract = sdk_abi.Interface(contract_name, method_list)
     contract = router.contract_construct()
     assert contract == sdk_contract


### PR DESCRIPTION
Since we are not caring too much about `network` field in `Contract`, returning `Interface` seems to be more appropriate.