### PR TITLE
adding comment class as an experiment

### DIFF
--- a/pyteal/__init__.pyi
+++ b/pyteal/__init__.pyi
@@ -75,6 +75,7 @@ __all__ = [
     "BytesXor",
     "BytesZero",
     "CallConfig",
+    "Comment",
     "CompileOptions",
     "Concat",
     "Cond",

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -41,6 +41,8 @@ from pyteal.ast.array import Array
 from pyteal.ast.tmpl import Tmpl
 from pyteal.ast.nonce import Nonce
 
+from pyteal.ast.comment import Comment
+
 # unary ops
 from pyteal.ast.unaryexpr import (
     UnaryExpr,
@@ -305,4 +307,5 @@ __all__ = [
     "EcdsaVerify",
     "EcdsaDecompress",
     "EcdsaRecover",
+    "Comment",
 ]

--- a/pyteal/ast/comment.py
+++ b/pyteal/ast/comment.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING, Tuple
+
+from pyteal.types import TealType
+from pyteal.ir import TealBlock, TealSimpleBlock
+from pyteal.ast.expr import Expr
+
+if TYPE_CHECKING:
+    from pyteal.compiler import CompileOptions
+
+
+class Comment(Expr):
+    def __init__(self, expr: Expr, comment: str):
+        self.expr = expr
+        self.comment = comment
+
+    def __teal__(self, options: "CompileOptions") -> Tuple[TealBlock, TealSimpleBlock]:
+        tb, tsb = self.expr.__teal__(options)
+        # tb.ops[-1].args.append("// "+self.comment)
+        tsb.ops[-1].args.append("// " + self.comment)
+        return tb, tsb
+
+    def __str__(self):
+        return "(Comment {} ({}))".format(self.comment, str(self.expr))
+
+    def type_of(self):
+        return TealType.none
+
+    def has_return(self):
+        return False
+
+
+Comment.__module__ = "pyteal"

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -308,6 +308,7 @@ def compileTeal(
             )
         teal = createConstantBlocks(teal)
 
+    print(teal)
     lines = ["#pragma version {}".format(version)]
     lines += [i.assemble() for i in teal]
     return "\n".join(lines)


### PR DESCRIPTION
I'd like to annotate produced teal with some comments.

Adding a new class here to support wrapping some existing expression rather than forcing each expression implementation to accept a comment. We append the comment string to the last ops' args.