### PR TITLE
Consistently use `start_index` and `end_index`

### DIFF
--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -58,30 +58,30 @@ def test_Address_decode():
     address = bytes([0] * abi.AddressLength.Bytes)
     encoded = pt.Bytes(address)
 
-    for startIndex in (None, pt.Int(0)):
-        for endIndex in (None, pt.Int(1)):
+    for start_index in (None, pt.Int(0)):
+        for end_index in (None, pt.Int(1)):
             for length in (None, pt.Int(2)):
                 value = abi.Address()
 
-                if endIndex is not None and length is not None:
+                if end_index is not None and length is not None:
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
-                            start_index=startIndex,
-                            end_index=endIndex,
+                            start_index=start_index,
+                            end_index=end_index,
                             length=length,
                         )
                     continue
 
                 expr = value.decode(
-                    encoded, start_index=startIndex, end_index=endIndex, length=length
+                    encoded, start_index=start_index, end_index=end_index, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert expr.has_return() is False
 
                 expectedExpr = value.stored_value.store(
                     substringForDecoding(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded, start_index=start_index, end_index=end_index, length=length
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/array_base.py
+++ b/pyteal/ast/abi/array_base.py
@@ -102,7 +102,7 @@ class Array(BaseType, Generic[T]):
             the scratch variable.
         """
         extracted = substringForDecoding(
-            encoded, startIndex=start_index, endIndex=end_index, length=length
+            encoded, start_index=start_index, end_index=end_index, length=length
         )
         return self.stored_value.store(extracted)
 

--- a/pyteal/ast/abi/array_dynamic_test.py
+++ b/pyteal/ast/abi/array_dynamic_test.py
@@ -62,30 +62,30 @@ def test_DynamicArrayTypeSpec_byte_length_static():
 def test_DynamicArray_decode():
     encoded = pt.Bytes("encoded")
     dynamicArrayType = abi.DynamicArrayTypeSpec(abi.Uint64TypeSpec())
-    for startIndex in (None, pt.Int(1)):
-        for endIndex in (None, pt.Int(2)):
+    for start_index in (None, pt.Int(1)):
+        for end_index in (None, pt.Int(2)):
             for length in (None, pt.Int(3)):
                 value = dynamicArrayType.new_instance()
 
-                if endIndex is not None and length is not None:
+                if end_index is not None and length is not None:
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
-                            start_index=startIndex,
-                            end_index=endIndex,
+                            start_index=start_index,
+                            end_index=end_index,
                             length=length,
                         )
                     continue
 
                 expr = value.decode(
-                    encoded, start_index=startIndex, end_index=endIndex, length=length
+                    encoded, start_index=start_index, end_index=end_index, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()
 
                 expectedExpr = value.stored_value.store(
                     substringForDecoding(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded, start_index=start_index, end_index=end_index, length=length
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -101,32 +101,32 @@ def test_StaticArrayTypeSpec_byte_length_static():
 
 def test_StaticArray_decode():
     encoded = pt.Bytes("encoded")
-    for startIndex in (None, pt.Int(1)):
-        for endIndex in (None, pt.Int(2)):
+    for start_index in (None, pt.Int(1)):
+        for end_index in (None, pt.Int(2)):
             for length in (None, pt.Int(3)):
                 value = abi.StaticArray(
                     abi.StaticArrayTypeSpec(abi.Uint64TypeSpec(), 10)
                 )
 
-                if endIndex is not None and length is not None:
+                if end_index is not None and length is not None:
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
-                            start_index=startIndex,
-                            end_index=endIndex,
+                            start_index=start_index,
+                            end_index=end_index,
                             length=length,
                         )
                     continue
 
                 expr = value.decode(
-                    encoded, start_index=startIndex, end_index=endIndex, length=length
+                    encoded, start_index=start_index, end_index=end_index, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()
 
                 expectedExpr = value.stored_value.store(
                     substringForDecoding(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded, start_index=start_index, end_index=end_index, length=length
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -116,29 +116,29 @@ T = TypeVar("T")
 
 
 def consecutiveThingNum(
-    things: Sequence[T], startIndex: int, condition: Callable[[T], bool]
+    things: Sequence[T], start_index: int, condition: Callable[[T], bool]
 ) -> int:
     numConsecutiveThings = 0
-    for t in things[startIndex:]:
+    for t in things[start_index:]:
         if not condition(t):
             break
         numConsecutiveThings += 1
     return numConsecutiveThings
 
 
-def consecutiveBoolTypeSpecNum(types: Sequence[TypeSpec], startIndex: int) -> int:
+def consecutiveBoolTypeSpecNum(types: Sequence[TypeSpec], start_index: int) -> int:
     if len(types) != 0 and not isinstance(types[0], TypeSpec):
         raise TypeError("Sequence of types expected")
-    return consecutiveThingNum(types, startIndex, lambda t: t == BoolTypeSpec())
+    return consecutiveThingNum(types, start_index, lambda t: t == BoolTypeSpec())
 
 
-def consecutiveBoolInstanceNum(values: Sequence[BaseType], startIndex: int) -> int:
+def consecutiveBoolInstanceNum(values: Sequence[BaseType], start_index: int) -> int:
     if len(values) != 0 and not isinstance(values[0], BaseType):
         raise TypeError(
             "Sequence of types expected, but got {}".format(type(values[0]))
         )
     return consecutiveThingNum(
-        values, startIndex, lambda t: t.type_spec() == BoolTypeSpec()
+        values, start_index, lambda t: t.type_spec() == BoolTypeSpec()
     )
 
 

--- a/pyteal/ast/abi/bool_test.py
+++ b/pyteal/ast/abi/bool_test.py
@@ -160,11 +160,11 @@ def test_Bool_get():
 def test_Bool_decode():
     value = abi.Bool()
     encoded = pt.Bytes("encoded")
-    for startIndex in (None, pt.Int(1)):
-        for endIndex in (None, pt.Int(2)):
+    for start_index in (None, pt.Int(1)):
+        for end_index in (None, pt.Int(2)):
             for length in (None, pt.Int(3)):
                 expr = value.decode(
-                    encoded, start_index=startIndex, end_index=endIndex, length=length
+                    encoded, start_index=start_index, end_index=end_index, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()
@@ -172,7 +172,7 @@ def test_Bool_decode():
                 expected = pt.TealSimpleBlock(
                     [
                         pt.TealOp(None, pt.Op.byte, '"encoded"'),
-                        pt.TealOp(None, pt.Op.int, 0 if startIndex is None else 1),
+                        pt.TealOp(None, pt.Op.int, 0 if start_index is None else 1),
                         pt.TealOp(None, pt.Op.int, 8),
                         pt.TealOp(None, pt.Op.mul),
                         pt.TealOp(None, pt.Op.getbit),

--- a/pyteal/ast/abi/reference_type_test.py
+++ b/pyteal/ast/abi/reference_type_test.py
@@ -44,13 +44,13 @@ def test_ReferenceType_encode():
 def test_ReferenceType_decode():
     encoded = pt.Bytes("encoded")
     for value in (abi.Account(), abi.Asset(), abi.Application()):
-        for startIndex in (None, pt.Int(1)):
-            for endIndex in (None, pt.Int(2)):
+        for start_index in (None, pt.Int(1)):
+            for end_index in (None, pt.Int(2)):
                 for length in (None, pt.Int(3)):
                     expr = value.decode(
                         encoded,
-                        start_index=startIndex,
-                        end_index=endIndex,
+                        start_index=start_index,
+                        end_index=end_index,
                         length=length,
                     )
                     assert expr.type_of() == pt.TealType.none
@@ -58,7 +58,7 @@ def test_ReferenceType_decode():
 
                     expected_decoding = value.stored_value.store(
                         pt.GetByte(
-                            encoded, startIndex if startIndex is not None else pt.Int(0)
+                            encoded, start_index if start_index is not None else pt.Int(0)
                         )
                     )
                     expected, _ = expected_decoding.__teal__(options)

--- a/pyteal/ast/abi/string_test.py
+++ b/pyteal/ast/abi/string_test.py
@@ -49,30 +49,30 @@ def test_String_encode():
 def test_DynamicArray_decode():
     encoded = pt.Bytes("encoded")
     stringType = abi.StringTypeSpec()
-    for startIndex in (None, pt.Int(1)):
-        for endIndex in (None, pt.Int(2)):
+    for start_index in (None, pt.Int(1)):
+        for end_index in (None, pt.Int(2)):
             for length in (None, pt.Int(3)):
                 value = stringType.new_instance()
 
-                if endIndex is not None and length is not None:
+                if end_index is not None and length is not None:
                     with pytest.raises(pt.TealInputError):
                         value.decode(
                             encoded,
-                            start_index=startIndex,
-                            end_index=endIndex,
+                            start_index=start_index,
+                            end_index=end_index,
                             length=length,
                         )
                     continue
 
                 expr = value.decode(
-                    encoded, start_index=startIndex, end_index=endIndex, length=length
+                    encoded, start_index=start_index, end_index=end_index, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert expr.has_return() is False
 
                 expectedExpr = value.stored_value.store(
                     substringForDecoding(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded, start_index=start_index, end_index=end_index, length=length
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -174,34 +174,34 @@ def indexTuple(
 
             nextDynamicValueOffset += typeAfter.byte_length_static()
 
-        startIndex = ExtractUint16(encoded, Int(offset))
+        start_index = ExtractUint16(encoded, Int(offset))
         if not hasNextDynamicValue:
-            # This is the final dynamic value, so decode the substring from startIndex to the end of
+            # This is the final dynamic value, so decode the substring from start_index to the end of
             # encoded
-            return output.decode(encoded, start_index=startIndex)
+            return output.decode(encoded, start_index=start_index)
 
-        # There is a dynamic value after this one, and endIndex is where its tail starts, so decode
-        # the substring from startIndex to endIndex
-        endIndex = ExtractUint16(encoded, Int(nextDynamicValueOffset))
-        return output.decode(encoded, start_index=startIndex, end_index=endIndex)
+        # There is a dynamic value after this one, and end_index is where its tail starts, so decode
+        # the substring from start_index to end_index
+        end_index = ExtractUint16(encoded, Int(nextDynamicValueOffset))
+        return output.decode(encoded, start_index=start_index, end_index=end_index)
 
-    startIndex = Int(offset)
+    start_index = Int(offset)
     length = Int(valueType.byte_length_static())
 
     if index + 1 == len(valueTypes):
         if offset == 0:
             # This is the first and only value in the tuple, so decode all of encoded
             return output.decode(encoded)
-        # This is the last value in the tuple, so decode the substring from startIndex to the end of
+        # This is the last value in the tuple, so decode the substring from start_index to the end of
         # encoded
-        return output.decode(encoded, start_index=startIndex)
+        return output.decode(encoded, start_index=start_index)
 
     if offset == 0:
         # This is the first value in the tuple, so decode the substring from 0 with length length
         return output.decode(encoded, length=length)
 
-    # This is not the first or last value, so decode the substring from startIndex with length length
-    return output.decode(encoded, start_index=startIndex, length=length)
+    # This is not the first or last value, so decode the substring from start_index with length length
+    return output.decode(encoded, start_index=start_index, length=length)
 
 
 class TupleTypeSpec(TypeSpec):
@@ -289,7 +289,7 @@ class Tuple(BaseType):
         length: Expr = None,
     ) -> Expr:
         extracted = substringForDecoding(
-            encoded, startIndex=start_index, endIndex=end_index, length=length
+            encoded, start_index=start_index, end_index=end_index, length=length
         )
         return self.stored_value.store(extracted)
 

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -600,28 +600,28 @@ def test_TupleTypeSpec_byte_length_static():
 def test_Tuple_decode():
     encoded = pt.Bytes("encoded")
     tupleValue = abi.Tuple(abi.TupleTypeSpec(abi.Uint64TypeSpec()))
-    for startIndex in (None, pt.Int(1)):
-        for endIndex in (None, pt.Int(2)):
+    for start_index in (None, pt.Int(1)):
+        for end_index in (None, pt.Int(2)):
             for length in (None, pt.Int(3)):
-                if endIndex is not None and length is not None:
+                if end_index is not None and length is not None:
                     with pytest.raises(pt.TealInputError):
                         tupleValue.decode(
                             encoded,
-                            start_index=startIndex,
-                            end_index=endIndex,
+                            start_index=start_index,
+                            end_index=end_index,
                             length=length,
                         )
                     continue
 
                 expr = tupleValue.decode(
-                    encoded, start_index=startIndex, end_index=endIndex, length=length
+                    encoded, start_index=start_index, end_index=end_index, length=length
                 )
                 assert expr.type_of() == pt.TealType.none
                 assert not expr.has_return()
 
                 expectedExpr = tupleValue.stored_value.store(
                     substringForDecoding(
-                        encoded, startIndex=startIndex, endIndex=endIndex, length=length
+                        encoded, start_index=start_index, end_index=end_index, length=length
                     )
                 )
                 expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -106,18 +106,18 @@ class BaseType(ABC):
         The arguments to this function are means to be as flexible as possible for the caller.
         Multiple types of substrings can be specified based on the arguments, as listed below:
 
-        * Entire string: if startIndex, endIndex, and length are all None, the entire encoded string
+        * Entire string: if start_index, end_index, and length are all None, the entire encoded string
           is decoded.
-        * Prefix: if startIndex is None and one of endIndex or length is provided, a prefix of the
-          encoded string is decoded. The range is 0 through endIndex or length (they are equivalent).
-        * Suffix: if startIndex is provided and endIndex and length are None, a suffix of the encoded
-          string is decoded. The range is startIndex through the end of the string.
-        * Substring specified with endIndex: if startIndex and endIndex are provided and length is
-          None, a substring of the encoded string is decoded. The range is startIndex through
-          endIndex.
-        * Substring specified with length: if startIndex and length are provided and endIndex is
-          None, a substring of the encoded string is decoded. The range is startIndex through
-          startIndex+length.
+        * Prefix: if start_index is None and one of end_index or length is provided, a prefix of the
+          encoded string is decoded. The range is 0 through end_index or length (they are equivalent).
+        * Suffix: if start_index is provided and end_index and length are None, a suffix of the encoded
+          string is decoded. The range is start_index through the end of the string.
+        * Substring specified with end_index: if start_index and end_index are provided and length is
+          None, a substring of the encoded string is decoded. The range is start_index through
+          end_index.
+        * Substring specified with length: if start_index and length are provided and end_index is
+          None, a substring of the encoded string is decoded. The range is start_index through
+          start_index+length.
 
         Args:
             encoded: An expression containing the bytes to decode. Must evaluate to TealType.bytes.

--- a/pyteal/ast/abi/uint.py
+++ b/pyteal/ast/abi/uint.py
@@ -62,8 +62,8 @@ def uint_decode(
     size: int,
     uintVar: ScratchVar,
     encoded: Expr,
-    startIndex: Optional[Expr],
-    endIndex: Optional[Expr],
+    start_index: Optional[Expr],
+    end_index: Optional[Expr],
     length: Optional[Expr],
 ) -> Expr:
     if size > 64:
@@ -72,21 +72,21 @@ def uint_decode(
         )
 
     if size == 64:
-        if startIndex is None:
-            if endIndex is None and length is None:
+        if start_index is None:
+            if end_index is None and length is None:
                 return uintVar.store(Btoi(encoded))
-            startIndex = Int(0)
-        return uintVar.store(ExtractUint64(encoded, startIndex))
+            start_index = Int(0)
+        return uintVar.store(ExtractUint64(encoded, start_index))
 
-    if startIndex is None:
-        startIndex = Int(0)
+    if start_index is None:
+        start_index = Int(0)
 
     if size == 8:
-        return uintVar.store(GetByte(encoded, startIndex))
+        return uintVar.store(GetByte(encoded, start_index))
     if size == 16:
-        return uintVar.store(ExtractUint16(encoded, startIndex))
+        return uintVar.store(ExtractUint16(encoded, start_index))
     if size == 32:
-        return uintVar.store(ExtractUint32(encoded, startIndex))
+        return uintVar.store(ExtractUint32(encoded, start_index))
 
     raise ValueError("Unsupported uint size: {}".format(size))
 

--- a/pyteal/ast/abi/uint_test.py
+++ b/pyteal/ast/abi/uint_test.py
@@ -33,8 +33,8 @@ testData = [
         expectedBits=8,
         maxValue=2**8 - 1,
         checkUpperBound=True,
-        expectedDecoding=lambda encoded, startIndex, endIndex, length: pt.GetByte(
-            encoded, noneToInt0(startIndex)
+        expectedDecoding=lambda encoded, start_index, end_index, length: pt.GetByte(
+            encoded, noneToInt0(start_index)
         ),
         expectedEncoding=lambda uintType: pt.SetByte(
             pt.Bytes(b"\x00"), pt.Int(0), uintType.get()
@@ -46,8 +46,8 @@ testData = [
         expectedBits=16,
         maxValue=2**16 - 1,
         checkUpperBound=True,
-        expectedDecoding=lambda encoded, startIndex, endIndex, length: pt.ExtractUint16(
-            encoded, noneToInt0(startIndex)
+        expectedDecoding=lambda encoded, start_index, end_index, length: pt.ExtractUint16(
+            encoded, noneToInt0(start_index)
         ),
         expectedEncoding=lambda uintType: pt.Suffix(pt.Itob(uintType.get()), pt.Int(6)),
     ),
@@ -57,8 +57,8 @@ testData = [
         expectedBits=32,
         maxValue=2**32 - 1,
         checkUpperBound=True,
-        expectedDecoding=lambda encoded, startIndex, endIndex, length: pt.ExtractUint32(
-            encoded, noneToInt0(startIndex)
+        expectedDecoding=lambda encoded, start_index, end_index, length: pt.ExtractUint32(
+            encoded, noneToInt0(start_index)
         ),
         expectedEncoding=lambda uintType: pt.Suffix(pt.Itob(uintType.get()), pt.Int(4)),
     ),
@@ -68,9 +68,9 @@ testData = [
         expectedBits=64,
         maxValue=2**64 - 1,
         checkUpperBound=False,
-        expectedDecoding=lambda encoded, startIndex, endIndex, length: pt.Btoi(encoded)
-        if startIndex is None and endIndex is None and length is None
-        else pt.ExtractUint64(encoded, noneToInt0(startIndex)),
+        expectedDecoding=lambda encoded, start_index, end_index, length: pt.Btoi(encoded)
+        if start_index is None and end_index is None and length is None
+        else pt.ExtractUint64(encoded, noneToInt0(start_index)),
         expectedEncoding=lambda uintType: pt.Itob(uintType.get()),
     ),
 ]
@@ -262,21 +262,21 @@ def test_Uint_get():
 def test_Uint_decode():
     encoded = pt.Bytes("encoded")
     for test in testData:
-        for startIndex in (None, pt.Int(1)):
-            for endIndex in (None, pt.Int(2)):
+        for start_index in (None, pt.Int(1)):
+            for end_index in (None, pt.Int(2)):
                 for length in (None, pt.Int(3)):
                     value = test.uintType.new_instance()
                     expr = value.decode(
                         encoded,
-                        start_index=startIndex,
-                        end_index=endIndex,
+                        start_index=start_index,
+                        end_index=end_index,
                         length=length,
                     )
                     assert expr.type_of() == pt.TealType.none
                     assert not expr.has_return()
 
                     expectedDecoding = value.stored_value.store(
-                        test.expectedDecoding(encoded, startIndex, endIndex, length)
+                        test.expectedDecoding(encoded, start_index, end_index, length)
                     )
                     expected, _ = expectedDecoding.__teal__(options)
                     expected.addIncoming()

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -22,33 +22,33 @@ from pyteal.ast.abi.type import TypeSpec, BaseType
 def substringForDecoding(
     encoded: Expr,
     *,
-    startIndex: Expr = None,
-    endIndex: Expr = None,
+    start_index: Expr = None,
+    end_index: Expr = None,
     length: Expr = None,
 ) -> Expr:
     """A helper function for getting the substring to decode according to the rules of BaseType.decode."""
-    if length is not None and endIndex is not None:
-        raise TealInputError("length and endIndex are mutually exclusive arguments")
+    if length is not None and end_index is not None:
+        raise TealInputError("length and end_index are mutually exclusive arguments")
 
-    if startIndex is not None:
+    if start_index is not None:
         if length is not None:
-            # substring from startIndex to startIndex + length
-            return Extract(encoded, startIndex, length)
+            # substring from start_index to start_index + length
+            return Extract(encoded, start_index, length)
 
-        if endIndex is not None:
-            # substring from startIndex to endIndex
-            return Substring(encoded, startIndex, endIndex)
+        if end_index is not None:
+            # substring from start_index to end_index
+            return Substring(encoded, start_index, end_index)
 
-        # substring from startIndex to end of string
-        return Suffix(encoded, startIndex)
+        # substring from start_index to end of string
+        return Suffix(encoded, start_index)
 
     if length is not None:
         # substring from 0 to length
         return Extract(encoded, Int(0), length)
 
-    if endIndex is not None:
-        # substring from 0 to endIndex
-        return Substring(encoded, Int(0), endIndex)
+    if end_index is not None:
+        # substring from 0 to end_index
+        return Substring(encoded, Int(0), end_index)
 
     # the entire string
     return encoded

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -20,54 +20,54 @@ options = pt.CompileOptions(version=5)
 
 def test_substringForDecoding():
     class SubstringTest(NamedTuple):
-        startIndex: Optional[pt.Expr]
-        endIndex: Optional[pt.Expr]
+        start_index: Optional[pt.Expr]
+        end_index: Optional[pt.Expr]
         length: Optional[pt.Expr]
         expected: Union[pt.Expr, Any]
 
     encoded = pt.Bytes("encoded")
 
     tests: List[SubstringTest] = [
-        SubstringTest(startIndex=None, endIndex=None, length=None, expected=encoded),
+        SubstringTest(start_index=None, end_index=None, length=None, expected=encoded),
         SubstringTest(
-            startIndex=None,
-            endIndex=None,
+            start_index=None,
+            end_index=None,
             length=pt.Int(4),
             expected=pt.Extract(encoded, pt.Int(0), pt.Int(4)),
         ),
         SubstringTest(
-            startIndex=None,
-            endIndex=pt.Int(4),
+            start_index=None,
+            end_index=pt.Int(4),
             length=None,
             expected=pt.Substring(encoded, pt.Int(0), pt.Int(4)),
         ),
         SubstringTest(
-            startIndex=None,
-            endIndex=pt.Int(4),
+            start_index=None,
+            end_index=pt.Int(4),
             length=pt.Int(5),
             expected=pt.TealInputError,
         ),
         SubstringTest(
-            startIndex=pt.Int(4),
-            endIndex=None,
+            start_index=pt.Int(4),
+            end_index=None,
             length=None,
             expected=pt.Suffix(encoded, pt.Int(4)),
         ),
         SubstringTest(
-            startIndex=pt.Int(4),
-            endIndex=None,
+            start_index=pt.Int(4),
+            end_index=None,
             length=pt.Int(5),
             expected=pt.Extract(encoded, pt.Int(4), pt.Int(5)),
         ),
         SubstringTest(
-            startIndex=pt.Int(4),
-            endIndex=pt.Int(5),
+            start_index=pt.Int(4),
+            end_index=pt.Int(5),
             length=None,
             expected=pt.Substring(encoded, pt.Int(4), pt.Int(5)),
         ),
         SubstringTest(
-            startIndex=pt.Int(4),
-            endIndex=pt.Int(5),
+            start_index=pt.Int(4),
+            end_index=pt.Int(5),
             length=pt.Int(6),
             expected=pt.TealInputError,
         ),
@@ -78,16 +78,16 @@ def test_substringForDecoding():
             with pytest.raises(test.expected):
                 substringForDecoding(
                     encoded,
-                    startIndex=test.startIndex,
-                    endIndex=test.endIndex,
+                    start_index=test.start_index,
+                    end_index=test.end_index,
                     length=test.length,
                 )
             continue
 
         expr = substringForDecoding(
             encoded,
-            startIndex=test.startIndex,
-            endIndex=test.endIndex,
+            start_index=test.start_index,
+            end_index=test.end_index,
             length=test.length,
         )
         assert expr.type_of() == pt.TealType.bytes


### PR DESCRIPTION
I realized that `substringForDecoding` still used camel case argument names, and that `BaseType.decode` still referenced the old camel case names in its docstring, so I made this.

The changeset is simply a result of VSCode's find-and-replace applied with `startIndex` -> `start_index` and `endIndex` -> `end_index` across the codebase, minus an occurrences that was completely irrelevant to the ABI.