### PR TITLE
__str__ formatting

### DIFF
--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -93,6 +93,9 @@ class Bool(BaseType):
         return SetBit(Bytes(b"\x00"), Int(0), self.get())
 
 
+Bool.__module__ = "pyteal"
+
+
 def boolAwareStaticByteLength(types: Sequence[TypeSpec]) -> int:
     length = 0
     ignoreNext = 0

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -144,12 +144,9 @@ class BaseType(ABC):
 
     def __str__(self) -> str:
         at = self.type_spec().annotation_type()
-
-        # Check if the type is the same as the annotation type
-        # This suggests it is not generic and we can just use the class name
-        if type(self) is at:
+        # If the annotation type itself is a class, just return its name
+        if isinstance(at, type):
             return self.__class__.__name__
-
         return str(at)
 
 

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -142,9 +142,8 @@ class BaseType(ABC):
             )
         return value.store_into(self)
 
-    def __str__(self)->str:
+    def __str__(self) -> str:
         return str(self.__class__.__name__)
-
 
 
 BaseType.__module__ = "pyteal"

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -143,7 +143,7 @@ class BaseType(ABC):
         return value.store_into(self)
 
     def __str__(self) -> str:
-        return str(self.__class__.__name__)
+        return str(self.type_spec().annotation_type())
 
 
 BaseType.__module__ = "pyteal"

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -142,6 +142,10 @@ class BaseType(ABC):
             )
         return value.store_into(self)
 
+    def __str__(self)->str:
+        return str(self.__class__.__name__)
+
+
 
 BaseType.__module__ = "pyteal"
 

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -143,11 +143,7 @@ class BaseType(ABC):
         return value.store_into(self)
 
     def __str__(self) -> str:
-        at = self.type_spec().annotation_type()
-        # If the annotation type itself is a class, just return its name
-        if isinstance(at, type):
-            return self.__class__.__name__
-        return str(at)
+        return str(self.type_spec())
 
 
 BaseType.__module__ = "pyteal"

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -143,7 +143,14 @@ class BaseType(ABC):
         return value.store_into(self)
 
     def __str__(self) -> str:
-        return str(self.type_spec().annotation_type())
+        at = self.type_spec().annotation_type()
+
+        # Check if the type is the same as the annotation type
+        # This suggests it is not generic and we can just use the class name
+        if type(self) is at:
+            return self.__class__.__name__
+
+        return str(at)
 
 
 BaseType.__module__ = "pyteal"

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -334,23 +334,21 @@ def test_size_of():
 
 ABI_TRANSLATION_TEST_CASES = [
     # Test for byte/bool/address/strings
-    (algosdk.abi.ByteType(), "byte", abi.ByteTypeSpec(), abi.Byte, "Byte"),
-    (algosdk.abi.BoolType(), "bool", abi.BoolTypeSpec(), abi.Bool, "Bool"),
+    (algosdk.abi.ByteType(), "byte", abi.ByteTypeSpec(), abi.Byte),
+    (algosdk.abi.BoolType(), "bool", abi.BoolTypeSpec(), abi.Bool),
     (
         algosdk.abi.AddressType(),
         "address",
         abi.AddressTypeSpec(),
         abi.Address,
-        "Address",
     ),
-    (algosdk.abi.StringType(), "string", abi.StringTypeSpec(), abi.String, "String"),
+    (algosdk.abi.StringType(), "string", abi.StringTypeSpec(), abi.String),
     # Test for dynamic array type
     (
         algosdk.abi.ArrayDynamicType(algosdk.abi.UintType(32)),
         "uint32[]",
         abi.DynamicArrayTypeSpec(abi.Uint32TypeSpec()),
         abi.DynamicArray[abi.Uint32],
-        "pyteal.DynamicArray[pyteal.Uint32]",
     ),
     (
         algosdk.abi.ArrayDynamicType(
@@ -359,7 +357,6 @@ ABI_TRANSLATION_TEST_CASES = [
         "byte[][]",
         abi.DynamicArrayTypeSpec(abi.DynamicArrayTypeSpec(abi.ByteTypeSpec())),
         abi.DynamicArray[abi.DynamicArray[abi.Byte]],
-        "pyteal.DynamicArray[pyteal.DynamicArray[pyteal.Byte]]",
     ),
     # TODO: Turn these tests on when PyTeal supports ufixed<N>x<M>
     # cf https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0004.md#types
@@ -385,10 +382,9 @@ ABI_TRANSLATION_TEST_CASES = [
             100,
         ),
         abi.StaticArray[abi.StaticArray[abi.Bool, Literal[256]], Literal[100]],
-        "pyteal.StaticArray[pyteal.StaticArray[pyteal.Bool, typing.Literal[256]], typing.Literal[100]]",
     ),
     # Test for tuple
-    (algosdk.abi.TupleType([]), "()", abi.TupleTypeSpec(), abi.Tuple0, "Tuple"),
+    (algosdk.abi.TupleType([]), "()", abi.TupleTypeSpec(), abi.Tuple0),
     (
         algosdk.abi.TupleType(
             [
@@ -416,7 +412,6 @@ ABI_TRANSLATION_TEST_CASES = [
                 abi.StaticArray[abi.Address, Literal[10]],
             ],
         ],
-        "pyteal.Tuple2[pyteal.Uint16, pyteal.Tuple2[pyteal.Byte, pyteal.StaticArray[pyteal.Address, typing.Literal[10]]]]",
     ),
     (
         algosdk.abi.TupleType(
@@ -451,7 +446,6 @@ ABI_TRANSLATION_TEST_CASES = [
             abi.Tuple,
             abi.Bool,
         ],
-        "pyteal.Tuple4[pyteal.Uint64, pyteal.Tuple2[pyteal.Byte, pyteal.StaticArray[pyteal.Address, typing.Literal[10]]], pyteal.Tuple0, pyteal.Bool]",
     ),
     # TODO: Turn the following test on when PyTeal supports ufixed<N>x<M>
     # cf https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0004.md#types
@@ -505,86 +499,74 @@ ABI_TRANSLATION_TEST_CASES = [
         "txn",
         abi.TransactionTypeSpec(),
         abi.Transaction,
-        "Transaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.PaymentTransactionTypeSpec",
         "pay",
         abi.PaymentTransactionTypeSpec(),
         abi.PaymentTransaction,
-        "PaymentTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.KeyRegisterTransactionTypeSpec",
         "keyreg",
         abi.KeyRegisterTransactionTypeSpec(),
         abi.KeyRegisterTransaction,
-        "KeyRegisterTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.AssetConfigTransactionTypeSpec",
         "acfg",
         abi.AssetConfigTransactionTypeSpec(),
         abi.AssetConfigTransaction,
-        "AssetConfigTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.AssetTransferTransactionTypeSpec",
         "axfer",
         abi.AssetTransferTransactionTypeSpec(),
         abi.AssetTransferTransaction,
-        "AssetTransferTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.AssetFreezeTransactionTypeSpec",
         "afrz",
         abi.AssetFreezeTransactionTypeSpec(),
         abi.AssetFreezeTransaction,
-        "AssetFreezeTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.ApplicationCallTransactionTypeSpec",
         "appl",
         abi.ApplicationCallTransactionTypeSpec(),
         abi.ApplicationCallTransaction,
-        "ApplicationCallTransaction",
     ),
     (
         "cannot map ABI reference type spec <pyteal.AccountTypeSpec",
         "account",
         abi.AccountTypeSpec(),
         abi.Account,
-        "Account",
     ),
     (
         "cannot map ABI reference type spec <pyteal.ApplicationTypeSpec",
         "application",
         abi.ApplicationTypeSpec(),
         abi.Application,
-        "Application",
     ),
     (
         "cannot map ABI reference type spec <pyteal.AssetTypeSpec",
         "asset",
         abi.AssetTypeSpec(),
         abi.Asset,
-        "Asset",
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "algosdk_abi, abi_string, pyteal_abi_ts, pyteal_abi, stringified",
+    "algosdk_abi, abi_string, pyteal_abi_ts, pyteal_abi",
     ABI_TRANSLATION_TEST_CASES,
 )
-def test_abi_type_translation(
-    algosdk_abi, abi_string, pyteal_abi_ts, pyteal_abi, stringified
-):
+def test_abi_type_translation(algosdk_abi, abi_string, pyteal_abi_ts, pyteal_abi):
     print(f"({algosdk_abi}, {abi_string}, {pyteal_abi_ts}),")
 
     assert pyteal_abi_ts == abi.type_spec_from_annotation(pyteal_abi)
 
-    assert str(pyteal_abi_ts.new_instance()) == stringified
+    assert str(pyteal_abi_ts.new_instance()) == abi_string
 
     if abi_string in (
         "account",

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -334,16 +334,23 @@ def test_size_of():
 
 ABI_TRANSLATION_TEST_CASES = [
     # Test for byte/bool/address/strings
-    (algosdk.abi.ByteType(), "byte", abi.ByteTypeSpec(), abi.Byte),
-    (algosdk.abi.BoolType(), "bool", abi.BoolTypeSpec(), abi.Bool),
-    (algosdk.abi.AddressType(), "address", abi.AddressTypeSpec(), abi.Address),
-    (algosdk.abi.StringType(), "string", abi.StringTypeSpec(), abi.String),
+    (algosdk.abi.ByteType(), "byte", abi.ByteTypeSpec(), abi.Byte, "Byte"),
+    (algosdk.abi.BoolType(), "bool", abi.BoolTypeSpec(), abi.Bool, "Bool"),
+    (
+        algosdk.abi.AddressType(),
+        "address",
+        abi.AddressTypeSpec(),
+        abi.Address,
+        "Address",
+    ),
+    (algosdk.abi.StringType(), "string", abi.StringTypeSpec(), abi.String, "String"),
     # Test for dynamic array type
     (
         algosdk.abi.ArrayDynamicType(algosdk.abi.UintType(32)),
         "uint32[]",
         abi.DynamicArrayTypeSpec(abi.Uint32TypeSpec()),
         abi.DynamicArray[abi.Uint32],
+        "pyteal.DynamicArray[pyteal.Uint32]",
     ),
     (
         algosdk.abi.ArrayDynamicType(
@@ -352,6 +359,7 @@ ABI_TRANSLATION_TEST_CASES = [
         "byte[][]",
         abi.DynamicArrayTypeSpec(abi.DynamicArrayTypeSpec(abi.ByteTypeSpec())),
         abi.DynamicArray[abi.DynamicArray[abi.Byte]],
+        "pyteal.DynamicArray[pyteal.DynamicArray[pyteal.Byte]]",
     ),
     # TODO: Turn these tests on when PyTeal supports ufixed<N>x<M>
     # cf https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0004.md#types
@@ -377,9 +385,10 @@ ABI_TRANSLATION_TEST_CASES = [
             100,
         ),
         abi.StaticArray[abi.StaticArray[abi.Bool, Literal[256]], Literal[100]],
+        "pyteal.StaticArray[pyteal.StaticArray[pyteal.Bool, typing.Literal[256]], typing.Literal[100]]",
     ),
     # Test for tuple
-    (algosdk.abi.TupleType([]), "()", abi.TupleTypeSpec(), abi.Tuple0),
+    (algosdk.abi.TupleType([]), "()", abi.TupleTypeSpec(), abi.Tuple0, "Tuple"),
     (
         algosdk.abi.TupleType(
             [
@@ -407,6 +416,7 @@ ABI_TRANSLATION_TEST_CASES = [
                 abi.StaticArray[abi.Address, Literal[10]],
             ],
         ],
+        "pyteal.Tuple2[pyteal.Uint16, pyteal.Tuple2[pyteal.Byte, pyteal.StaticArray[pyteal.Address, typing.Literal[10]]]]",
     ),
     (
         algosdk.abi.TupleType(
@@ -441,6 +451,7 @@ ABI_TRANSLATION_TEST_CASES = [
             abi.Tuple,
             abi.Bool,
         ],
+        "pyteal.Tuple4[pyteal.Uint64, pyteal.Tuple2[pyteal.Byte, pyteal.StaticArray[pyteal.Address, typing.Literal[10]]], pyteal.Tuple0, pyteal.Bool]",
     ),
     # TODO: Turn the following test on when PyTeal supports ufixed<N>x<M>
     # cf https://github.com/algorandfoundation/ARCs/blob/main/ARCs/arc-0004.md#types
@@ -489,77 +500,91 @@ ABI_TRANSLATION_TEST_CASES = [
     #         ]
     #     ),
     # ),
-    (algosdk.abi.TupleType([]), "()", abi.TupleTypeSpec(), abi.Tuple0),
     (
         "cannot map ABI transaction type spec <pyteal.TransactionTypeSpec",
         "txn",
         abi.TransactionTypeSpec(),
         abi.Transaction,
+        "Transaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.PaymentTransactionTypeSpec",
         "pay",
         abi.PaymentTransactionTypeSpec(),
         abi.PaymentTransaction,
+        "PaymentTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.KeyRegisterTransactionTypeSpec",
         "keyreg",
         abi.KeyRegisterTransactionTypeSpec(),
         abi.KeyRegisterTransaction,
+        "KeyRegisterTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.AssetConfigTransactionTypeSpec",
         "acfg",
         abi.AssetConfigTransactionTypeSpec(),
         abi.AssetConfigTransaction,
+        "AssetConfigTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.AssetTransferTransactionTypeSpec",
         "axfer",
         abi.AssetTransferTransactionTypeSpec(),
         abi.AssetTransferTransaction,
+        "AssetTransferTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.AssetFreezeTransactionTypeSpec",
         "afrz",
         abi.AssetFreezeTransactionTypeSpec(),
         abi.AssetFreezeTransaction,
+        "AssetFreezeTransaction",
     ),
     (
         "cannot map ABI transaction type spec <pyteal.ApplicationCallTransactionTypeSpec",
         "appl",
         abi.ApplicationCallTransactionTypeSpec(),
         abi.ApplicationCallTransaction,
+        "ApplicationCallTransaction",
     ),
     (
         "cannot map ABI reference type spec <pyteal.AccountTypeSpec",
         "account",
         abi.AccountTypeSpec(),
         abi.Account,
+        "Account",
     ),
     (
         "cannot map ABI reference type spec <pyteal.ApplicationTypeSpec",
         "application",
         abi.ApplicationTypeSpec(),
         abi.Application,
+        "Application",
     ),
     (
         "cannot map ABI reference type spec <pyteal.AssetTypeSpec",
         "asset",
         abi.AssetTypeSpec(),
         abi.Asset,
+        "Asset",
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "algosdk_abi, abi_string, pyteal_abi_ts, pyteal_abi", ABI_TRANSLATION_TEST_CASES
+    "algosdk_abi, abi_string, pyteal_abi_ts, pyteal_abi, stringified",
+    ABI_TRANSLATION_TEST_CASES,
 )
-def test_abi_type_translation(algosdk_abi, abi_string, pyteal_abi_ts, pyteal_abi):
+def test_abi_type_translation(
+    algosdk_abi, abi_string, pyteal_abi_ts, pyteal_abi, stringified
+):
     print(f"({algosdk_abi}, {abi_string}, {pyteal_abi_ts}),")
 
     assert pyteal_abi_ts == abi.type_spec_from_annotation(pyteal_abi)
+
+    assert str(pyteal_abi_ts.new_instance()) == stringified
 
     if abi_string in (
         "account",

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -46,7 +46,9 @@ class BinaryExpr(Expr):
         )
 
     def __str__(self):
-        return "({} {} {})".format(str(self.op).title().replace("_", ""), self.argLeft, self.argRight)
+        return "({} {} {})".format(
+            str(self.op).title().replace("_", ""), self.argLeft, self.argRight
+        )
 
     def type_of(self):
         return self.outputType

--- a/pyteal/ast/binaryexpr.py
+++ b/pyteal/ast/binaryexpr.py
@@ -46,7 +46,7 @@ class BinaryExpr(Expr):
         )
 
     def __str__(self):
-        return "({} {} {})".format(self.op, self.argLeft, self.argRight)
+        return "({} {} {})".format(str(self.op).title().replace("_", ""), self.argLeft, self.argRight)
 
     def type_of(self):
         return self.outputType

--- a/pyteal/ast/int.py
+++ b/pyteal/ast/int.py
@@ -33,7 +33,7 @@ class Int(LeafExpr):
         return TealBlock.FromOp(options, op)
 
     def __str__(self):
-        return "(Int: {})".format(self.value)
+        return "(Int {})".format(self.value)
 
     def type_of(self):
         return TealType.uint64
@@ -59,7 +59,7 @@ class EnumInt(LeafExpr):
         return TealBlock.FromOp(options, op)
 
     def __str__(self):
-        return "(IntEnum: {})".format(self.name)
+        return "(IntEnum {})".format(self.name)
 
     def type_of(self):
         return TealType.uint64

--- a/pyteal/ast/methodsig.py
+++ b/pyteal/ast/methodsig.py
@@ -33,7 +33,7 @@ class MethodSignature(LeafExpr):
         return TealBlock.FromOp(options, op)
 
     def __str__(self) -> str:
-        return "(method: {})".format(self.methodName)
+        return "(MethodSignature '{}')".format(self.methodName)
 
     def type_of(self) -> TealType:
         return TealType.bytes

--- a/pyteal/ast/naryexpr.py
+++ b/pyteal/ast/naryexpr.py
@@ -48,7 +48,7 @@ class NaryExpr(Expr):
         return start, end
 
     def __str__(self):
-        ret_str = "(" + str(self.op).title().replace("_", " ")
+        ret_str = "(" + str(self.op).title().replace("_", "")
         for a in self.args:
             ret_str += " " + a.__str__()
         ret_str += ")"

--- a/pyteal/ast/naryexpr.py
+++ b/pyteal/ast/naryexpr.py
@@ -48,7 +48,7 @@ class NaryExpr(Expr):
         return start, end
 
     def __str__(self):
-        ret_str = "(" + str(self.op)
+        ret_str = "(" + str(self.op).title().replace("_", " ")
         for a in self.args:
             ret_str += " " + a.__str__()
         ret_str += ")"

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -31,7 +31,7 @@ class UnaryExpr(Expr):
         return TealBlock.FromOp(options, TealOp(self, self.op), self.arg)
 
     def __str__(self):
-        return "({} {})".format(str(self.op).title().replace("_",""), self.arg)
+        return "({} {})".format(str(self.op).title().replace("_", ""), self.arg)
 
     def type_of(self):
         return self.outputType

--- a/pyteal/ast/unaryexpr.py
+++ b/pyteal/ast/unaryexpr.py
@@ -31,7 +31,7 @@ class UnaryExpr(Expr):
         return TealBlock.FromOp(options, TealOp(self, self.op), self.arg)
 
     def __str__(self):
-        return "({} {})".format(self.op, self.arg)
+        return "({} {})".format(str(self.op).title().replace("_",""), self.arg)
 
     def type_of(self):
         return self.outputType


### PR DESCRIPTION
When printing out the Expression tree, some of the Exprs had slightly different formatting. This just tries to convert them all to standard formatting of `(ExprNameAsTitleCase arg arg)`