### PR TITLE
Convenience wrapper for subroutine calls

### DIFF
--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -1,5 +1,5 @@
 import math
-from typing import Callable, Generic, ParamSpec, Sequence, TypeVar, cast
+from typing import Any, Callable, Generic, ParamSpec, Sequence, TypeVar, cast
 from dataclasses import dataclass
 
 import algosdk.abi
@@ -136,7 +136,6 @@ def Blackbox(input_types: list[TealType | None]):
 
 
 P = ParamSpec("P")
-R = TypeVar("R")
 
 
 def CallableSubroutine(
@@ -151,7 +150,7 @@ def CallableSubroutine(
     Python native functions (e.g. raising on error during dryrun).
     """
 
-    def decorator_runner(func: Callable[P, R]) -> Callable[P, R]:
+    def decorator_runner(func: Callable[P, Any]) -> Callable[P, Any]:
         if isinstance(func, SubroutineFnWrapper):
             if output_type is not None:
                 raise ValueError(

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -135,13 +135,33 @@ def Blackbox(input_types: list[TealType | None]):
     return decorator_blackbox
 
 
-def SubroutineRunner(input_types: list[TealType | None], mode=Mode.Application):
+def CallableSubroutine(
+    input_types: list[TealType | None],
+    output_type: TealType | None = None,
+    name: str | None = None,
+    mode: Mode = Mode.Application,
+):
     """
-    Decorator for enabling @Subroutine wrapped functions to be called directly and behave similarly
-    to Python native functions (e.g. raising on error during dryrun).
+    Decorator for enabling functions to be called directly as Subroutines and behave similarly to
+    Python native functions (e.g. raising on error during dryrun).
     """
 
-    def decorator_runner(func: SubroutineFnWrapper):
+    def decorator_runner(func: SubroutineFnWrapper | Callable[..., Expr]):
+        if isinstance(func, SubroutineFnWrapper):
+            if output_type is not None:
+                raise ValueError(
+                    "received 'output_type', but function is already a Subroutine"
+                )
+            elif name is not None:
+                raise ValueError(
+                    "received 'name', but function is already a Subroutine"
+                )
+        elif output_type is None:
+            raise ValueError(
+                "'output_type' must be specified if function is not already a Subroutine"
+            )
+        else:
+            func = SubroutineFnWrapper(func, output_type, name=name)
         return _SubroutineRunner(func, input_types, mode)
 
     return decorator_runner

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -1,5 +1,5 @@
 import math
-from typing import Callable, Generic, Sequence, TypeVar, cast
+from typing import Callable, Generic, ParamSpec, Sequence, TypeVar, cast
 from dataclasses import dataclass
 
 import algosdk.abi
@@ -135,6 +135,10 @@ def Blackbox(input_types: list[TealType | None]):
     return decorator_blackbox
 
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
 def CallableSubroutine(
     input_types: list[TealType | None],
     output_type: TealType | None = None,
@@ -147,7 +151,7 @@ def CallableSubroutine(
     Python native functions (e.g. raising on error during dryrun).
     """
 
-    def decorator_runner(func: SubroutineFnWrapper | Callable[..., Expr]):
+    def decorator_runner(func: Callable[P, R]) -> Callable[P, R]:
         if isinstance(func, SubroutineFnWrapper):
             if output_type is not None:
                 raise ValueError(
@@ -162,8 +166,8 @@ def CallableSubroutine(
                 "'output_type' must be specified if function is not already a Subroutine"
             )
         else:
-            func = SubroutineFnWrapper(func, output_type, name=name)
-        return _SubroutineRunner(func, input_types, inline, mode)
+            func = SubroutineFnWrapper(func, output_type, name=name)  # type: ignore
+        return _SubroutineRunner(func, input_types, inline, mode)  # type: ignore
 
     return decorator_runner
 

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -203,7 +203,7 @@ class _SubroutineRunner:
         if dryrun.error():
             raise RuntimeError(f"subroutine failed: '{dryrun.error_message()}'")
 
-        match (subr_type := self.subroutine.type_of()):
+        match (subr_type := self.subroutine.subroutine.return_type):
             case TealType.uint64:
                 if (out := dryrun.stack_top()) is None:
                     return 0

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -221,7 +221,7 @@ class _SubroutineRunner:
     def inline(self, *args, **kwargs) -> Expr:
         return self.subroutine.subroutine.implementation(*args, **kwargs)
 
-    def _order_input(self, *args, **kwargs) -> list[bytes | str | int]:
+    def _order_input(self, *args, **kwargs) -> list[str | int]:
         # ensure args / kwargs map to subroutine arguments in right order
         subr_args = self.subroutine.subroutine.arguments()
 
@@ -244,8 +244,8 @@ class _SubroutineRunner:
 
     def run(
         self,
-        *args: bytes | str | int,
-        **kwargs: bytes | str | int,
+        *args: str | int,
+        **kwargs: str | int,
     ) -> DryRunInspector:
         ordered_inputs = self._order_input(*args, **kwargs)
         # casting ints to bytes to circumvent uint64 assumption for int args
@@ -253,6 +253,15 @@ class _SubroutineRunner:
             self._itobytes(v) if isinstance(v, int) else v for v in ordered_inputs
         ]
         return self.executor.dryrun(byte_inputs)
+
+    def report(
+        self,
+        *args: str | int,
+        **kwargs: str | int,
+    ) -> None:
+        inspector = self.run(*args, **kwargs)
+        ordered_inputs = self._order_input(*args, **kwargs)
+        print(inspector.report(ordered_inputs))
 
 
 # ---- API ---- #


### PR DESCRIPTION
Hi there, I spoke to @tzaffi on the [graviton repo](https://github.com/algorand/graviton/issues/23) who suggested I make a pull request here. I wrote a `CallableSubroutine` decorator to make directly testing subroutine calls a bit more convenient for me personally. It doesn't add any new functionality, it is just a way to skip along some steps in case you only care about quickly comparing some outputs.

Example use:

```python
# can be used to wrap existing Subroutine
@CallableSubroutine(input_types=[TealType.uint64, TealType.uint64])
@Subroutine(TealType.bytes)
def bytes_subr(x: Expr, y: Expr) -> Expr:
    # (x * 1000) // y
    return BytesDiv(BytesMul(Itob(x), Bytes("base16", "0x03e8")), Itob(y))

# can also wrap a regular function and internally wrap as subroutine if output_type is specified
@CallableSubroutine(
    input_types=[TealType.uint64, TealType.uint64],
    output_type=TealType.uint64,
)
def uint64_subr(x: Expr, y: Expr) -> Expr:
    return Div(x, y)

# returns 500: reorders arguments according to order in subroutine
assert bytes_subr(y=5, x=10) == 2000 == bytes_subr(x=10, y=5)
# all equal 0
assert uint64_subr(y=10, x=5) == 0 == uint64_subr(x=5, y=10)
# x / 0: raises RuntimeError and reports error message from dryrun
bytes_subr(5, y=0)
```

I removed a lot of the things I had initially implemented locally, since I was unaware of how much work had been done on the `feature/abi` branch on PyTeal integration. I tried to strip the thing whole thing down a bit, but I use something like this in my own testing and found it super convenient, since it makes it pretty easy to write unit tests the way you would for any other Python project.

It's pretty hacky still and I'm sure it could be polished a lot by incorporating all the work happening on this branch, but it's been suitable for what I need and thought others might find it useful too. Hopefully I didn't miss something like this already existing in the repo, otherwise feel free to close!

It'd be pretty nice to infer the (Python-native) return types based on the ABI types too, but I only needed it for some numeric calculations and didn't want to spend too much time in case nobody else would want this. Otherwise happy to incorporate feedback. :)