### PR TITLE
Check transaction type arguments

### DIFF
--- a/pyteal/ast/abi/transaction.py
+++ b/pyteal/ast/abi/transaction.py
@@ -3,10 +3,10 @@ from typing import TypeVar, Union, cast, List, Final
 from pyteal.ast.abi.type import BaseType, ComputedValue, TypeSpec
 from pyteal.ast.expr import Expr
 from pyteal.ast.int import Int
-from pyteal.ast.txn import TxnObject
+from pyteal.ast.txn import TxnObject, TxnType
 from pyteal.ast.gtxn import Gtxn
 from pyteal.types import TealType
-from pyteal.errors import TealInputError
+from pyteal.errors import TealInputError, TealInternalError
 
 T = TypeVar("T", bound=BaseType)
 
@@ -42,6 +42,17 @@ class TransactionTypeSpec(TypeSpec):
 
     def storage_type(self) -> TealType:
         return TealType.uint64
+
+    def txn_type_enum(self) -> Expr:
+        """Get the integer transaction type value this TransactionTypeSpec represents.
+
+        See :any:`TxnType` for the complete list.
+
+        If this is a generic TransactionTypeSpec, i.e. type :code:`txn`, this method will raise an error, since this type does not represent a single transaction type.
+        """
+        raise TealInternalError(
+            "abi.TransactionTypeSpec does not represent a specific transaction type"
+        )
 
     def __eq__(self, other: object) -> bool:
         return type(self) is type(other)
@@ -106,6 +117,9 @@ class PaymentTransactionTypeSpec(TransactionTypeSpec):
     def annotation_type(self) -> "type[PaymentTransaction]":
         return PaymentTransaction
 
+    def txn_type_enum(self) -> Expr:
+        return TxnType.Payment
+
     def __str__(self) -> str:
         return TransactionType.Payment.value
 
@@ -127,6 +141,9 @@ class KeyRegisterTransactionTypeSpec(TransactionTypeSpec):
 
     def annotation_type(self) -> "type[KeyRegisterTransaction]":
         return KeyRegisterTransaction
+
+    def txn_type_enum(self) -> Expr:
+        return TxnType.KeyRegistration
 
     def __str__(self) -> str:
         return TransactionType.KeyRegistration.value
@@ -150,6 +167,9 @@ class AssetConfigTransactionTypeSpec(TransactionTypeSpec):
     def annotation_type(self) -> "type[AssetConfigTransaction]":
         return AssetConfigTransaction
 
+    def txn_type_enum(self) -> Expr:
+        return TxnType.AssetConfig
+
     def __str__(self) -> str:
         return TransactionType.AssetConfig.value
 
@@ -171,6 +191,9 @@ class AssetFreezeTransactionTypeSpec(TransactionTypeSpec):
 
     def annotation_type(self) -> "type[AssetFreezeTransaction]":
         return AssetFreezeTransaction
+
+    def txn_type_enum(self) -> Expr:
+        return TxnType.AssetFreeze
 
     def __str__(self) -> str:
         return TransactionType.AssetFreeze.value
@@ -194,6 +217,9 @@ class AssetTransferTransactionTypeSpec(TransactionTypeSpec):
     def annotation_type(self) -> "type[AssetTransferTransaction]":
         return AssetTransferTransaction
 
+    def txn_type_enum(self) -> Expr:
+        return TxnType.AssetTransfer
+
     def __str__(self) -> str:
         return TransactionType.AssetTransfer.value
 
@@ -215,6 +241,9 @@ class ApplicationCallTransactionTypeSpec(TransactionTypeSpec):
 
     def annotation_type(self) -> "type[ApplicationCallTransaction]":
         return ApplicationCallTransaction
+
+    def txn_type_enum(self) -> Expr:
+        return TxnType.ApplicationCall
 
     def __str__(self) -> str:
         return TransactionType.ApplicationCall.value

--- a/pyteal/ast/abi/transaction.py
+++ b/pyteal/ast/abi/transaction.py
@@ -77,7 +77,9 @@ class Transaction(BaseType):
     def get(self) -> TxnObject:
         return Gtxn[self.index()]
 
-    def set(self: T, value: Union[int, Expr, "Transaction", ComputedValue[T]]) -> Expr:
+    def _set_index(
+        self: T, value: Union[int, Expr, "Transaction", ComputedValue[T]]
+    ) -> Expr:
         match value:
             case ComputedValue():
                 return self._set_with_computed_type(value)

--- a/pyteal/ast/abi/transaction_test.py
+++ b/pyteal/ast/abi/transaction_test.py
@@ -14,29 +14,46 @@ class TransactionTypeTest:
     ts: abi.TransactionTypeSpec
     t: abi.Transaction
     s: str
+    txn_type_enum: pt.Expr | None
 
 
 TransactionValues: List[TransactionTypeTest] = [
-    TransactionTypeTest(abi.TransactionTypeSpec(), abi.Transaction(), "txn"),
+    TransactionTypeTest(abi.TransactionTypeSpec(), abi.Transaction(), "txn", None),
     TransactionTypeTest(
-        abi.KeyRegisterTransactionTypeSpec(), abi.KeyRegisterTransaction(), "keyreg"
+        abi.KeyRegisterTransactionTypeSpec(),
+        abi.KeyRegisterTransaction(),
+        "keyreg",
+        pt.TxnType.KeyRegistration,
     ),
     TransactionTypeTest(
-        abi.PaymentTransactionTypeSpec(), abi.PaymentTransaction(), "pay"
+        abi.PaymentTransactionTypeSpec(),
+        abi.PaymentTransaction(),
+        "pay",
+        pt.TxnType.Payment,
     ),
     TransactionTypeTest(
-        abi.AssetConfigTransactionTypeSpec(), abi.AssetConfigTransaction(), "acfg"
+        abi.AssetConfigTransactionTypeSpec(),
+        abi.AssetConfigTransaction(),
+        "acfg",
+        pt.TxnType.AssetConfig,
     ),
     TransactionTypeTest(
-        abi.AssetFreezeTransactionTypeSpec(), abi.AssetFreezeTransaction(), "afrz"
+        abi.AssetFreezeTransactionTypeSpec(),
+        abi.AssetFreezeTransaction(),
+        "afrz",
+        pt.TxnType.AssetFreeze,
     ),
     TransactionTypeTest(
-        abi.AssetTransferTransactionTypeSpec(), abi.AssetTransferTransaction(), "axfer"
+        abi.AssetTransferTransactionTypeSpec(),
+        abi.AssetTransferTransaction(),
+        "axfer",
+        pt.TxnType.AssetTransfer,
     ),
     TransactionTypeTest(
         abi.ApplicationCallTransactionTypeSpec(),
         abi.ApplicationCallTransaction(),
         "appl",
+        pt.TxnType.ApplicationCall,
     ),
 ]
 
@@ -54,6 +71,18 @@ def test_TransactionTypeSpec_is_dynamic():
 def test_TransactionTypeSpec_new_instance():
     for tv in TransactionValues:
         assert isinstance(tv.ts.new_instance(), abi.Transaction)
+
+
+def test_TransactionTypeSpec_txn_type_enum():
+    for tv in TransactionValues:
+        if tv.txn_type_enum is None:
+            with pytest.raises(
+                pt.TealInternalError,
+                match=r"abi.TransactionTypeSpec does not represent a specific transaction type$",
+            ):
+                tv.ts.txn_type_enum()
+        else:
+            assert tv.ts.txn_type_enum() is tv.txn_type_enum
 
 
 def test_TransactionTypeSpec_eq():

--- a/pyteal/ast/abi/transaction_test.py
+++ b/pyteal/ast/abi/transaction_test.py
@@ -120,10 +120,10 @@ def test_Transaction_get():
         assert isinstance(expr, pt.TxnObject)
 
 
-def test_Transaction_set():
+def test_Transaction__set_index():
     for tv in TransactionValues:
         val_to_set = 2
-        expr = tv.t.set(val_to_set)
+        expr = tv.t._set_index(val_to_set)
 
         assert expr.type_of() == pt.TealType.none
         assert expr.has_return() is False

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -417,7 +417,7 @@ class ASTBuilder:
 
                 for idx, arg_val in enumerate(txn_arg_vals):
                     txn_decode_instructions.append(
-                        arg_val.set(Txn.group_index() - Int(txn_arg_len - idx))
+                        arg_val._set_index(Txn.group_index() - Int(txn_arg_len - idx))
                     )
                     spec = arg_val.type_spec()
                     if type(spec) is not abi.TransactionTypeSpec:

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -23,8 +23,8 @@ from pyteal.ast.subroutine import (
 from pyteal.ast.assert_ import Assert
 from pyteal.ast.cond import Cond
 from pyteal.ast.expr import Expr
-from pyteal.ast.app import OnComplete, EnumInt
-from pyteal.ast.int import Int
+from pyteal.ast.app import OnComplete
+from pyteal.ast.int import Int, EnumInt
 from pyteal.ast.seq import Seq
 from pyteal.ast.methodsig import MethodSignature
 from pyteal.ast.naryexpr import And, Or
@@ -374,7 +374,7 @@ class ASTBuilder:
             tuplify = len(app_arg_vals) > METHOD_ARG_NUM_CUTOFF
 
             # only transaction args (these are omitted from app args)
-            txn_arg_vals: list[abi.BaseType] = [
+            txn_arg_vals: list[abi.Transaction] = [
                 ats for ats in arg_vals if isinstance(ats, abi.Transaction)
             ]
 
@@ -413,12 +413,18 @@ class ASTBuilder:
                 # and subtract that from the current index to get the absolute position
                 # in the group
 
-                txn_decode_instructions: list[Expr] = [
-                    cast(abi.Transaction, arg_val).set(
-                        Txn.group_index() - Int(txn_arg_len - idx)
+                txn_decode_instructions: list[Expr] = []
+
+                for idx, arg_val in enumerate(txn_arg_vals):
+                    txn_decode_instructions.append(
+                        arg_val.set(Txn.group_index() - Int(txn_arg_len - idx))
                     )
-                    for idx, arg_val in enumerate(txn_arg_vals)
-                ]
+                    spec = arg_val.type_spec()
+                    if type(spec) is not abi.TransactionTypeSpec:
+                        # this is a specific transaction type
+                        txn_decode_instructions.append(
+                            Assert(arg_val.get().type_enum() == spec.txn_type_enum())
+                        )
 
                 decode_instructions += txn_decode_instructions
 

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -501,7 +501,9 @@ def test_wrap_handler_method_call():
         if len(txn_args) > 0:
             for idx, txn_arg in enumerate(txn_args):
                 loading.append(
-                    txn_arg.set(pt.Txn.group_index() - pt.Int(len(txn_args) - idx))
+                    txn_arg._set_index(
+                        pt.Txn.group_index() - pt.Int(len(txn_args) - idx)
+                    )
                 )
                 if str(txn_arg.type_spec()) != "txn":
                     loading.append(
@@ -551,13 +553,13 @@ def test_wrap_handler_method_txn_types():
     ]
     output_temp = pt.abi.Uint64()
     expected_ast = pt.Seq(
-        args[0].set(pt.Txn.group_index() - pt.Int(4)),
+        args[0]._set_index(pt.Txn.group_index() - pt.Int(4)),
         pt.Assert(args[0].get().type_enum() == pt.TxnType.ApplicationCall),
-        args[1].set(pt.Txn.group_index() - pt.Int(3)),
+        args[1]._set_index(pt.Txn.group_index() - pt.Int(3)),
         pt.Assert(args[1].get().type_enum() == pt.TxnType.AssetTransfer),
-        args[2].set(pt.Txn.group_index() - pt.Int(2)),
+        args[2]._set_index(pt.Txn.group_index() - pt.Int(2)),
         pt.Assert(args[2].get().type_enum() == pt.TxnType.Payment),
-        args[3].set(pt.Txn.group_index() - pt.Int(1)),
+        args[3]._set_index(pt.Txn.group_index() - pt.Int(1)),
         multiple_txn(*args).store_into(output_temp),
         pt.abi.MethodReturn(output_temp),
         pt.Approve(),

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -162,10 +162,13 @@ def multiple_txn(
     appl: pt.abi.ApplicationCallTransaction,
     axfer: pt.abi.AssetTransferTransaction,
     pay: pt.abi.PaymentTransaction,
+    any_txn: pt.abi.Transaction,
     *,
     output: pt.abi.Uint64,
 ):
-    return output.set(appl.get().fee() + axfer.get().fee() + pay.get().fee())
+    return output.set(
+        appl.get().fee() + axfer.get().fee() + pay.get().fee() + any_txn.get().fee()
+    )
 
 
 GOOD_SUBROUTINE_CASES: list[pt.ABIReturnSubroutine | pt.SubroutineFnWrapper] = [
@@ -470,7 +473,7 @@ def test_wrap_handler_method_call():
 
         app_arg_cnt = len(app_args)
 
-        txn_args = [
+        txn_args: list[pt.abi.Transaction] = [
             arg for arg in args if arg.type_spec() in pt.abi.TransactionTypeSpecs
         ]
 
@@ -496,14 +499,17 @@ def test_wrap_handler_method_call():
             ]
 
         if len(txn_args) > 0:
-            loading.extend(
-                [
-                    typing.cast(pt.abi.Transaction, txn_arg).set(
-                        pt.Txn.group_index() - pt.Int(len(txn_args) - idx)
+            for idx, txn_arg in enumerate(txn_args):
+                loading.append(
+                    txn_arg.set(pt.Txn.group_index() - pt.Int(len(txn_args) - idx))
+                )
+                if str(txn_arg.type_spec()) != "txn":
+                    loading.append(
+                        pt.Assert(
+                            txn_arg.get().type_enum()
+                            == txn_arg.type_spec().txn_type_enum()
+                        )
                     )
-                    for idx, txn_arg in enumerate(txn_args)
-                ]
-            )
 
         if app_arg_cnt > pt.METHOD_ARG_NUM_CUTOFF:
             loading.extend(
@@ -541,12 +547,17 @@ def test_wrap_handler_method_txn_types():
         pt.abi.ApplicationCallTransaction(),
         pt.abi.AssetTransferTransaction(),
         pt.abi.PaymentTransaction(),
+        pt.abi.Transaction(),
     ]
     output_temp = pt.abi.Uint64()
     expected_ast = pt.Seq(
-        args[0].set(pt.Txn.group_index() - pt.Int(3)),
-        args[1].set(pt.Txn.group_index() - pt.Int(2)),
-        args[2].set(pt.Txn.group_index() - pt.Int(1)),
+        args[0].set(pt.Txn.group_index() - pt.Int(4)),
+        pt.Assert(args[0].get().type_enum() == pt.TxnType.ApplicationCall),
+        args[1].set(pt.Txn.group_index() - pt.Int(3)),
+        pt.Assert(args[1].get().type_enum() == pt.TxnType.AssetTransfer),
+        args[2].set(pt.Txn.group_index() - pt.Int(2)),
+        pt.Assert(args[2].get().type_enum() == pt.TxnType.Payment),
+        args[3].set(pt.Txn.group_index() - pt.Int(1)),
         multiple_txn(*args).store_into(output_temp),
         pt.abi.MethodReturn(output_temp),
         pt.Approve(),


### PR DESCRIPTION
This PR adds logic to the ABI router to verify that the type of provided transactions in the group match the declared type of any transaction arguments.

Prior to this PR, a method could be declared as `example(pay)void`, but there would be no checks to ensure that the transaction argument was a payment transaction at runtime.

The only transaction type that is unchanged is the generic `txn` type, since it requires no verification.