### PR TITLE
Fix Sphinx warnings

### DIFF
--- a/pyteal/ast/abi/array_dynamic.py
+++ b/pyteal/ast/abi/array_dynamic.py
@@ -60,7 +60,8 @@ class DynamicArray(Array[T]):
         self,
         values: Union[Sequence[T], "DynamicArray[T]", ComputedValue["DynamicArray[T]"]],
     ) -> Expr:
-        """Set the ABI dynamic array with one of the following
+        """Set the ABI dynamic array with one of the following:
+
         * a sequence of ABI type variables
         * or another ABI static array
         * or a ComputedType with same TypeSpec
@@ -69,10 +70,15 @@ class DynamicArray(Array[T]):
         from ComputedType to store the internal ABI encoding into this StaticArray.
 
         This function determines if the argument `values` is an ABI dynamic array:
+
         * if so:
+
           * checks whether `values` is same type as this ABI dynamic array.
+
           * stores the encoding of `values`.
+
         * if not:
+
           * calls the inherited `set` function and stores `values`.
 
         Args:

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -85,6 +85,7 @@ class StaticArray(Array[T], Generic[T, N]):
         ],
     ) -> Expr:
         """Set the ABI static array with one of the following:
+
         * a sequence of ABI type variables
         * or another ABI static array
         * or a ComputedType with same TypeSpec
@@ -93,12 +94,15 @@ class StaticArray(Array[T], Generic[T, N]):
         from ComputedType to store the internal ABI encoding into this StaticArray.
 
         This function determines if the argument `values` is an ABI static array:
+
         * if so:
+
           * checks whether `values` is same type as this ABI staic array.
 
           * stores the encoding of `values`.
 
         * if not:
+
           * checks whether static array length matches sequence length.
 
           * calls the inherited `set` function and stores `values`.

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -95,9 +95,12 @@ class StaticArray(Array[T], Generic[T, N]):
         This function determines if the argument `values` is an ABI static array:
         * if so:
           * checks whether `values` is same type as this ABI staic array.
+
           * stores the encoding of `values`.
+
         * if not:
           * checks whether static array length matches sequence length.
+
           * calls the inherited `set` function and stores `values`.
 
         Args:

--- a/pyteal/ir/tealblock.py
+++ b/pyteal/ir/tealblock.py
@@ -255,8 +255,10 @@ class TealBlock(ABC):
         A mapping is defined as follows:
           * The actual and expected lists must have the same length.
           * For every ScratchSlot referenced by either list:
+
             * If the slot appears in both lists, it must appear the exact same number of times and at
               the exact same indexes in both lists.
+
             * If the slot appears only in one list, for each of its appearances in that list, there
               must be a ScratchSlot in the other list that appears the exact same number of times
               and at the exact same indexes.


### PR DESCRIPTION
Extends #400 to address these Sphinx build warnings (also visible in https://github.com/algorand/pyteal/runs/6926771582?check_suite_focus=true#step:5:39) and list rendering:

```
/Users/michael/dev/pyteal/pyteal/__init__.py:docstring of pyteal.ir.tealblock.TealBlock.MatchScratchSlotReferences:7: WARNING: Unexpected indentation.
/Users/michael/dev/pyteal/pyteal/__init__.py:docstring of pyteal.ir.tealblock.TealBlock.MatchScratchSlotReferences:8: WARNING: Block quote ends without a blank line; unexpected unindent.
docstring of pyteal.ast.abi.address.Address.set:11: WARNING: Unexpected indentation.
docstring of pyteal.ast.abi.address.Address.set:13: WARNING: Block quote ends without a blank line; unexpected unindent.
docstring of pyteal.ast.abi.array_dynamic.DynamicArray.set:11: WARNING: Unexpected indentation.
docstring of pyteal.ast.abi.array_dynamic.DynamicArray.set:13: WARNING: Block quote ends without a blank line; unexpected unindent.
docstring of pyteal.ast.abi.array_static.StaticArray.set:11: WARNING: Unexpected indentation.
docstring of pyteal.ast.abi.array_static.StaticArray.set:13: WARNING: Block quote ends without a blank line; unexpected unindent.
docstring of pyteal.ast.abi.string.String.set:11: WARNING: Unexpected indentation.
docstring of pyteal.ast.abi.string.String.set:13: WARNING: Block quote ends without a blank line; unexpected unindent.
```

