### PR TITLE
Support `FirstValidTime` transaction field

### DIFF
--- a/docs/accessing_transaction_field.rst
+++ b/docs/accessing_transaction_field.rst
@@ -27,6 +27,7 @@ Operator                                                                        
 :any:`Txn.sender() <TxnObject.sender>`                                           :code:`TealType.bytes`    2                32 byte address
 :any:`Txn.fee() <TxnObject.fee>`                                                 :code:`TealType.uint64`   2                in microAlgos
 :any:`Txn.first_valid() <TxnObject.first_valid>`                                 :code:`TealType.uint64`   2                round number
+:any:`Txn.first_valid_time() <TxnObject.first_valid_time>`                       :code:`TealType.uint64`   7                UNIX timestamp of block before :code:`Txn.first_valid()`. Fails if negative
 :any:`Txn.last_valid() <TxnObject.last_valid>`                                   :code:`TealType.uint64`   2                round number
 :any:`Txn.note() <TxnObject.note>`                                               :code:`TealType.bytes`    2                transaction note in bytes
 :any:`Txn.lease() <TxnObject.lease>`                                             :code:`TealType.bytes`    2                transaction lease in bytes

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -304,8 +304,8 @@ class TxnObject:
         return self.makeTxnExpr(TxnField.first_valid)
 
     def first_valid_time(self) -> TxnExpr:
-        """Get the UNIX timestamp of block before txn.FirstValid. Fails if negative
-        
+        """Get the UNIX timestamp of block before txn.FirstValid. Fails if negative.
+
         For more information, see https://developer.algorand.org/docs/reference/transactions/#firstvalidtime
         """
         return self.makeTxnExpr(TxnField.first_valid_time)

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -37,7 +37,7 @@ class TxnField(Enum):
     sender = (0, "Sender", TealType.bytes, False, 2)
     fee = (1, "Fee", TealType.uint64, False, 2)
     first_valid = (2, "FirstValid", TealType.uint64, False, 2)
-    first_valid_time = (3, "FirstValidTime", TealType.uint64, False, 2)
+    first_valid_time = (3, "FirstValidTime", TealType.uint64, False, 7)
     last_valid = (4, "LastValid", TealType.uint64, False, 2)
     note = (5, "Note", TealType.bytes, False, 2)
     lease = (6, "Lease", TealType.bytes, False, 2)
@@ -302,6 +302,13 @@ class TxnObject:
         For more information, see https://developer.algorand.org/docs/reference/transactions/#firstvalid
         """
         return self.makeTxnExpr(TxnField.first_valid)
+
+    def first_valid_time(self) -> TxnExpr:
+        """Get the UNIX timestamp of block before txn.FirstValid. Fails if negative
+        
+        For more information, see https://developer.algorand.org/docs/reference/transactions/#firstvalidtime
+        """
+        return self.makeTxnExpr(TxnField.first_valid_time)
 
     def last_valid(self) -> TxnExpr:
         """Get the last valid round number.

--- a/pyteal/ast/txn_test.py
+++ b/pyteal/ast/txn_test.py
@@ -8,6 +8,7 @@ fieldToMethod: Dict[pt.TxnField, Callable[[pt.TxnObject], pt.Expr]] = {
     pt.TxnField.sender: lambda txn: txn.sender(),
     pt.TxnField.fee: lambda txn: txn.fee(),
     pt.TxnField.first_valid: lambda txn: txn.first_valid(),
+    pt.TxnField.first_valid_time: lambda txn: txn.first_valid_time(),
     pt.TxnField.last_valid: lambda txn: txn.last_valid(),
     pt.TxnField.note: lambda txn: txn.note(),
     pt.TxnField.lease: lambda txn: txn.lease(),


### PR DESCRIPTION
This PR adds necessary components to allow accessing the first valid time transaction field property.