### PR TITLE
Support Secp256r1 curve

### DIFF
--- a/pyteal/ast/ecdsa.py
+++ b/pyteal/ast/ecdsa.py
@@ -147,7 +147,7 @@ class EcdsaDecompress(MultiValue):
 
 
 class EcdsaRecover(MultiValue):
-    """Reover an ECDSA public key from a signature.
+    """Recover an ECDSA public key from a signature.
 
     All byte arguments must be big endian encoded.
 

--- a/pyteal/ast/ecdsa_test.py
+++ b/pyteal/ast/ecdsa_test.py
@@ -3,20 +3,19 @@ import pytest
 import pyteal as pt
 
 teal4Options = pt.CompileOptions(version=4)
-teal5Options = pt.CompileOptions(version=5)
+teal7Options = pt.CompileOptions(version=7)
 
 
-def test_ecdsa_decompress():
+@pytest.mark.parametrize("curve", [pt.EcdsaCurve.Secp256k1, pt.EcdsaCurve.Secp256r1])
+def test_ecdsa_decompress(curve: pt.EcdsaCurve):
     compressed_pubkey = pt.Bytes("XY")
-    pubkey = pt.EcdsaDecompress(pt.EcdsaCurve.Secp256k1, compressed_pubkey)
+    pubkey = pt.EcdsaDecompress(curve, compressed_pubkey)
     assert pubkey.type_of() == pt.TealType.none
 
     expected = pt.TealSimpleBlock(
         [
             pt.TealOp(compressed_pubkey, pt.Op.byte, '"XY"'),
-            pt.TealOp(
-                pubkey, pt.Op.ecdsa_pk_decompress, pt.EcdsaCurve.Secp256k1.arg_name
-            ),
+            pt.TealOp(pubkey, pt.Op.ecdsa_pk_decompress, curve.arg_name),
             pt.TealOp(
                 pubkey.output_slots[1].store(), pt.Op.store, pubkey.output_slots[1]
             ),
@@ -26,7 +25,7 @@ def test_ecdsa_decompress():
         ]
     )
 
-    actual, _ = pubkey.__teal__(teal5Options)
+    actual, _ = pubkey.__teal__(teal7Options)
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
@@ -34,14 +33,22 @@ def test_ecdsa_decompress():
         assert actual == expected
 
     # compile without errors this is necessary so assembly is also tested
-    pt.compileTeal(pt.Seq(pubkey, pt.Approve()), pt.Mode.Application, version=5)
-
-
-def test_ecdsa_recover():
-    args = [pt.Bytes("data"), pt.Int(1), pt.Bytes("sigA"), pt.Bytes("sigB")]
-    pubkey = pt.EcdsaRecover(
-        pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], args[3]
+    pt.compileTeal(
+        pt.Seq(pubkey, pt.Approve()), pt.Mode.Application, version=curve.min_version
     )
+
+    with pytest.raises(pt.TealInputError):
+        pt.compileTeal(
+            pt.Seq(pubkey, pt.Approve()),
+            pt.Mode.Application,
+            version=curve.min_version - 1,
+        )
+
+
+@pytest.mark.parametrize("curve", [pt.EcdsaCurve.Secp256k1, pt.EcdsaCurve.Secp256r1])
+def test_ecdsa_recover(curve: pt.EcdsaCurve):
+    args = [pt.Bytes("data"), pt.Int(1), pt.Bytes("sigA"), pt.Bytes("sigB")]
+    pubkey = pt.EcdsaRecover(curve, args[0], args[1], args[2], args[3])
     assert pubkey.type_of() == pt.TealType.none
 
     expected = pt.TealSimpleBlock(
@@ -50,7 +57,7 @@ def test_ecdsa_recover():
             pt.TealOp(args[1], pt.Op.int, 1),
             pt.TealOp(args[2], pt.Op.byte, '"sigA"'),
             pt.TealOp(args[3], pt.Op.byte, '"sigB"'),
-            pt.TealOp(pubkey, pt.Op.ecdsa_pk_recover, pt.EcdsaCurve.Secp256k1.arg_name),
+            pt.TealOp(pubkey, pt.Op.ecdsa_pk_recover, curve.arg_name),
             pt.TealOp(
                 pubkey.output_slots[1].store(), pt.Op.store, pubkey.output_slots[1]
             ),
@@ -60,7 +67,7 @@ def test_ecdsa_recover():
         ]
     )
 
-    actual, _ = pubkey.__teal__(teal5Options)
+    actual, _ = pubkey.__teal__(teal7Options)
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
@@ -68,13 +75,23 @@ def test_ecdsa_recover():
         assert actual == expected
 
     # compile without errors this is necessary so assembly is also tested
-    pt.compileTeal(pt.Seq(pubkey, pt.Approve()), pt.Mode.Application, version=5)
+    pt.compileTeal(
+        pt.Seq(pubkey, pt.Approve()), pt.Mode.Application, version=curve.min_version
+    )
+
+    with pytest.raises(pt.TealInputError):
+        pt.compileTeal(
+            pt.Seq(pubkey, pt.Approve()),
+            pt.Mode.Application,
+            version=curve.min_version - 1,
+        )
 
 
-def test_ecdsa_verify_basic():
+@pytest.mark.parametrize("curve", [pt.EcdsaCurve.Secp256k1, pt.EcdsaCurve.Secp256r1])
+def test_ecdsa_verify_basic(curve: pt.EcdsaCurve):
     args = [pt.Bytes("data"), pt.Bytes("sigA"), pt.Bytes("sigB")]
     pubkey = (pt.Bytes("X"), pt.Bytes("Y"))
-    expr = pt.EcdsaVerify(pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], pubkey)
+    expr = pt.EcdsaVerify(curve, args[0], args[1], args[2], pubkey)
     assert expr.type_of() == pt.TealType.uint64
 
     expected = pt.TealSimpleBlock(
@@ -84,33 +101,43 @@ def test_ecdsa_verify_basic():
             pt.TealOp(args[2], pt.Op.byte, '"sigB"'),
             pt.TealOp(pubkey[0], pt.Op.byte, '"X"'),
             pt.TealOp(pubkey[1], pt.Op.byte, '"Y"'),
-            pt.TealOp(expr, pt.Op.ecdsa_verify, pt.EcdsaCurve.Secp256k1.arg_name),
+            pt.TealOp(expr, pt.Op.ecdsa_verify, curve.arg_name),
         ]
     )
 
-    actual, _ = expr.__teal__(teal5Options)
+    actual, _ = expr.__teal__(teal7Options)
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
     assert actual == expected
 
     # compile without errors this is necessary so assembly is also tested
-    pt.compileTeal(pt.Seq(pt.Pop(expr), pt.Approve()), pt.Mode.Application, version=5)
+    pt.compileTeal(
+        pt.Seq(pt.Pop(expr), pt.Approve()),
+        pt.Mode.Application,
+        version=curve.min_version,
+    )
+
+    with pytest.raises(pt.TealInputError):
+        pt.compileTeal(
+            pt.Seq(pt.Pop(expr), pt.Approve()),
+            pt.Mode.Application,
+            version=curve.min_version - 1,
+        )
 
 
-def test_ecdsa_verify_compressed_pk():
+@pytest.mark.parametrize("curve", [pt.EcdsaCurve.Secp256k1, pt.EcdsaCurve.Secp256r1])
+def test_ecdsa_verify_compressed_pk(curve: pt.EcdsaCurve):
     args = [pt.Bytes("data"), pt.Bytes("sigA"), pt.Bytes("sigB")]
     compressed_pubkey = pt.Bytes("XY")
-    pubkey = pt.EcdsaDecompress(pt.EcdsaCurve.Secp256k1, compressed_pubkey)
-    expr = pt.EcdsaVerify(pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], pubkey)
+    pubkey = pt.EcdsaDecompress(curve, compressed_pubkey)
+    expr = pt.EcdsaVerify(curve, args[0], args[1], args[2], pubkey)
     assert expr.type_of() == pt.TealType.uint64
 
     expected = pt.TealSimpleBlock(
         [
             pt.TealOp(compressed_pubkey, pt.Op.byte, '"XY"'),
-            pt.TealOp(
-                pubkey, pt.Op.ecdsa_pk_decompress, pt.EcdsaCurve.Secp256k1.arg_name
-            ),
+            pt.TealOp(pubkey, pt.Op.ecdsa_pk_decompress, curve.arg_name),
             pt.TealOp(
                 pubkey.output_slots[1].store(), pt.Op.store, pubkey.output_slots[1]
             ),
@@ -126,11 +153,11 @@ def test_ecdsa_verify_compressed_pk():
             pt.TealOp(
                 pubkey.output_slots[1].load(), pt.Op.load, pubkey.output_slots[1]
             ),
-            pt.TealOp(expr, pt.Op.ecdsa_verify, pt.EcdsaCurve.Secp256k1.arg_name),
+            pt.TealOp(expr, pt.Op.ecdsa_verify, curve.arg_name),
         ]
     )
 
-    actual, _ = expr.__teal__(teal5Options)
+    actual, _ = expr.__teal__(teal7Options)
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
@@ -138,15 +165,25 @@ def test_ecdsa_verify_compressed_pk():
         assert actual == expected
 
     # compile without errors this is necessary so assembly is also tested
-    pt.compileTeal(pt.Seq(pt.Pop(expr), pt.Approve()), pt.Mode.Application, version=5)
-
-
-def test_ecdsa_verify_recovered_pk():
-    args = [pt.Bytes("data"), pt.Int(1), pt.Bytes("sigA"), pt.Bytes("sigB")]
-    pubkey = pt.EcdsaRecover(
-        pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], args[3]
+    pt.compileTeal(
+        pt.Seq(pt.Pop(expr), pt.Approve()),
+        pt.Mode.Application,
+        version=curve.min_version,
     )
-    expr = pt.EcdsaVerify(pt.EcdsaCurve.Secp256k1, args[0], args[2], args[3], pubkey)
+
+    with pytest.raises(pt.TealInputError):
+        pt.compileTeal(
+            pt.Seq(pt.Pop(expr), pt.Approve()),
+            pt.Mode.Application,
+            version=curve.min_version - 1,
+        )
+
+
+@pytest.mark.parametrize("curve", [pt.EcdsaCurve.Secp256k1, pt.EcdsaCurve.Secp256r1])
+def test_ecdsa_verify_recovered_pk(curve: pt.EcdsaCurve):
+    args = [pt.Bytes("data"), pt.Int(1), pt.Bytes("sigA"), pt.Bytes("sigB")]
+    pubkey = pt.EcdsaRecover(curve, args[0], args[1], args[2], args[3])
+    expr = pt.EcdsaVerify(curve, args[0], args[2], args[3], pubkey)
     assert expr.type_of() == pt.TealType.uint64
 
     expected = pt.TealSimpleBlock(
@@ -155,7 +192,7 @@ def test_ecdsa_verify_recovered_pk():
             pt.TealOp(args[1], pt.Op.int, 1),
             pt.TealOp(args[2], pt.Op.byte, '"sigA"'),
             pt.TealOp(args[3], pt.Op.byte, '"sigB"'),
-            pt.TealOp(pubkey, pt.Op.ecdsa_pk_recover, pt.EcdsaCurve.Secp256k1.arg_name),
+            pt.TealOp(pubkey, pt.Op.ecdsa_pk_recover, curve.arg_name),
             pt.TealOp(
                 pubkey.output_slots[1].store(), pt.Op.store, pubkey.output_slots[1]
             ),
@@ -171,11 +208,11 @@ def test_ecdsa_verify_recovered_pk():
             pt.TealOp(
                 pubkey.output_slots[1].load(), pt.Op.load, pubkey.output_slots[1]
             ),
-            pt.TealOp(expr, pt.Op.ecdsa_verify, pt.EcdsaCurve.Secp256k1.arg_name),
+            pt.TealOp(expr, pt.Op.ecdsa_verify, curve.arg_name),
         ]
     )
 
-    actual, _ = expr.__teal__(teal5Options)
+    actual, _ = expr.__teal__(teal7Options)
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
@@ -183,26 +220,38 @@ def test_ecdsa_verify_recovered_pk():
         assert actual == expected
 
     # compile without errors this is necessary so assembly is also tested
-    pt.compileTeal(pt.Seq(pt.Pop(expr), pt.Approve()), pt.Mode.Application, version=5)
+    pt.compileTeal(
+        pt.Seq(pt.Pop(expr), pt.Approve()),
+        pt.Mode.Application,
+        version=curve.min_version,
+    )
+
+    with pytest.raises(pt.TealInputError):
+        pt.compileTeal(
+            pt.Seq(pt.Pop(expr), pt.Approve()),
+            pt.Mode.Application,
+            version=curve.min_version - 1,
+        )
 
 
-def test_ecdsa_invalid():
+@pytest.mark.parametrize("curve", [pt.EcdsaCurve.Secp256k1, pt.EcdsaCurve.Secp256r1])
+def test_ecdsa_invalid(curve: pt.EcdsaCurve):
     with pytest.raises(pt.TealTypeError):
         args = [pt.Bytes("data"), pt.Bytes("1"), pt.Bytes("sigA"), pt.Bytes("sigB")]
-        pt.EcdsaRecover(pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], args[3])
+        pt.EcdsaRecover(curve, args[0], args[1], args[2], args[3])
 
     with pytest.raises(pt.TealTypeError):
-        pt.EcdsaDecompress(pt.EcdsaCurve.Secp256k1, pt.Int(1))
+        pt.EcdsaDecompress(curve, pt.Int(1))
 
     with pytest.raises(pt.TealTypeError):
         args = [pt.Bytes("data"), pt.Bytes("sigA"), pt.Bytes("sigB")]
         pubkey = (pt.Bytes("X"), pt.Int(1))
-        pt.EcdsaVerify(pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], pubkey)
+        pt.EcdsaVerify(curve, args[0], args[1], args[2], pubkey)
 
     with pytest.raises(pt.TealTypeError):
         args = [pt.Bytes("data"), pt.Int(1), pt.Bytes("sigB")]
         pubkey = (pt.Bytes("X"), pt.Bytes("Y"))
-        pt.EcdsaVerify(pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], pubkey)
+        pt.EcdsaVerify(curve, args[0], args[1], args[2], pubkey)
 
     with pytest.raises(pt.TealTypeError):
         args = [pt.Bytes("data"), pt.Bytes("sigA"), pt.Bytes("sigB")]
@@ -210,17 +259,15 @@ def test_ecdsa_invalid():
         pubkey = pt.MultiValue(
             pt.Op.ecdsa_pk_decompress,
             [pt.TealType.uint64, pt.TealType.bytes],
-            immediate_args=[pt.EcdsaCurve.Secp256k1],
+            immediate_args=[curve],
             args=[compressed_pk],
         )
-        pt.EcdsaVerify(pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], pubkey)
+        pt.EcdsaVerify(curve, args[0], args[1], args[2], pubkey)
 
     with pytest.raises(pt.TealInputError):
         args = [pt.Bytes("data"), pt.Bytes("sigA"), pt.Bytes("sigB")]
         pubkey = (pt.Bytes("X"), pt.Bytes("Y"))
-        expr = pt.EcdsaVerify(
-            pt.EcdsaCurve.Secp256k1, args[0], args[1], args[2], pubkey
-        )
+        expr = pt.EcdsaVerify(curve, args[0], args[1], args[2], pubkey)
 
         expr.__teal__(teal4Options)
 

--- a/pyteal/ast/ecdsa_test.py
+++ b/pyteal/ast/ecdsa_test.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Union, List, cast
 
 import pyteal as pt
 
@@ -237,7 +238,12 @@ def test_ecdsa_verify_recovered_pk(curve: pt.EcdsaCurve):
 @pytest.mark.parametrize("curve", [pt.EcdsaCurve.Secp256k1, pt.EcdsaCurve.Secp256r1])
 def test_ecdsa_invalid(curve: pt.EcdsaCurve):
     with pytest.raises(pt.TealTypeError):
-        args = [pt.Bytes("data"), pt.Bytes("1"), pt.Bytes("sigA"), pt.Bytes("sigB")]
+        args: List[Union[pt.Bytes, pt.Int]] = [
+            pt.Bytes("data"),
+            pt.Bytes("1"),
+            pt.Bytes("sigA"),
+            pt.Bytes("sigB"),
+        ]
         pt.EcdsaRecover(curve, args[0], args[1], args[2], args[3])
 
     with pytest.raises(pt.TealTypeError):
@@ -245,7 +251,10 @@ def test_ecdsa_invalid(curve: pt.EcdsaCurve):
 
     with pytest.raises(pt.TealTypeError):
         args = [pt.Bytes("data"), pt.Bytes("sigA"), pt.Bytes("sigB")]
-        pubkey = (pt.Bytes("X"), pt.Int(1))
+        pubkey: Union[tuple[pt.Bytes, Union[pt.Int, pt.Bytes]], pt.MultiValue] = (
+            pt.Bytes("X"),
+            pt.Int(1),
+        )
         pt.EcdsaVerify(curve, args[0], args[1], args[2], pubkey)
 
     with pytest.raises(pt.TealTypeError):
@@ -259,7 +268,7 @@ def test_ecdsa_invalid(curve: pt.EcdsaCurve):
         pubkey = pt.MultiValue(
             pt.Op.ecdsa_pk_decompress,
             [pt.TealType.uint64, pt.TealType.bytes],
-            immediate_args=[curve],
+            immediate_args=[curve.__str__()],
             args=[compressed_pk],
         )
         pt.EcdsaVerify(curve, args[0], args[1], args[2], pubkey)
@@ -274,4 +283,4 @@ def test_ecdsa_invalid(curve: pt.EcdsaCurve):
     with pytest.raises(pt.TealTypeError):
         args = [pt.Bytes("data"), pt.Bytes("sigA"), pt.Bytes("sigB")]
         pubkey = (pt.Bytes("X"), pt.Bytes("Y"))
-        expr = pt.EcdsaVerify(5, args[0], args[1], args[2], pubkey)
+        expr = pt.EcdsaVerify(cast(pt.EcdsaCurve, 5), args[0], args[1], args[2], pubkey)

--- a/pyteal/ast/ecdsa_test.py
+++ b/pyteal/ast/ecdsa_test.py
@@ -4,7 +4,13 @@ from typing import Union, List, cast
 import pyteal as pt
 
 teal4Options = pt.CompileOptions(version=4)
+teal5Options = pt.CompileOptions(version=5)
 teal7Options = pt.CompileOptions(version=7)
+
+curve_options_map = {
+    pt.EcdsaCurve.Secp256k1: teal5Options,
+    pt.EcdsaCurve.Secp256r1: teal7Options,
+}
 
 
 @pytest.mark.parametrize("curve", [pt.EcdsaCurve.Secp256k1, pt.EcdsaCurve.Secp256r1])
@@ -26,7 +32,7 @@ def test_ecdsa_decompress(curve: pt.EcdsaCurve):
         ]
     )
 
-    actual, _ = pubkey.__teal__(teal7Options)
+    actual, _ = pubkey.__teal__(curve_options_map[curve])
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
@@ -68,7 +74,7 @@ def test_ecdsa_recover(curve: pt.EcdsaCurve):
         ]
     )
 
-    actual, _ = pubkey.__teal__(teal7Options)
+    actual, _ = pubkey.__teal__(curve_options_map[curve])
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
@@ -106,7 +112,7 @@ def test_ecdsa_verify_basic(curve: pt.EcdsaCurve):
         ]
     )
 
-    actual, _ = expr.__teal__(teal7Options)
+    actual, _ = expr.__teal__(curve_options_map[curve])
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
@@ -158,7 +164,7 @@ def test_ecdsa_verify_compressed_pk(curve: pt.EcdsaCurve):
         ]
     )
 
-    actual, _ = expr.__teal__(teal7Options)
+    actual, _ = expr.__teal__(curve_options_map[curve])
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
@@ -213,7 +219,7 @@ def test_ecdsa_verify_recovered_pk(curve: pt.EcdsaCurve):
         ]
     )
 
-    actual, _ = expr.__teal__(teal7Options)
+    actual, _ = expr.__teal__(curve_options_map[curve])
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
 

--- a/pyteal/ast/multi.py
+++ b/pyteal/ast/multi.py
@@ -20,7 +20,8 @@ class MultiValue(LeafExpr):
         types: List[TealType],
         *,
         immediate_args: List[Union[int, str]] = None,
-        args: List[Expr] = None
+        args: List[Expr] = None,
+        compile_check: Callable[["CompileOptions"], None] = lambda _: None,
     ):
         """Create a new MultiValue.
 
@@ -35,6 +36,7 @@ class MultiValue(LeafExpr):
         self.types = types
         self.immediate_args = immediate_args if immediate_args is not None else []
         self.args = args if args is not None else []
+        self.compile_check = compile_check
 
         self.output_slots = [ScratchSlot() for _ in self.types]
 
@@ -57,6 +59,8 @@ class MultiValue(LeafExpr):
         return ret_str
 
     def __teal__(self, options: "CompileOptions"):
+        self.compile_check(options)
+
         tealOp = TealOp(self, self.op, *self.immediate_args)
         callStart, callEnd = TealBlock.FromOp(options, tealOp, *self.args)
 

--- a/pyteal/ast/multi_test.py
+++ b/pyteal/ast/multi_test.py
@@ -1,3 +1,4 @@
+import pytest
 from typing import List
 
 import pyteal as pt
@@ -147,47 +148,70 @@ def __test_single_with_vars(
         assert actual == expected
 
 
-def test_multi_value():
-    ops = (
+@pytest.mark.parametrize(
+    "op",
+    [
         pt.Op.app_global_get_ex,
         pt.Op.app_local_get_ex,
         pt.Op.asset_holding_get,
         pt.Op.asset_params_get,
+    ],
+)
+@pytest.mark.parametrize(
+    "type", [pt.TealType.uint64, pt.TealType.bytes, pt.TealType.anytype]
+)
+@pytest.mark.parametrize("iargs", [[], ["AssetFrozen"]])
+@pytest.mark.parametrize("args", [[], [pt.Int(0)], [pt.Int(1), pt.Int(2)]])
+def test_multi_value(op, type, iargs, args):
+    reducer = (
+        lambda value, hasValue: pt.If(hasValue)
+        .Then(value)
+        .Else(pt.App.globalGet(pt.Bytes("None")))
     )
-    types = (pt.TealType.uint64, pt.TealType.bytes, pt.TealType.anytype)
-    immedate_argv = ([], ["AssetFrozen"])
-    argv = ([], [pt.Int(0)], [pt.Int(1), pt.Int(2)])
+    expr = pt.MultiValue(
+        op, [type, pt.TealType.uint64], immediate_args=iargs, args=args
+    )
+    __test_single_conditional(expr, op, args, iargs, reducer)
 
-    for op in ops:
-        for type in types:
-            for iargs in immedate_argv:
-                for args in argv:
-                    reducer = (
-                        lambda value, hasValue: pt.If(hasValue)
-                        .Then(value)
-                        .Else(pt.App.globalGet(pt.Bytes("None")))
-                    )
-                    expr = pt.MultiValue(
-                        op, [type, pt.TealType.uint64], immediate_args=iargs, args=args
-                    )
-                    __test_single_conditional(expr, op, args, iargs, reducer)
+    reducer = lambda value, hasValue: pt.Seq(pt.Assert(hasValue), value)  # noqa: E731
+    expr = pt.MultiValue(
+        op, [type, pt.TealType.uint64], immediate_args=iargs, args=args
+    )
+    __test_single_assert(expr, op, args, iargs, reducer)
 
-                    reducer = lambda value, hasValue: pt.Seq(  # noqa: E731
-                        pt.Assert(hasValue), value
-                    )
-                    expr = pt.MultiValue(
-                        op, [type, pt.TealType.uint64], immediate_args=iargs, args=args
-                    )
-                    __test_single_assert(expr, op, args, iargs, reducer)
+    hasValueVar = pt.ScratchVar(pt.TealType.uint64)
+    valueVar = pt.ScratchVar(type)
+    reducer = lambda value, hasValue: pt.Seq(  # noqa: E731
+        hasValueVar.store(hasValue), valueVar.store(value)
+    )
+    expr = pt.MultiValue(
+        op, [type, pt.TealType.uint64], immediate_args=iargs, args=args
+    )
+    __test_single_with_vars(expr, op, args, iargs, hasValueVar, valueVar, reducer)
 
-                    hasValueVar = pt.ScratchVar(pt.TealType.uint64)
-                    valueVar = pt.ScratchVar(type)
-                    reducer = lambda value, hasValue: pt.Seq(  # noqa: E731
-                        hasValueVar.store(hasValue), valueVar.store(value)
-                    )
-                    expr = pt.MultiValue(
-                        op, [type, pt.TealType.uint64], immediate_args=iargs, args=args
-                    )
-                    __test_single_with_vars(
-                        expr, op, args, iargs, hasValueVar, valueVar, reducer
-                    )
+
+def test_multi_compile_check():
+    def never_fails(options):
+        return
+
+    program_never_fails = pt.MultiValue(
+        pt.Op.app_global_get_ex,
+        [pt.TealType.uint64, pt.TealType.uint64],
+        compile_check=never_fails,
+    )
+    program_never_fails.__teal__(options)
+
+    class TestException(Exception):
+        pass
+
+    def always_fails(options):
+        raise TestException()
+
+    program_always_fails = pt.MultiValue(
+        pt.Op.app_global_get_ex,
+        [pt.TealType.uint64, pt.TealType.uint64],
+        compile_check=always_fails,
+    )
+
+    with pytest.raises(TestException):
+        program_always_fails.__teal__(options)


### PR DESCRIPTION
This PR adds the `Secp256r1` curve available in AVM 7.

* Converted `EcdsaDecompress` and `EcdsaRecover` to classes so that field version checking was possible.