### PR TITLE
Router return subroutine

### DIFF
--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -538,7 +538,7 @@ class Router:
         overriding_name: str = None,
         method_config: MethodConfig = None,
         description: str = None,
-    ) -> None:
+    ) -> ABIReturnSubroutine:
         if not isinstance(method_call, ABIReturnSubroutine):
             raise TealInputError(
                 "for adding method handler, must be ABIReturnSubroutine"
@@ -576,6 +576,7 @@ class Router:
         self.clear_state_ast.add_method_to_ast(
             method_signature, method_clear_state_cond, method_call
         )
+        return method_call
 
     def method(
         self,
@@ -607,7 +608,7 @@ class Router:
         # - None
         # - CallConfig.Never
         # both cases evaluate to False in if statement.
-        def wrap(_func):
+        def wrap(_func) -> ABIReturnSubroutine:
             wrapped_subroutine = ABIReturnSubroutine(_func)
             call_configs: MethodConfig
             if (
@@ -639,7 +640,9 @@ class Router:
                     update_application=_update_app,
                     delete_application=_delete_app,
                 )
-            self.add_method_handler(wrapped_subroutine, name, call_configs, description)
+            return self.add_method_handler(
+                wrapped_subroutine, name, call_configs, description
+            )
 
         if not func:
             return wrap

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -1,3 +1,4 @@
+from pyparsing import empty
 import pytest
 
 import pyteal as pt
@@ -2203,7 +2204,8 @@ def test_router_app():
         ) -> pt.Expr:
             return output.set(a.get() + b.get())
 
-        router.add_method_handler(add)
+        meth = router.add_method_handler(add)
+        assert meth.method_signature() == "add(uint64,uint64)uint64"
 
         @pt.ABIReturnSubroutine
         def sub(
@@ -2211,7 +2213,8 @@ def test_router_app():
         ) -> pt.Expr:
             return output.set(a.get() - b.get())
 
-        router.add_method_handler(sub)
+        meth = router.add_method_handler(sub)
+        assert meth.method_signature() == "sub(uint64,uint64)uint64"
 
         @pt.ABIReturnSubroutine
         def mul(
@@ -2219,7 +2222,8 @@ def test_router_app():
         ) -> pt.Expr:
             return output.set(a.get() * b.get())
 
-        router.add_method_handler(mul)
+        meth = router.add_method_handler(mul)
+        assert meth.method_signature() == "mul(uint64,uint64)uint64"
 
         @pt.ABIReturnSubroutine
         def div(
@@ -2227,7 +2231,8 @@ def test_router_app():
         ) -> pt.Expr:
             return output.set(a.get() / b.get())
 
-        router.add_method_handler(div)
+        meth = router.add_method_handler(div)
+        assert meth.method_signature() == "div(uint64,uint64)uint64"
 
         @pt.ABIReturnSubroutine
         def mod(
@@ -2235,7 +2240,8 @@ def test_router_app():
         ) -> pt.Expr:
             return output.set(a.get() % b.get())
 
-        router.add_method_handler(mod)
+        meth = router.add_method_handler(mod)
+        assert meth.method_signature() == "mod(uint64,uint64)uint64"
 
         @pt.ABIReturnSubroutine
         def all_laid_to_args(
@@ -2277,13 +2283,17 @@ def test_router_app():
                 + _p.get()
             )
 
-        router.add_method_handler(all_laid_to_args)
+        meth = router.add_method_handler(all_laid_to_args)
+        assert (
+            meth.method_signature()
+            == "all_laid_to_args(uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64)uint64"
+        )
 
         @pt.ABIReturnSubroutine
         def empty_return_subroutine() -> pt.Expr:
             return pt.Log(pt.Bytes("appear in both approval and clear state"))
 
-        router.add_method_handler(
+        meth = router.add_method_handler(
             empty_return_subroutine,
             method_config=pt.MethodConfig(
                 no_op=pt.CallConfig.CALL,
@@ -2291,12 +2301,13 @@ def test_router_app():
                 clear_state=pt.CallConfig.CALL,
             ),
         )
+        assert meth.method_signature() == "empty_return_subroutine()void"
 
         @pt.ABIReturnSubroutine
         def log_1(*, output: pt.abi.Uint64) -> pt.Expr:
             return output.set(1)
 
-        router.add_method_handler(
+        meth = router.add_method_handler(
             log_1,
             method_config=pt.MethodConfig(
                 no_op=pt.CallConfig.CALL,
@@ -2305,13 +2316,16 @@ def test_router_app():
             ),
         )
 
+        assert meth.method_signature() == "log_1()uint64"
+
         @pt.ABIReturnSubroutine
         def log_creation(*, output: pt.abi.String) -> pt.Expr:
             return output.set("logging creation")
 
-        router.add_method_handler(
+        meth = router.add_method_handler(
             log_creation, method_config=pt.MethodConfig(no_op=pt.CallConfig.CREATE)
         )
+        assert meth.method_signature() == "log_creation()string"
 
         @pt.ABIReturnSubroutine
         def approve_if_odd(condition_encoding: pt.abi.Uint32) -> pt.Expr:
@@ -2321,12 +2335,13 @@ def test_router_app():
                 .Else(pt.Reject())
             )
 
-        router.add_method_handler(
+        meth = router.add_method_handler(
             approve_if_odd,
             method_config=pt.MethodConfig(
                 no_op=pt.CallConfig.NEVER, clear_state=pt.CallConfig.CALL
             ),
         )
+        assert meth.method_signature() == "approve_if_odd(uint32)void"
 
     on_completion_actions = pt.BareCallActions(
         opt_in=pt.OnCompleteAction.call_only(pt.Log(pt.Bytes("optin call"))),

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -1,4 +1,3 @@
-from pyparsing import empty
 import pytest
 
 import pyteal as pt


### PR DESCRIPTION
If I declare a method like 

```py
@router.method
def thing():
    return Int(1)
```

And I want to get the method selector or signature, I need to filter the `methods` array for those methods with the properties I'm interested in 

```py
thingmethod = list(filter(lambda m: m.name == "thing", router.methods)).pop()
signature = thingmethod.get_signature()
selector = Bytes(thingmethod.get_selector())
```

With this change I can call `thing.method_selector()` directly although the type hinting doesn't work very well.

