### PR TITLE
Rename decode parameters to abide by PEP8 conventions

### DIFF
--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -66,14 +66,14 @@ def test_Address_decode():
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
-                            startIndex=startIndex,
-                            endIndex=endIndex,
+                            start_index=startIndex,
+                            end_index=endIndex,
                             length=length,
                         )
                     continue
 
                 expr = value.decode(
-                    encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                    encoded, start_index=startIndex, end_index=endIndex, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert expr.has_return() is False

--- a/pyteal/ast/abi/array_base.py
+++ b/pyteal/ast/abi/array_base.py
@@ -82,17 +82,17 @@ class Array(BaseType, Generic[T]):
         self,
         encoded: Expr,
         *,
-        startIndex: Expr = None,
-        endIndex: Expr = None,
+        start_index: Expr = None,
+        end_index: Expr = None,
         length: Expr = None
     ) -> Expr:
         """Decode a substring of the passed in encoded byte string and set it as this type's value.
 
         Args:
             encoded: An expression containing the bytes to decode. Must evaluate to TealType.bytes.
-            startIndex (optional): An expression containing the index to start decoding. Must
+            start_index (optional): An expression containing the index to start decoding. Must
                 evaluate to TealType.uint64. Defaults to None.
-            endIndex (optional): An expression containing the index to stop decoding. Must evaluate
+            end_index (optional): An expression containing the index to stop decoding. Must evaluate
                 to TealType.uint64. Defaults to None.
             length (optional): An expression containing the length of the substring to decode. Must
                 evaluate to TealType.uint64. Defaults to None.
@@ -102,7 +102,7 @@ class Array(BaseType, Generic[T]):
             the scratch variable.
         """
         extracted = substringForDecoding(
-            encoded, startIndex=startIndex, endIndex=endIndex, length=length
+            encoded, startIndex=start_index, endIndex=end_index, length=length
         )
         return self.stored_value.store(extracted)
 
@@ -268,14 +268,16 @@ class ArrayElement(ComputedValue[T]):
                 .Else(nextValueStart)
             )
 
-            return output.decode(encodedArray, startIndex=valueStart, endIndex=valueEnd)
+            return output.decode(
+                encodedArray, start_index=valueStart, end_index=valueEnd
+            )
 
         # Handling case for array elements are static:
         # since array._stride() is element's static byte length
         # we partition the substring for array element.
         valueStart = byteIndex
         valueLength = Int(arrayType._stride())
-        return output.decode(encodedArray, startIndex=valueStart, length=valueLength)
+        return output.decode(encodedArray, start_index=valueStart, length=valueLength)
 
 
 ArrayElement.__module__ = "pyteal"

--- a/pyteal/ast/abi/array_base_test.py
+++ b/pyteal/ast/abi/array_base_test.py
@@ -84,13 +84,13 @@ def test_ArrayElement_store_into():
             expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index)
         elif not elementType.is_dynamic():
             expectedExpr = output.decode(
-                encoded, startIndex=stride * index, length=stride
+                encoded, start_index=stride * index, length=stride
             )
         else:
             expectedExpr = output.decode(
                 encoded,
-                startIndex=pt.ExtractUint16(encoded, stride * index),
-                endIndex=pt.If(index + pt.Int(1) == expectedLength)
+                start_index=pt.ExtractUint16(encoded, stride * index),
+                end_index=pt.If(index + pt.Int(1) == expectedLength)
                 .Then(pt.Len(encoded))
                 .Else(pt.ExtractUint16(encoded, stride * index + pt.Int(2))),
             )
@@ -125,14 +125,14 @@ def test_ArrayElement_store_into():
             expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index + pt.Int(16))
         elif not elementType.is_dynamic():
             expectedExpr = output.decode(
-                encoded, startIndex=stride * index + pt.Int(2), length=stride
+                encoded, start_index=stride * index + pt.Int(2), length=stride
             )
         else:
             expectedExpr = output.decode(
                 encoded,
-                startIndex=pt.ExtractUint16(encoded, stride * index + pt.Int(2))
+                start_index=pt.ExtractUint16(encoded, stride * index + pt.Int(2))
                 + pt.Int(2),
-                endIndex=pt.If(index + pt.Int(1) == expectedLength)
+                end_index=pt.If(index + pt.Int(1) == expectedLength)
                 .Then(pt.Len(encoded))
                 .Else(
                     pt.ExtractUint16(encoded, stride * index + pt.Int(2) + pt.Int(2))

--- a/pyteal/ast/abi/array_dynamic_test.py
+++ b/pyteal/ast/abi/array_dynamic_test.py
@@ -71,14 +71,14 @@ def test_DynamicArray_decode():
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
-                            startIndex=startIndex,
-                            endIndex=endIndex,
+                            start_index=startIndex,
+                            end_index=endIndex,
                             length=length,
                         )
                     continue
 
                 expr = value.decode(
-                    encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                    encoded, start_index=startIndex, end_index=endIndex, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -112,14 +112,14 @@ def test_StaticArray_decode():
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
-                            startIndex=startIndex,
-                            endIndex=endIndex,
+                            start_index=startIndex,
+                            end_index=endIndex,
                             length=length,
                         )
                     continue
 
                 expr = value.decode(
-                    encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                    encoded, start_index=startIndex, end_index=endIndex, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()

--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -78,13 +78,13 @@ class Bool(BaseType):
         self,
         encoded: Expr,
         *,
-        startIndex: Expr = None,
-        endIndex: Expr = None,
+        start_index: Expr = None,
+        end_index: Expr = None,
         length: Expr = None
     ) -> Expr:
-        if startIndex is None:
-            startIndex = Int(0)
-        return self.decodeBit(encoded, startIndex * Int(NUM_BITS_IN_BYTE))
+        if start_index is None:
+            start_index = Int(0)
+        return self.decodeBit(encoded, start_index * Int(NUM_BITS_IN_BYTE))
 
     def decodeBit(self, encoded, bitIndex: Expr) -> Expr:
         return self.stored_value.store(GetBit(encoded, bitIndex))

--- a/pyteal/ast/abi/bool_test.py
+++ b/pyteal/ast/abi/bool_test.py
@@ -164,7 +164,7 @@ def test_Bool_decode():
         for endIndex in (None, pt.Int(2)):
             for length in (None, pt.Int(3)):
                 expr = value.decode(
-                    encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                    encoded, start_index=startIndex, end_index=endIndex, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()

--- a/pyteal/ast/abi/reference_type.py
+++ b/pyteal/ast/abi/reference_type.py
@@ -61,16 +61,16 @@ class ReferenceType(BaseType):
         self,
         encoded: Expr,
         *,
-        startIndex: Expr = None,
-        endIndex: Expr = None,
+        start_index: Expr = None,
+        end_index: Expr = None,
         length: Expr = None,
     ) -> Expr:
         return uint_decode(
             self.type_spec().bit_size(),
             self.stored_value,
             encoded,
-            startIndex,
-            endIndex,
+            start_index,
+            end_index,
             length,
         )
 

--- a/pyteal/ast/abi/reference_type_test.py
+++ b/pyteal/ast/abi/reference_type_test.py
@@ -48,7 +48,10 @@ def test_ReferenceType_decode():
             for endIndex in (None, pt.Int(2)):
                 for length in (None, pt.Int(3)):
                     expr = value.decode(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded,
+                        start_index=startIndex,
+                        end_index=endIndex,
+                        length=length,
                     )
                     assert expr.type_of() == pt.TealType.none
                     assert expr.has_return() is False

--- a/pyteal/ast/abi/string_test.py
+++ b/pyteal/ast/abi/string_test.py
@@ -58,14 +58,14 @@ def test_DynamicArray_decode():
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
-                            startIndex=startIndex,
-                            endIndex=endIndex,
+                            start_index=startIndex,
+                            end_index=endIndex,
                             length=length,
                         )
                     continue
 
                 expr = value.decode(
-                    encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                    encoded, start_index=startIndex, end_index=endIndex, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert expr.has_return() is False

--- a/pyteal/ast/abi/transaction.py
+++ b/pyteal/ast/abi/transaction.py
@@ -86,8 +86,8 @@ class Transaction(BaseType):
         self,
         encoded: Expr,
         *,
-        startIndex: Expr = None,
-        endIndex: Expr = None,
+        start_index: Expr = None,
+        end_index: Expr = None,
         length: Expr = None,
     ) -> Expr:
         raise TealInputError("A Transaction cannot be decoded")

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -178,12 +178,12 @@ def indexTuple(
         if not hasNextDynamicValue:
             # This is the final dynamic value, so decode the substring from startIndex to the end of
             # encoded
-            return output.decode(encoded, startIndex=startIndex)
+            return output.decode(encoded, start_index=startIndex)
 
         # There is a dynamic value after this one, and endIndex is where its tail starts, so decode
         # the substring from startIndex to endIndex
         endIndex = ExtractUint16(encoded, Int(nextDynamicValueOffset))
-        return output.decode(encoded, startIndex=startIndex, endIndex=endIndex)
+        return output.decode(encoded, start_index=startIndex, end_index=endIndex)
 
     startIndex = Int(offset)
     length = Int(valueType.byte_length_static())
@@ -194,14 +194,14 @@ def indexTuple(
             return output.decode(encoded)
         # This is the last value in the tuple, so decode the substring from startIndex to the end of
         # encoded
-        return output.decode(encoded, startIndex=startIndex)
+        return output.decode(encoded, start_index=startIndex)
 
     if offset == 0:
         # This is the first value in the tuple, so decode the substring from 0 with length length
         return output.decode(encoded, length=length)
 
     # This is not the first or last value, so decode the substring from startIndex with length length
-    return output.decode(encoded, startIndex=startIndex, length=length)
+    return output.decode(encoded, start_index=startIndex, length=length)
 
 
 class TupleTypeSpec(TypeSpec):
@@ -284,12 +284,12 @@ class Tuple(BaseType):
         self,
         encoded: Expr,
         *,
-        startIndex: Expr = None,
-        endIndex: Expr = None,
+        start_index: Expr = None,
+        end_index: Expr = None,
         length: Expr = None,
     ) -> Expr:
         extracted = substringForDecoding(
-            encoded, startIndex=startIndex, endIndex=endIndex, length=length
+            encoded, startIndex=start_index, endIndex=end_index, length=length
         )
         return self.stored_value.store(extracted)
 

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -249,20 +249,20 @@ def test_indexTuple():
         IndexTest(
             types=[uint64_t, uint64_t],
             typeIndex=1,
-            expected=lambda output: output.decode(encoded, startIndex=pt.Int(8)),
+            expected=lambda output: output.decode(encoded, start_index=pt.Int(8)),
         ),
         IndexTest(
             types=[uint64_t, byte_t, uint64_t],
             typeIndex=1,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.Int(8), length=pt.Int(1)
+                encoded, start_index=pt.Int(8), length=pt.Int(1)
             ),
         ),
         IndexTest(
             types=[uint64_t, byte_t, uint64_t],
             typeIndex=2,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.Int(9), length=pt.Int(8)
+                encoded, start_index=pt.Int(9), length=pt.Int(8)
             ),
         ),
         IndexTest(
@@ -303,7 +303,7 @@ def test_indexTuple():
         IndexTest(
             types=[bool_t, uint64_t],
             typeIndex=1,
-            expected=lambda output: output.decode(encoded, startIndex=pt.Int(1)),
+            expected=lambda output: output.decode(encoded, start_index=pt.Int(1)),
         ),
         IndexTest(
             types=[bool_t, bool_t, uint64_t],
@@ -318,7 +318,7 @@ def test_indexTuple():
         IndexTest(
             types=[bool_t, bool_t, uint64_t],
             typeIndex=2,
-            expected=lambda output: output.decode(encoded, startIndex=pt.Int(1)),
+            expected=lambda output: output.decode(encoded, start_index=pt.Int(1)),
         ),
         IndexTest(
             types=[tuple_t], typeIndex=0, expected=lambda output: output.decode(encoded)
@@ -326,14 +326,14 @@ def test_indexTuple():
         IndexTest(
             types=[byte_t, tuple_t],
             typeIndex=1,
-            expected=lambda output: output.decode(encoded, startIndex=pt.Int(1)),
+            expected=lambda output: output.decode(encoded, start_index=pt.Int(1)),
         ),
         IndexTest(
             types=[tuple_t, byte_t],
             typeIndex=0,
             expected=lambda output: output.decode(
                 encoded,
-                startIndex=pt.Int(0),
+                start_index=pt.Int(0),
                 length=pt.Int(tuple_t.byte_length_static()),
             ),
         ),
@@ -342,7 +342,7 @@ def test_indexTuple():
             typeIndex=1,
             expected=lambda output: output.decode(
                 encoded,
-                startIndex=pt.Int(1),
+                start_index=pt.Int(1),
                 length=pt.Int(tuple_t.byte_length_static()),
             ),
         ),
@@ -350,28 +350,28 @@ def test_indexTuple():
             types=[dynamic_array_t1],
             typeIndex=0,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(0))
+                encoded, start_index=pt.ExtractUint16(encoded, pt.Int(0))
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1],
             typeIndex=1,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(1))
+                encoded, start_index=pt.ExtractUint16(encoded, pt.Int(1))
             ),
         ),
         IndexTest(
             types=[dynamic_array_t1, byte_t],
             typeIndex=0,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(0))
+                encoded, start_index=pt.ExtractUint16(encoded, pt.Int(0))
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1, byte_t],
             typeIndex=1,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(1))
+                encoded, start_index=pt.ExtractUint16(encoded, pt.Int(1))
             ),
         ),
         IndexTest(
@@ -379,15 +379,15 @@ def test_indexTuple():
             typeIndex=1,
             expected=lambda output: output.decode(
                 encoded,
-                startIndex=pt.ExtractUint16(encoded, pt.Int(1)),
-                endIndex=pt.ExtractUint16(encoded, pt.Int(4)),
+                start_index=pt.ExtractUint16(encoded, pt.Int(1)),
+                end_index=pt.ExtractUint16(encoded, pt.Int(4)),
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1, byte_t, dynamic_array_t2],
             typeIndex=3,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(4))
+                encoded, start_index=pt.ExtractUint16(encoded, pt.Int(4))
             ),
         ),
         IndexTest(
@@ -395,15 +395,15 @@ def test_indexTuple():
             typeIndex=1,
             expected=lambda output: output.decode(
                 encoded,
-                startIndex=pt.ExtractUint16(encoded, pt.Int(1)),
-                endIndex=pt.ExtractUint16(encoded, pt.Int(4)),
+                start_index=pt.ExtractUint16(encoded, pt.Int(1)),
+                end_index=pt.ExtractUint16(encoded, pt.Int(4)),
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1, tuple_t, dynamic_array_t2],
             typeIndex=3,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(4))
+                encoded, start_index=pt.ExtractUint16(encoded, pt.Int(4))
             ),
         ),
         IndexTest(
@@ -411,15 +411,15 @@ def test_indexTuple():
             typeIndex=1,
             expected=lambda output: output.decode(
                 encoded,
-                startIndex=pt.ExtractUint16(encoded, pt.Int(1)),
-                endIndex=pt.ExtractUint16(encoded, pt.Int(4)),
+                start_index=pt.ExtractUint16(encoded, pt.Int(1)),
+                end_index=pt.ExtractUint16(encoded, pt.Int(4)),
             ),
         ),
         IndexTest(
             types=[byte_t, dynamic_array_t1, bool_t, bool_t, dynamic_array_t2],
             typeIndex=4,
             expected=lambda output: output.decode(
-                encoded, startIndex=pt.ExtractUint16(encoded, pt.Int(4))
+                encoded, start_index=pt.ExtractUint16(encoded, pt.Int(4))
             ),
         ),
     ]
@@ -607,14 +607,14 @@ def test_Tuple_decode():
                     with pytest.raises(pt.TealInputError):
                         tupleValue.decode(
                             encoded,
-                            startIndex=startIndex,
-                            endIndex=endIndex,
+                            start_index=startIndex,
+                            end_index=endIndex,
                             length=length,
                         )
                     continue
 
                 expr = tupleValue.decode(
-                    encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                    encoded, start_index=startIndex, end_index=endIndex, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -97,8 +97,8 @@ class BaseType(ABC):
         self,
         encoded: Expr,
         *,
-        startIndex: Expr = None,
-        endIndex: Expr = None,
+        start_index: Expr = None,
+        end_index: Expr = None,
         length: Expr = None,
     ) -> Expr:
         """Decode a substring of the passed in encoded string and set it as this type's value.
@@ -121,9 +121,9 @@ class BaseType(ABC):
 
         Args:
             encoded: An expression containing the bytes to decode. Must evaluate to TealType.bytes.
-            startIndex (optional): An expression containing the index to start decoding. Must
+            start_index (optional): An expression containing the index to start decoding. Must
                 evaluate to TealType.uint64. Defaults to None.
-            endIndex (optional): An expression containing the index to stop decoding. Must evaluate
+            end_index (optional): An expression containing the index to stop decoding. Must evaluate
                 to TealType.uint64. Defaults to None.
             length (optional): An expression containing the length of the substring to decode. Must
                 evaluate to TealType.uint64. Defaults to None.

--- a/pyteal/ast/abi/uint.py
+++ b/pyteal/ast/abi/uint.py
@@ -261,16 +261,16 @@ class Uint(BaseType):
         self,
         encoded: Expr,
         *,
-        startIndex: Expr = None,
-        endIndex: Expr = None,
+        start_index: Expr = None,
+        end_index: Expr = None,
         length: Expr = None,
     ) -> Expr:
         return uint_decode(
             self.type_spec().bit_size(),
             self.stored_value,
             encoded,
-            startIndex,
-            endIndex,
+            start_index,
+            end_index,
             length,
         )
 

--- a/pyteal/ast/abi/uint_test.py
+++ b/pyteal/ast/abi/uint_test.py
@@ -267,7 +267,10 @@ def test_Uint_decode():
                 for length in (None, pt.Int(3)):
                     value = test.uintType.new_instance()
                     expr = value.decode(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded,
+                        start_index=startIndex,
+                        end_index=endIndex,
+                        length=length,
                     )
                     assert expr.type_of() == pt.TealType.none
                     assert not expr.has_return()


### PR DESCRIPTION
Renames parameters in `pyteal.ast.abi.Type.decode`to abide by PEP8 naming conventions.

* The intent is to avoid backwards incompatibilities by renaming _before_ an initial release.  The PR deliberately makes _no_ other changes to keep the changeset minimal. 
* Changes generated via PyCharm renaming facilities.