### PR TITLE
MaybeValue error prior to scratch slot check

### DIFF
--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -36,9 +36,13 @@ class MaybeValue(MultiValue):
 
         This will return 1 if the value exists, otherwise 0.
         """
-        if not self.initialized:
-            raise TealInputError("Expected MaybeValue to be initialized before calling `hasValue`")
-        return self.output_slots[1].load(self.types[1])
+        try:
+            sl = self.output_slots[1].load(self.types[1])
+        except TealInputError:
+            raise TealInputError(
+                "Expected MaybeValue to be initialized prior to calling `hasValue`"
+            )
+        return sl
 
     def value(self) -> ScratchLoad:
         """Get the value.
@@ -46,9 +50,14 @@ class MaybeValue(MultiValue):
         If the value exists, it will be returned. Otherwise, the zero value for this type will be
         returned (i.e. either 0 or an empty byte string, depending on the type).
         """
-        if not self.initialized:
-            raise TealInputError("Expected MaybeValue to be initialized before calling `value`")
-        return self.output_slots[0].load(self.types[0])
+        try:
+            sl = self.output_slots[0].load(self.types[0])
+        except TealInputError:
+            raise TealInputError(
+                "Expected MaybeValue to be initialized prior to calling `value`"
+            )
+
+        return sl
 
     @property
     def slotOk(self) -> ScratchSlot:

--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -36,13 +36,11 @@ class MaybeValue(MultiValue):
 
         This will return 1 if the value exists, otherwise 0.
         """
-        try:
-            sl = self.output_slots[1].load(self.types[1])
-        except TealInputError:
+        if not self.output_slots[1].initialized:
             raise TealInputError(
                 "Expected MaybeValue to be initialized prior to calling `hasValue`"
             )
-        return sl
+        return self.output_slots[1].load(self.types[1])
 
     def value(self) -> ScratchLoad:
         """Get the value.
@@ -50,14 +48,12 @@ class MaybeValue(MultiValue):
         If the value exists, it will be returned. Otherwise, the zero value for this type will be
         returned (i.e. either 0 or an empty byte string, depending on the type).
         """
-        try:
-            sl = self.output_slots[0].load(self.types[0])
-        except TealInputError:
+        if not self.output_slots[0].initialized:
             raise TealInputError(
                 "Expected MaybeValue to be initialized prior to calling `value`"
             )
 
-        return sl
+        return self.output_slots[0].load(self.types[0])
 
     @property
     def slotOk(self) -> ScratchSlot:

--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -1,6 +1,7 @@
 from typing import List, Union
 
 from pyteal.ast.multi import MultiValue
+from pyteal.errors import TealInputError
 
 from pyteal.types import TealType
 from pyteal.ir import Op
@@ -35,6 +36,8 @@ class MaybeValue(MultiValue):
 
         This will return 1 if the value exists, otherwise 0.
         """
+        if not self.initialized:
+            raise TealInputError("Expected MaybeValue to be initialized before calling `hasValue`")
         return self.output_slots[1].load(self.types[1])
 
     def value(self) -> ScratchLoad:
@@ -43,6 +46,8 @@ class MaybeValue(MultiValue):
         If the value exists, it will be returned. Otherwise, the zero value for this type will be
         returned (i.e. either 0 or an empty byte string, depending on the type).
         """
+        if not self.initialized:
+            raise TealInputError("Expected MaybeValue to be initialized before calling `value`")
         return self.output_slots[0].load(self.types[0])
 
     @property

--- a/pyteal/ast/multi.py
+++ b/pyteal/ast/multi.py
@@ -35,7 +35,7 @@ class MultiValue(LeafExpr):
         self.types = types
         self.immediate_args = immediate_args if immediate_args is not None else []
         self.args = args if args is not None else []
-
+        self.initialized = False 
         self.output_slots = [ScratchSlot() for _ in self.types]
 
     def outputReducer(self, reducer: Callable[..., Expr]) -> Expr:
@@ -57,6 +57,8 @@ class MultiValue(LeafExpr):
         return ret_str
 
     def __teal__(self, options: "CompileOptions"):
+        self.initialized = True 
+
         tealOp = TealOp(self, self.op, *self.immediate_args)
         callStart, callEnd = TealBlock.FromOp(options, tealOp, *self.args)
 

--- a/pyteal/ast/multi.py
+++ b/pyteal/ast/multi.py
@@ -35,7 +35,6 @@ class MultiValue(LeafExpr):
         self.types = types
         self.immediate_args = immediate_args if immediate_args is not None else []
         self.args = args if args is not None else []
-        self.initialized = False 
         self.output_slots = [ScratchSlot() for _ in self.types]
 
     def outputReducer(self, reducer: Callable[..., Expr]) -> Expr:
@@ -57,8 +56,6 @@ class MultiValue(LeafExpr):
         return ret_str
 
     def __teal__(self, options: "CompileOptions"):
-        self.initialized = True 
-
         tealOp = TealOp(self, self.op, *self.immediate_args)
         callStart, callEnd = TealBlock.FromOp(options, tealOp, *self.args)
 

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -24,6 +24,8 @@ class ScratchSlot:
             requestedSlotId (optional): A scratch slot id that the compiler must store the value.
             This id may be a Python int in the range [0-256).
         """
+        self.initialized = False
+
         if requestedSlotId is None:
             self.id = ScratchSlot.nextSlotId
             ScratchSlot.nextSlotId += 1
@@ -46,6 +48,7 @@ class ScratchSlot:
             the stack will be stored. NOTE: storing the last value on the stack breaks the typical
             semantics of PyTeal, only use if you know what you're doing.
         """
+        self.initialized = True
         if value is not None:
             return ScratchStore(self, value)
         return ScratchStackStore(self)
@@ -57,6 +60,10 @@ class ScratchSlot:
             type (optional): The type being loaded from this slot, if known. Defaults to
                 TealType.anytype.
         """
+        if not self.initialized:
+            raise TealInputError(
+                "Expected slot to be initialized prior to calling `load`"
+            )
         return ScratchLoad(self, type)
 
     def index(self) -> "ScratchIndex":

--- a/pyteal/ast/scratchvar.py
+++ b/pyteal/ast/scratchvar.py
@@ -43,6 +43,7 @@ class ScratchVar:
             value: The value to store. Must conform to this ScratchVar's type.
         """
         require_type(value, self.type)
+        self.initialized = True
         return self.slot.store(value)
 
     def load(self) -> ScratchLoad:


### PR DESCRIPTION
During compilation we should know to error on an uninitialized MaybeValue prior to checking if the scratch slots are assigned. This attempts to add some flag to tell us if it's been done.

before:
```
pyteal.TealCompileError: Scratch slot load occurs before store
Traceback of origin expression (most recent call last):
  File "/home/ben/pyteal/examples/application/maybe_test.py", line 5, in <module>
    AssetHolding.balance(Global.zero_address(), Int(0)).value(),
  File "/home/ben/pyteal/pyteal/ast/maybe.py", line 46, in value
    return self.output_slots[0].load(self.types[0])
  File "/home/ben/pyteal/pyteal/ast/scratch.py", line 60, in load
    return ScratchLoad(self, type)
  File "/home/ben/pyteal/pyteal/ast/scratch.py", line 117, in __init__
    super().__init__()


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ben/pyteal/examples/application/maybe_test.py", line 8, in <module>
    print(compileTeal(program, mode=Mode.Application, version=6))
  File "/home/ben/pyteal/pyteal/compiler/compiler.py", line 252, in compileTeal
    localSlotAssignments = assignScratchSlotsToSubroutines(subroutine_start_blocks)
  File "/home/ben/pyteal/pyteal/compiler/scratchslots.py", line 148, in assignScratchSlotsToSubroutines
    raise TealInternalError(msg) from errors[0]
pyteal.TealInternalError: Encountered 1 error when assigning slots to subroutine
```

after:
```
Traceback (most recent call last):
  File "/home/ben/pyteal/examples/application/maybe_test.py", line 5, in <module>
    AssetHolding.balance(Global.zero_address(), Int(0)).value(),
  File "/home/ben/pyteal/pyteal/ast/maybe.py", line 52, in value
    raise TealInputError(
pyteal.TealInputError: Expected MaybeValue to be initialized prior to calling `value`
```