### PR TITLE
Clarify minimum Python version management docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ PyTeal provides high level, functional programming style abstractions over TEAL 
 
 PyTeal requires Python version >= 3.10.
 
-To manage multiple Python versions use tooling like [pyenv](https://github.com/pyenv/pyenv).
+If your operating system (OS) Python version < 3.10, we recommend:
+* Rather than override the OS Python version, install Python  >= 3.10 alongside the OS Python version.
+* Use [pyenv](https://github.com/pyenv/pyenv#installation) or similar tooling to manage multiple Python versions.
 
 ### Recommended: Install from PyPi
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,6 +1,13 @@
 Install PyTeal
 ==============
 
+PyTeal requires Python version >= 3.10.
+
+If your operating system (OS) Python version < 3.10, we recommend:
+
+* Rather than override the OS Python version, install Python  >= 3.10 alongside the OS Python version.
+* Use `pyenv <https://github.com/pyenv/pyenv#installation>`_ or similar tooling to manage multiple Python versions.
+
 The easiest way of installing PyTeal is using :code:`pip` : ::
 
   $ pip3 install pyteal


### PR DESCRIPTION
Updates Python version management docs to explicitly highlight the need to manage parallel Python versions rather than overriding the operating system-provided Python version.