### PR TITLE
adding any length tuple

### DIFF
--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -30,6 +30,7 @@ from pyteal.ast.abi.tuple import (
     Tuple3,
     Tuple4,
     Tuple5,
+    TupleAny,
 )
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
 from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray
@@ -110,6 +111,7 @@ __all__ = [
     "Tuple3",
     "Tuple4",
     "Tuple5",
+    "TupleAny",
     "ArrayTypeSpec",
     "Array",
     "ArrayElement",

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -459,8 +459,11 @@ class Tuple5(Tuple, Generic[T1, T2, T3, T4, T5]):
 Tuple5.__module__ = "pyteal"
 
 P = TypeVarTuple("P")
+
+
 class TupleAny(Tuple, Generic[Unpack[P]]):
-    def __init_(self, value_type_spec: TupleTypeSpec)->None:
+    def __init_(self, value_type_spec: TupleTypeSpec) -> None:
         super().__init__(value_type_spec)
+
 
 TupleAny.__module__ = "pyteal"

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -7,6 +7,7 @@ from typing import (
     cast,
     overload,
 )
+from typing_extensions import TypeVarTuple, Unpack
 
 from pyteal.types import TealType
 from pyteal.errors import TealInputError
@@ -244,6 +245,9 @@ class TupleTypeSpec(TypeSpec):
             case 5:
                 v0, v1, v2, v3, v4 = annotater()
                 return Tuple5[v0, v1, v2, v3, v4]  # type: ignore[valid-type]
+            case 6:
+                v0, v1, v2, v3, v4, v5 = annotater()
+                return TupleAny[v0, v1, v2, v3, v4, v5]
 
         raise TypeError(f"Cannot annotate tuple of length {len(vtses)}")
 
@@ -453,3 +457,10 @@ class Tuple5(Tuple, Generic[T1, T2, T3, T4, T5]):
 
 
 Tuple5.__module__ = "pyteal"
+
+P = TypeVarTuple("P")
+class TupleAny(Tuple, Generic[Unpack[P]]):
+    def __init_(self, value_type_spec: TupleTypeSpec)->None:
+        super().__init__(value_type_spec)
+
+TupleAny.__module__ = "pyteal"

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -108,6 +108,7 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         Tuple3,
         Tuple4,
         Tuple5,
+        TupleAny,
     )
     from pyteal.ast.abi.string import StringTypeSpec, String
     from pyteal.ast.abi.address import AddressTypeSpec, Address
@@ -243,6 +244,9 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
     if origin is Tuple5:
         if len(args) != 5:
             raise TypeError("Tuple5 expects 5 type arguments. Got: {}".format(args))
+        return TupleTypeSpec(*(type_spec_from_annotation(arg) for arg in args))
+
+    if origin is TupleAny:
         return TupleTypeSpec(*(type_spec_from_annotation(arg) for arg in args))
 
     if origin is Transaction:


### PR DESCRIPTION
While trying to figure out the right way to define a tuple of length >6 I found that the typing_extensions package offers an `Unpack` for variadic length.  This PR appears to do what I want for something like:

```py
@router.method
def random_tuple(a: abi.TupleAny[abi.Uint16, abi.Uint64, abi.Uint64, abi.Uint64, abi.Uint64, abi.Uint64]):
    #...
```


We may consider removing the TupleN types in favor of this setup


It looks like mypy hates it, TypeVarTuples may not be bound yet either

https://peps.python.org/pep-0646/#variance-type-constraints-and-type-bounds-not-yet-supported