### PR TITLE
Simplify multi-expression clauses

### DIFF
--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -12,18 +12,18 @@ if TYPE_CHECKING:
 class Assert(Expr):
     """A control flow expression to verify that a condition is true."""
 
-    def __init__(self, cond: Expr, *additionalConds: Expr) -> None:
+    def __init__(self, cond: Expr, *additional_conds: Expr) -> None:
         """Create an assert statement that raises an error if the condition is false.
 
         Args:
             cond: The condition to check. Must evaluate to a uint64.
-            *additionalConds: Additional conditions to check. Must evaluate to uint64.
+            *additional_conds: Additional conditions to check. Must evaluate to uint64.
         """
         super().__init__()
         require_type(cond, TealType.uint64)
-        for cond_single in additionalConds:
+        for cond_single in additional_conds:
             require_type(cond_single, TealType.uint64)
-        self.cond = [cond] + list(additionalConds)
+        self.cond = [cond] + list(additional_conds)
 
     def __teal__(self, options: "CompileOptions"):
         if len(self.cond) > 1:

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from pyteal.types import TealType, require_type
 from pyteal.ir import TealOp, Op, TealBlock, TealSimpleBlock, TealConditionalBlock
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class Assert(Expr):
     """A control flow expression to verify that a condition is true."""
 
-    def __init__(self, cond: Expr, *condMulti: List[Expr]) -> None:
+    def __init__(self, cond: Expr, *condMulti: list[Expr]) -> None:
         """Create an assert statement that raises an error if the condition is false.
 
         Args:

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class Assert(Expr):
     """A control flow expression to verify that a condition is true."""
 
-    def __init__(self, cond: Expr, *condMulti: list[Expr]) -> None:
+    def __init__(self, cond: Expr, *condMulti: Expr) -> None:
         """Create an assert statement that raises an error if the condition is false.
 
         Args:

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -17,6 +17,7 @@ class Assert(Expr):
 
         Args:
             cond: The condition to check. Must evaluate to a uint64.
+            *additionalConds: Additional conditions to check. Must evaluate to uint64.
         """
         super().__init__()
         require_type(cond, TealType.uint64)

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class Assert(Expr):
     """A control flow expression to verify that a condition is true."""
 
-    def __init__(self, cond: Expr, *condMulti: Expr) -> None:
+    def __init__(self, cond: Expr, *additionalConds: Expr) -> None:
         """Create an assert statement that raises an error if the condition is false.
 
         Args:
@@ -20,9 +20,9 @@ class Assert(Expr):
         """
         super().__init__()
         require_type(cond, TealType.uint64)
-        for cond_single in condMulti:
+        for cond_single in additionalConds:
             require_type(cond_single, TealType.uint64)
-        self.cond = [cond] + list(condMulti)
+        self.cond = [cond] + list(additionalConds)
 
     def __teal__(self, options: "CompileOptions"):
         if len(self.cond) > 1:

--- a/pyteal/ast/assert_test.py
+++ b/pyteal/ast/assert_test.py
@@ -23,6 +23,22 @@ def test_teal_2_assert():
         assert actual == expected
 
 
+def test_teal_2_assert_multi():
+    args = [pt.Int(1), pt.Int(2)]
+    expr = pt.Assert(*args)
+    assert expr.type_of() == pt.TealType.none
+
+    firstAssert = pt.Assert(args[0])
+    secondAssert = pt.Assert(args[1])
+
+    expected, _ = pt.Seq(firstAssert, secondAssert).__teal__(teal2Options)
+
+    actual, _ = expr.__teal__(teal2Options)
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+
 def test_teal_3_assert():
     arg = pt.Int(1)
     expr = pt.Assert(arg)
@@ -37,6 +53,24 @@ def test_teal_3_assert():
     actual = pt.TealBlock.NormalizeBlocks(actual)
 
     assert actual == expected
+
+
+def test_teal_3_assert_multi():
+    args = [pt.Int(1), pt.Int(2)]
+    expr = pt.Assert(*args)
+    assert expr.type_of() == pt.TealType.none
+
+    expected = pt.TealSimpleBlock(
+        [pt.TealOp(args[0], pt.Op.int, 1), pt.TealOp(expr, pt.Op.assert_)] + 
+        [pt.TealOp(args[1], pt.Op.int, 2), pt.TealOp(expr, pt.Op.assert_)]
+    )
+
+    actual, _ = expr.__teal__(teal3Options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
 
 
 def test_assert_invalid():

--- a/pyteal/ast/assert_test.py
+++ b/pyteal/ast/assert_test.py
@@ -61,8 +61,8 @@ def test_teal_3_assert_multi():
     assert expr.type_of() == pt.TealType.none
 
     expected = pt.TealSimpleBlock(
-        [pt.TealOp(args[0], pt.Op.int, 1), pt.TealOp(expr, pt.Op.assert_)] + 
-        [pt.TealOp(args[1], pt.Op.int, 2), pt.TealOp(expr, pt.Op.assert_)]
+        [pt.TealOp(args[0], pt.Op.int, 1), pt.TealOp(expr, pt.Op.assert_)]
+        + [pt.TealOp(args[1], pt.Op.int, 2), pt.TealOp(expr, pt.Op.assert_)]
     )
 
     actual, _ = expr.__teal__(teal3Options)
@@ -76,3 +76,6 @@ def test_teal_3_assert_multi():
 def test_assert_invalid():
     with pytest.raises(pt.TealTypeError):
         pt.Assert(pt.Txn.receiver())
+
+    with pytest.raises(pt.TealTypeError):
+        pt.Assert(pt.Int(1), pt.Txn.receiver())

--- a/pyteal/ast/cond.py
+++ b/pyteal/ast/cond.py
@@ -34,10 +34,10 @@ class Cond(Expr):
     def __init__(self, *argv: List[Expr]):
         """Create a new Cond expression.
 
-        At least one argument must be provided, and each argument must be a list with two elements.
-        The first element is a condition which evalutes to uint64, and the second is the body of the
-        condition, which will execute if that condition is true. All condition bodies must have the
-        same return type. During execution, each condition is tested in order, and the first
+        At least one argument must be provided, and each argument must be a list with two or more elements.
+        The first element is a condition which evalutes to uint64, and the remaining elements are the body
+        of the condition, which will execute if that condition is true. The last elements of the condition bodies
+        must have the same return type. During execution, each condition is tested in order, and the first
         condition to evaluate to a true value will cause its associated body to execute and become
         the value for this Cond expression. If no condition evalutes to a true value, the Cond
         expression produces an error and the TEAL program terminates.
@@ -46,7 +46,7 @@ class Cond(Expr):
             .. code-block:: python
 
                 Cond([Global.group_size() == Int(5), bid],
-                    [Global.group_size() == Int(4), redeem],
+                    [Global.group_size() == Int(4), redeem, log],
                     [Global.group_size() == Int(1), wrapup])
         """
         super().__init__()

--- a/pyteal/ast/cond.py
+++ b/pyteal/ast/cond.py
@@ -1,5 +1,5 @@
 from typing import List, cast, TYPE_CHECKING
-from pyteal.ast.seq import use_seq_if_multiple
+from pyteal.ast.seq import _use_seq_if_multiple
 
 from pyteal.types import TealType, require_type
 from pyteal.ir import TealOp, Op, TealSimpleBlock, TealConditionalBlock
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pyteal.compiler import CompileOptions
 
 
-def reformat_multi_argv(argv: tuple[list[Expr], ...]) -> list[list[Expr]]:
+def _reformat_multi_argv(argv: tuple[list[Expr], ...]) -> list[list[Expr]]:
     """Reformat a list of lists of expressions with potentially multiple value expressions into a list of lists of expressions with only one value expression
         by using Seq blocks where appropriate.
 
@@ -23,7 +23,7 @@ def reformat_multi_argv(argv: tuple[list[Expr], ...]) -> list[list[Expr]]:
         if len(arg) <= 1:
             reformatted.append(arg)
         else:
-            reformatted.append([arg[0], use_seq_if_multiple(arg[1:])])
+            reformatted.append([arg[0], _use_seq_if_multiple(arg[1:])])
 
     return reformatted
 
@@ -55,7 +55,7 @@ class Cond(Expr):
             raise TealInputError("Cond requires at least one [condition, value]")
 
         value_type = None
-        sequenced_argv = reformat_multi_argv(argv)
+        sequenced_argv = _reformat_multi_argv(argv)
 
         for arg in sequenced_argv:
             msg = "Cond should be in the form of Cond([cond1, value1], [cond2, value2], ...), error in {}"

--- a/pyteal/ast/cond.py
+++ b/pyteal/ast/cond.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pyteal.compiler import CompileOptions
 
 
-def reformat_multi_argv(argv: List[List[Expr]]) -> List[List[Expr]]:
+def reformat_multi_argv(argv: list[list[Expr]]) -> list[list[Expr]]:
     """Reformat a list of lists of expressions with potentially multiple value expressions into a list of lists of expressions with only one value expression
         by using Seq blocks where appropriate.
 

--- a/pyteal/ast/cond.py
+++ b/pyteal/ast/cond.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pyteal.compiler import CompileOptions
 
 
-def reformat_multi_argv(argv: list[list[Expr]]) -> list[list[Expr]]:
+def reformat_multi_argv(argv: tuple[list[Expr], ...]) -> list[list[Expr]]:
     """Reformat a list of lists of expressions with potentially multiple value expressions into a list of lists of expressions with only one value expression
         by using Seq blocks where appropriate.
 

--- a/pyteal/ast/cond_test.py
+++ b/pyteal/ast/cond_test.py
@@ -119,6 +119,9 @@ def test_cond_invalid():
     with pytest.raises(pt.TealInputError):
         pt.Cond([])
 
+    with pytest.raises(pt.TealInputError):
+        pt.Cond([pt.Int(1)], [pt.Int(2), pt.Pop(pt.Txn.receiver())])
+
     with pytest.raises(pt.TealTypeError):
         pt.Cond([pt.Int(1), pt.Int(2)], [pt.Int(2), pt.Txn.receiver()])
 

--- a/pyteal/ast/cond_test.py
+++ b/pyteal/ast/cond_test.py
@@ -125,6 +125,12 @@ def test_cond_invalid():
     with pytest.raises(pt.TealTypeError):
         pt.Cond([pt.Arg(0), pt.Int(2)])
 
+    with pytest.raises(pt.TealTypeError):
+        pt.Cond([pt.Int(1), pt.Int(2)], [pt.Int(2), pt.Pop(pt.Int(2))])
+
+    with pytest.raises(pt.TealTypeError):
+        pt.Cond([pt.Int(1), pt.Pop(pt.Int(1))], [pt.Int(2), pt.Int(2)])
+
 
 def test_cond_two_pred_multi():
     args = [

--- a/pyteal/ast/cond_test.py
+++ b/pyteal/ast/cond_test.py
@@ -124,3 +124,44 @@ def test_cond_invalid():
 
     with pytest.raises(pt.TealTypeError):
         pt.Cond([pt.Arg(0), pt.Int(2)])
+
+
+def test_cond_two_pred_multi():
+    args = [
+        pt.Int(1),
+        [pt.Pop(pt.Int(1)), pt.Bytes("one")],
+        pt.Int(0),
+        [pt.Pop(pt.Int(2)), pt.Bytes("zero")],
+    ]
+    expr = pt.Cond(
+        [args[0]] + args[1],
+        [args[2]] + args[3],
+    )
+    assert expr.type_of() == pt.TealType.bytes
+
+    cond1, _ = args[0].__teal__(options)
+    pred1, pred1End = pt.Seq(args[1]).__teal__(options)
+    cond1Branch = pt.TealConditionalBlock([])
+    cond2, _ = args[2].__teal__(options)
+    pred2, pred2End = pt.Seq(args[3]).__teal__(options)
+    cond2Branch = pt.TealConditionalBlock([])
+    end = pt.TealSimpleBlock([])
+
+    cond1.setNextBlock(cond1Branch)
+    cond1Branch.setTrueBlock(pred1)
+    cond1Branch.setFalseBlock(cond2)
+    pred1End.setNextBlock(end)
+
+    cond2.setNextBlock(cond2Branch)
+    cond2Branch.setTrueBlock(pred2)
+    cond2Branch.setFalseBlock(pt.Err().__teal__(options)[0])
+    pred2End.setNextBlock(end)
+
+    expected = cond1
+
+    actual, _ = expr.__teal__(options)
+    print(actual)
+    print(expected)
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected

--- a/pyteal/ast/for_.py
+++ b/pyteal/ast/for_.py
@@ -97,11 +97,11 @@ class For(Expr):
     def has_return(self):
         return False
 
-    def Do(self, doBlock: Expr, *doBlockMulti: Expr):
+    def Do(self, doBlock: Expr, *do_block_multi: Expr):
         if self.doBlock is not None:
             raise TealCompileError("For expression already has a doBlock", self)
 
-        doBlock = _use_seq_if_multiple(doBlock, *doBlockMulti)
+        doBlock = _use_seq_if_multiple(doBlock, *do_block_multi)
 
         require_type(doBlock, TealType.none)
         self.doBlock = doBlock

--- a/pyteal/ast/for_.py
+++ b/pyteal/ast/for_.py
@@ -90,7 +90,7 @@ class For(Expr):
     def has_return(self):
         return False
 
-    def Do(self, doBlock: Expr, *doBlockMulti: list[Expr]):
+    def Do(self, doBlock: Expr, *doBlockMulti: Expr):
         if self.doBlock is not None:
             raise TealCompileError("For expression already has a doBlock", self)
 

--- a/pyteal/ast/for_.py
+++ b/pyteal/ast/for_.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Optional
-from pyteal.ast.seq import use_seq_if_multiple
+from pyteal.ast.seq import _use_seq_if_multiple
 
 from pyteal.types import TealType, require_type
 from pyteal.ir import TealSimpleBlock, TealConditionalBlock
@@ -101,7 +101,7 @@ class For(Expr):
         if self.doBlock is not None:
             raise TealCompileError("For expression already has a doBlock", self)
 
-        doBlock = use_seq_if_multiple(doBlock, *doBlockMulti)
+        doBlock = _use_seq_if_multiple(doBlock, *doBlockMulti)
 
         require_type(doBlock, TealType.none)
         self.doBlock = doBlock

--- a/pyteal/ast/for_.py
+++ b/pyteal/ast/for_.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
+from pyteal.ast.seq import use_seq_if_multiple
 
 from pyteal.types import TealType, require_type
 from pyteal.ir import TealSimpleBlock, TealConditionalBlock
@@ -89,9 +90,12 @@ class For(Expr):
     def has_return(self):
         return False
 
-    def Do(self, doBlock: Expr):
+    def Do(self, doBlock: Expr, *doBlockMulti: List[Expr]):
         if self.doBlock is not None:
             raise TealCompileError("For expression already has a doBlock", self)
+
+        doBlock = use_seq_if_multiple(doBlock, *doBlockMulti)
+
         require_type(doBlock, TealType.none)
         self.doBlock = doBlock
         return self

--- a/pyteal/ast/for_.py
+++ b/pyteal/ast/for_.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 from pyteal.ast.seq import use_seq_if_multiple
 
 from pyteal.types import TealType, require_type
@@ -90,7 +90,7 @@ class For(Expr):
     def has_return(self):
         return False
 
-    def Do(self, doBlock: Expr, *doBlockMulti: List[Expr]):
+    def Do(self, doBlock: Expr, *doBlockMulti: list[Expr]):
         if self.doBlock is not None:
             raise TealCompileError("For expression already has a doBlock", self)
 

--- a/pyteal/ast/for_.py
+++ b/pyteal/ast/for_.py
@@ -24,6 +24,13 @@ class For(Expr):
             start: Expression setting the variable's initial value
             cond: The condition to check. Must evaluate to uint64.
             step: Expression to update the variable's value.
+
+        Example:
+            .. code-block:: python
+
+                i = ScratchVar()
+                For(i.store(Int(0)), i.load() < Int(10), i.store(i.load() + Int(1))
+                    .Do(expr1, expr2, ...)
         """
         super().__init__()
         require_type(cond, TealType.uint64)

--- a/pyteal/ast/for_test.py
+++ b/pyteal/ast/for_test.py
@@ -194,3 +194,36 @@ def test_invalid_for():
             .Do(pt.Continue())
         )
         expr.__str__()
+
+
+def test_for_multi():
+    i = pt.ScratchVar()
+    items = [
+        (i.store(pt.Int(0))),
+        i.load() < pt.Int(10),
+        i.store(i.load() + pt.Int(1)),
+        [pt.Pop(pt.Int(1)), pt.App.globalPut(pt.Itob(i.load()), i.load() * pt.Int(2))],
+    ]
+    expr = pt.For(items[0], items[1], items[2]).Do(*items[3])
+
+    assert expr.type_of() == pt.TealType.none
+    assert not expr.has_return()
+
+    expected, varEnd = items[0].__teal__(options)
+    condStart, condEnd = items[1].__teal__(options)
+    stepStart, stepEnd = items[2].__teal__(options)
+    do, doEnd = pt.Seq(items[3]).__teal__(options)
+    expectedBranch = pt.TealConditionalBlock([])
+    end = pt.TealSimpleBlock([])
+
+    varEnd.setNextBlock(condStart)
+    doEnd.setNextBlock(stepStart)
+
+    expectedBranch.setTrueBlock(do)
+    expectedBranch.setFalseBlock(end)
+    condEnd.setNextBlock(expectedBranch)
+    stepEnd.setNextBlock(condStart)
+
+    actual, _ = expr.__teal__(options)
+
+    assert actual == expected

--- a/pyteal/ast/for_test.py
+++ b/pyteal/ast/for_test.py
@@ -187,6 +187,12 @@ def test_invalid_for():
             pt.Int(0)
         )
 
+    with pytest.raises(pt.TealTypeError):
+        i = pt.ScratchVar()
+        expr = pt.For(i.store(pt.Int(0)), pt.Int(1), i.store(i.load() + pt.Int(1))).Do(
+            pt.Pop(pt.Int(1)), pt.Int(2)
+        )
+
     with pytest.raises(pt.TealCompileError):
         expr = (
             pt.For(i.store(pt.Int(0)), pt.Int(1), i.store(i.load() + pt.Int(1)))

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from pyteal.errors import (
     TealCompileError,
@@ -100,7 +100,7 @@ class If(Expr):
         # otherwise, this expression has a return op only if both branches result in a return op
         return self.thenBranch.has_return() and self.elseBranch.has_return()
 
-    def Then(self, thenBranch: Expr, *thenBranchMulti: List[Expr]):
+    def Then(self, thenBranch: Expr, *thenBranchMulti: list[Expr]):
         if not self.alternateSyntaxFlag:
             raise TealInputError("Cannot mix two different If syntax styles")
 

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -7,7 +7,7 @@ from pyteal.errors import (
 from pyteal.types import TealType, require_type
 from pyteal.ir import TealSimpleBlock, TealConditionalBlock
 from pyteal.ast.expr import Expr
-from pyteal.ast.seq import use_seq_if_multiple
+from pyteal.ast.seq import _use_seq_if_multiple
 
 if TYPE_CHECKING:
     from pyteal.compiler import CompileOptions
@@ -104,7 +104,7 @@ class If(Expr):
         if not self.alternateSyntaxFlag:
             raise TealInputError("Cannot mix two different If syntax styles")
 
-        thenBranch = use_seq_if_multiple(thenBranch, *thenBranchMulti)
+        thenBranch = _use_seq_if_multiple(thenBranch, *thenBranchMulti)
 
         if not self.elseBranch:
             self.thenBranch = thenBranch
@@ -133,7 +133,7 @@ class If(Expr):
         if not self.thenBranch:
             raise TealInputError("Must set Then branch before Else branch")
 
-        elseBranch = use_seq_if_multiple(elseBranch, *elseBranchMulti)
+        elseBranch = _use_seq_if_multiple(elseBranch, *elseBranchMulti)
 
         if not self.elseBranch:
             require_type(elseBranch, self.thenBranch.type_of())

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -100,7 +100,7 @@ class If(Expr):
         # otherwise, this expression has a return op only if both branches result in a return op
         return self.thenBranch.has_return() and self.elseBranch.has_return()
 
-    def Then(self, thenBranch: Expr, *thenBranchMulti: list[Expr]):
+    def Then(self, thenBranch: Expr, *thenBranchMulti: Expr):
         if not self.alternateSyntaxFlag:
             raise TealInputError("Cannot mix two different If syntax styles")
 

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -126,7 +126,7 @@ class If(Expr):
             self.elseBranch.ElseIf(cond)
         return self
 
-    def Else(self, elseBranch: Expr, *elseBranchMulti):
+    def Else(self, elseBranch: Expr, *elseBranchMulti: Expr):
         if not self.alternateSyntaxFlag:
             raise TealInputError("Cannot mix two different If syntax styles")
 

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -100,11 +100,11 @@ class If(Expr):
         # otherwise, this expression has a return op only if both branches result in a return op
         return self.thenBranch.has_return() and self.elseBranch.has_return()
 
-    def Then(self, thenBranch: Expr, *thenBranchMulti: Expr):
+    def Then(self, thenBranch: Expr, *then_branch_multi: Expr):
         if not self.alternateSyntaxFlag:
             raise TealInputError("Cannot mix two different If syntax styles")
 
-        thenBranch = _use_seq_if_multiple(thenBranch, *thenBranchMulti)
+        thenBranch = _use_seq_if_multiple(thenBranch, *then_branch_multi)
 
         if not self.elseBranch:
             self.thenBranch = thenBranch
@@ -126,14 +126,14 @@ class If(Expr):
             self.elseBranch.ElseIf(cond)
         return self
 
-    def Else(self, elseBranch: Expr, *elseBranchMulti: Expr):
+    def Else(self, elseBranch: Expr, *else_branch_multi: Expr):
         if not self.alternateSyntaxFlag:
             raise TealInputError("Cannot mix two different If syntax styles")
 
         if not self.thenBranch:
             raise TealInputError("Must set Then branch before Else branch")
 
-        elseBranch = _use_seq_if_multiple(elseBranch, *elseBranchMulti)
+        elseBranch = _use_seq_if_multiple(elseBranch, *else_branch_multi)
 
         if not self.elseBranch:
             require_type(elseBranch, self.thenBranch.type_of())

--- a/pyteal/ast/if_test.py
+++ b/pyteal/ast/if_test.py
@@ -256,6 +256,10 @@ def test_if_invalid_alt_syntax():
         expr = pt.If(pt.Int(0)).Then(pt.Int(2))
         expr.type_of()
 
+    with pytest.raises(pt.TealTypeError):
+        expr = pt.If(pt.Int(0)).Then(pt.Pop(pt.Int(1)), pt.Int(2))
+        expr.type_of()
+
     with pytest.raises(pt.TealInputError):
         pt.If(pt.Int(0)).Else(pt.Int(1)).Then(pt.Int(2))
 

--- a/pyteal/ast/if_test.py
+++ b/pyteal/ast/if_test.py
@@ -271,3 +271,82 @@ def test_if_invalid_alt_syntax():
 
     with pytest.raises(pt.TealInputError):
         expr = pt.If(pt.Int(0), pt.Pop(pt.Int(1))).Else(pt.Int(2))
+
+
+def test_if_alt_multi():
+    args = [pt.Int(0), [pt.Pop(pt.Int(1)), pt.Int(2)], pt.Int(3)]
+    expr = pt.If(args[0]).Then(*args[1]).Else(args[2])
+
+    expected, _ = args[0].__teal__(options)
+    thenBlockStart, thenBlockEnd = pt.Seq(*args[1]).__teal__(options)
+    elseBlockStart, elseBlockEnd = args[2].__teal__(options)
+    expectedBranch = pt.TealConditionalBlock([])
+    expectedBranch.setTrueBlock(thenBlockStart)
+    expectedBranch.setFalseBlock(elseBlockStart)
+    expected.setNextBlock(expectedBranch)
+    end = pt.TealSimpleBlock([])
+    thenBlockEnd.setNextBlock(end)
+    elseBlockEnd.setNextBlock(end)
+
+    actual, _ = expr.__teal__(options)
+
+    assert actual == expected
+
+
+def test_else_alt_multi():
+    args = [pt.Int(0), pt.Int(1), [pt.Pop(pt.Int(2)), pt.Int(3)]]
+    expr = pt.If(args[0]).Then(args[1]).Else(*args[2])
+
+    expected, _ = args[0].__teal__(options)
+    thenBlockStart, thenBlockEnd = args[1].__teal__(options)
+    elseBlockStart, elseBlockEnd = pt.Seq(*args[2]).__teal__(options)
+    expectedBranch = pt.TealConditionalBlock([])
+    expectedBranch.setTrueBlock(thenBlockStart)
+    expectedBranch.setFalseBlock(elseBlockStart)
+    expected.setNextBlock(expectedBranch)
+    end = pt.TealSimpleBlock([])
+    thenBlockEnd.setNextBlock(end)
+    elseBlockEnd.setNextBlock(end)
+
+    actual, _ = expr.__teal__(options)
+
+    assert actual == expected
+
+
+def test_elseif_multiple_with_multi():
+    args = [
+        pt.Int(0),
+        [pt.Pop(pt.Int(1)), pt.Int(2)],
+        pt.Int(3),
+        [pt.Pop(pt.Int(4)), pt.Int(5)],
+        pt.Int(6),
+        [pt.Pop(pt.Int(7)), pt.Int(8)],
+        [pt.Pop(pt.Int(9)), pt.Int(10)],
+    ]
+    expr = (
+        pt.If(args[0])
+        .Then(*args[1])
+        .ElseIf(args[2])
+        .Then(*args[3])
+        .ElseIf(args[4])
+        .Then(*args[5])
+        .Else(*args[6])
+    )
+
+    elseIfExpr = pt.If(
+        args[2], pt.Seq(args[3]), pt.If(args[4], pt.Seq(args[5]), pt.Seq(args[6]))
+    )
+    expected, _ = args[0].__teal__(options)
+    thenBlock, thenBlockEnd = pt.Seq(args[1]).__teal__(options)
+    elseStart, elseBlockEnd = elseIfExpr.__teal__(options)
+    expectedBranch = pt.TealConditionalBlock([])
+    expectedBranch.setTrueBlock(thenBlock)
+    expectedBranch.setFalseBlock(elseStart)
+    expected.setNextBlock(expectedBranch)
+    end = pt.TealSimpleBlock([])
+    thenBlockEnd.setNextBlock(end)
+    elseBlockEnd.setNextBlock(end)
+
+    actual, _ = expr.__teal__(options)
+
+    assert actual == expected

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -83,3 +83,15 @@ class Seq(Expr):
 
 
 Seq.__module__ = "pyteal"
+
+
+def use_seq_if_multiple(*exprs: List[Expr]):
+    """If multiple expressions are provided, wrap them in a Seq expression."""
+
+    # Handle case where a list of expressions is provided
+    if len(exprs) == 1 and isinstance(exprs[0], list):
+        exprs = exprs[0]
+
+    if len(exprs) > 1:
+        return Seq(*exprs)
+    return exprs[0]

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -86,16 +86,16 @@ Seq.__module__ = "pyteal"
 
 
 @overload
-def use_seq_if_multiple(exprs: list[Expr]) -> Expr:
+def _use_seq_if_multiple(exprs: list[Expr]) -> Expr:
     ...
 
 
 @overload
-def use_seq_if_multiple(*exprs: Expr) -> Expr:
+def _use_seq_if_multiple(*exprs: Expr) -> Expr:
     ...
 
 
-def use_seq_if_multiple(*exprs):
+def _use_seq_if_multiple(*exprs):
     """If multiple expressions are provided, wrap them in a Seq expression."""
 
     # Guard against no expressions

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -104,4 +104,6 @@ def use_seq_if_multiple(*exprs):
 
     if len(exprs) > 1:
         return Seq(*exprs)
+    if len(exprs) == 0:
+        return None
     return exprs[0]

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -1,4 +1,4 @@
-from typing import List, TYPE_CHECKING, overload
+from typing import Union, List, TYPE_CHECKING, overload
 
 from pyteal.types import TealType, require_type
 from pyteal.errors import TealInputError
@@ -85,7 +85,17 @@ class Seq(Expr):
 Seq.__module__ = "pyteal"
 
 
-def use_seq_if_multiple(*exprs: Expr):
+@overload
+def use_seq_if_multiple(exprs: list[Expr]) -> Union[Seq, Expr]:
+    ...
+
+
+@overload
+def use_seq_if_multiple(*exprs: Expr) -> Union[Seq, Expr]:
+    ...
+
+
+def use_seq_if_multiple(*exprs):
     """If multiple expressions are provided, wrap them in a Seq expression."""
 
     # Handle case where a list of expressions is provided

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -98,12 +98,14 @@ def use_seq_if_multiple(*exprs: Expr) -> Expr:
 def use_seq_if_multiple(*exprs):
     """If multiple expressions are provided, wrap them in a Seq expression."""
 
+    # Guard against no expressions
+    if len(exprs) == 0:
+        raise TealInputError("Expressions cannot be empty.")
+
     # Handle case where a list of expressions is provided
     if len(exprs) == 1 and isinstance(exprs[0], list):
         exprs = exprs[0]
 
     if len(exprs) > 1:
         return Seq(*exprs)
-    if len(exprs) == 0:
-        return None
     return exprs[0]

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -1,4 +1,4 @@
-from typing import Union, List, TYPE_CHECKING, overload
+from typing import List, TYPE_CHECKING, overload
 
 from pyteal.types import TealType, require_type
 from pyteal.errors import TealInputError
@@ -86,12 +86,12 @@ Seq.__module__ = "pyteal"
 
 
 @overload
-def use_seq_if_multiple(exprs: list[Expr]) -> Union[Seq, Expr]:
+def use_seq_if_multiple(exprs: list[Expr]) -> Expr:
     ...
 
 
 @overload
-def use_seq_if_multiple(*exprs: Expr) -> Union[Seq, Expr]:
+def use_seq_if_multiple(*exprs: Expr) -> Expr:
     ...
 
 

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -85,7 +85,7 @@ class Seq(Expr):
 Seq.__module__ = "pyteal"
 
 
-def use_seq_if_multiple(*exprs: List[Expr]):
+def use_seq_if_multiple(*exprs: Expr):
     """If multiple expressions are provided, wrap them in a Seq expression."""
 
     # Handle case where a list of expressions is provided

--- a/pyteal/ast/seq_test.py
+++ b/pyteal/ast/seq_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pyteal as pt
+from pyteal.ast.seq import use_seq_if_multiple
 
 options = pt.CompileOptions()
 
@@ -110,5 +111,35 @@ def test_seq_overloads_equivalence():
 
     expected = expr1.__teal__(options)
     actual = expr2.__teal__(options)
+
+    assert actual == expected
+
+
+def test_use_seq_if_multiple():
+    # Test a single expression
+    items = [pt.Int(1)]
+    expr = use_seq_if_multiple(*items)
+
+    expected = items[0].__teal__(options)
+    actual = expr.__teal__(options)
+
+    assert actual == expected
+
+    # Test multiple expressions
+    items = [pt.Pop(pt.Int(1)), pt.Int(2)]
+    expr = use_seq_if_multiple(*items)
+
+    expected = pt.Seq(items).__teal__(options)
+    actual = expr.__teal__(options)
+
+    assert actual == expected
+
+
+def test_use_seq_if_multiple_overloads_equivalence():
+    items = [pt.Pop(pt.Int(1)), pt.Int(2)]
+    expr = use_seq_if_multiple(items)
+
+    expected = pt.Seq(items).__teal__(options)
+    actual = expr.__teal__(options)
 
     assert actual == expected

--- a/pyteal/ast/seq_test.py
+++ b/pyteal/ast/seq_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 import pyteal as pt
-from pyteal.ast.seq import use_seq_if_multiple
+from pyteal.ast.seq import _use_seq_if_multiple
 
 options = pt.CompileOptions()
 
@@ -118,7 +118,7 @@ def test_seq_overloads_equivalence():
 def test_use_seq_if_multiple():
     # Test a single expression
     items = [pt.Int(1)]
-    expr = use_seq_if_multiple(*items)
+    expr = _use_seq_if_multiple(*items)
 
     expected = items[0].__teal__(options)
     actual = expr.__teal__(options)
@@ -127,7 +127,7 @@ def test_use_seq_if_multiple():
 
     # Test multiple expressions
     items = [pt.Pop(pt.Int(1)), pt.Int(2)]
-    expr = use_seq_if_multiple(*items)
+    expr = _use_seq_if_multiple(*items)
 
     expected = pt.Seq(items).__teal__(options)
     actual = expr.__teal__(options)
@@ -137,7 +137,7 @@ def test_use_seq_if_multiple():
 
 def test_use_seq_if_multiple_overloads_equivalence():
     items = [pt.Pop(pt.Int(1)), pt.Int(2)]
-    expr = use_seq_if_multiple(items)
+    expr = _use_seq_if_multiple(items)
 
     expected = pt.Seq(items).__teal__(options)
     actual = expr.__teal__(options)

--- a/pyteal/ast/while_.py
+++ b/pyteal/ast/while_.py
@@ -79,11 +79,11 @@ class While(Expr):
     def has_return(self):
         return False
 
-    def Do(self, doBlock: Expr, *doBlockMulti: Expr):
+    def Do(self, doBlock: Expr, *do_block_multi: Expr):
         if self.doBlock is not None:
             raise TealCompileError("While expression already has a doBlock", self)
 
-        doBlock = _use_seq_if_multiple(doBlock, *doBlockMulti)
+        doBlock = _use_seq_if_multiple(doBlock, *do_block_multi)
 
         require_type(doBlock, TealType.none)
         self.doBlock = doBlock

--- a/pyteal/ast/while_.py
+++ b/pyteal/ast/while_.py
@@ -22,6 +22,14 @@ class While(Expr):
 
         Args:
             cond: The condition to check. Must evaluate to uint64.
+
+        Example:
+            .. code-block:: python
+
+                i = ScratchVar()
+                i.store(Int(0))
+                While(i.load() < pt.Int(2))
+                    .Do(Pop(Int(1)), i.store(i.load() + Int(1)))
         """
         super().__init__()
         require_type(cond, TealType.uint64)

--- a/pyteal/ast/while_.py
+++ b/pyteal/ast/while_.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 from pyteal.ast.seq import use_seq_if_multiple
 
 from pyteal.errors import TealCompileError
@@ -71,7 +71,7 @@ class While(Expr):
     def has_return(self):
         return False
 
-    def Do(self, doBlock: Expr, *doBlockMulti: List[Expr]):
+    def Do(self, doBlock: Expr, *doBlockMulti: list[Expr]):
         if self.doBlock is not None:
             raise TealCompileError("While expression already has a doBlock", self)
 

--- a/pyteal/ast/while_.py
+++ b/pyteal/ast/while_.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Optional
-from pyteal.ast.seq import use_seq_if_multiple
+from pyteal.ast.seq import _use_seq_if_multiple
 
 from pyteal.errors import TealCompileError
 from pyteal.types import TealType, require_type
@@ -83,7 +83,7 @@ class While(Expr):
         if self.doBlock is not None:
             raise TealCompileError("While expression already has a doBlock", self)
 
-        doBlock = use_seq_if_multiple(doBlock, *doBlockMulti)
+        doBlock = _use_seq_if_multiple(doBlock, *doBlockMulti)
 
         require_type(doBlock, TealType.none)
         self.doBlock = doBlock

--- a/pyteal/ast/while_.py
+++ b/pyteal/ast/while_.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
+from pyteal.ast.seq import use_seq_if_multiple
 
 from pyteal.errors import TealCompileError
 from pyteal.types import TealType, require_type
@@ -70,9 +71,12 @@ class While(Expr):
     def has_return(self):
         return False
 
-    def Do(self, doBlock: Expr):
+    def Do(self, doBlock: Expr, *doBlockMulti: List[Expr]):
         if self.doBlock is not None:
             raise TealCompileError("While expression already has a doBlock", self)
+
+        doBlock = use_seq_if_multiple(doBlock, *doBlockMulti)
+
         require_type(doBlock, TealType.none)
         self.doBlock = doBlock
         return self

--- a/pyteal/ast/while_.py
+++ b/pyteal/ast/while_.py
@@ -71,7 +71,7 @@ class While(Expr):
     def has_return(self):
         return False
 
-    def Do(self, doBlock: Expr, *doBlockMulti: list[Expr]):
+    def Do(self, doBlock: Expr, *doBlockMulti: Expr):
         if self.doBlock is not None:
             raise TealCompileError("While expression already has a doBlock", self)
 

--- a/pyteal/ast/while_test.py
+++ b/pyteal/ast/while_test.py
@@ -148,3 +148,25 @@ def test_while_invalid():
     with pytest.raises(pt.TealCompileError):
         expr = pt.While(pt.Int(0)).Do(pt.Continue()).Do(pt.Continue())
         expr.__str__()
+
+
+def test_while_multi():
+    i = pt.ScratchVar()
+    i.store(pt.Int(0))
+    items = [i.load() < pt.Int(2), [pt.Pop(pt.Int(1)), i.store(i.load() + pt.Int(1))]]
+    expr = pt.While(items[0]).Do(*items[1])
+    assert expr.type_of() == pt.TealType.none
+    assert not expr.has_return()
+
+    expected, condEnd = items[0].__teal__(options)
+    do, doEnd = pt.Seq(items[1]).__teal__(options)
+    expectedBranch = pt.TealConditionalBlock([])
+    end = pt.TealSimpleBlock([])
+
+    expectedBranch.setTrueBlock(do)
+    expectedBranch.setFalseBlock(end)
+    condEnd.setNextBlock(expectedBranch)
+    doEnd.setNextBlock(expected)
+    actual, _ = expr.__teal__(options)
+
+    assert actual == expected

--- a/pyteal/ast/while_test.py
+++ b/pyteal/ast/while_test.py
@@ -143,7 +143,9 @@ def test_while_invalid():
 
     with pytest.raises(pt.TealTypeError):
         expr = pt.While(pt.Int(2)).Do(pt.Int(2))
-        expr.__str__()
+
+    with pytest.raises(pt.TealTypeError):
+        expr = pt.While(pt.Int(2)).Do(pt.Pop(pt.Int(2)), pt.Int(2))
 
     with pytest.raises(pt.TealCompileError):
         expr = pt.While(pt.Int(0)).Do(pt.Continue()).Do(pt.Continue())


### PR DESCRIPTION
This PR simplifies multi-expression clauses by using `Seq` internally when more than one expression is given.

#### If/Then/Else

```python
If(x).Then(y1, y2, y3).Else(z1, z2, z3)
# is equivalent to
If(x).Then(Seq(y1, y2, y3)).Else(Seq(z1, z2, z3))
```

#### While/Do

```python
While(x).Do(x1, x2, x3)
# is equivalent to
While(x).Do(Seq(x1, x2, x3)
```

#### For/Do

```python
For(x, y, z).Do(w1, w2, w3)
# is equivalent to
For(x, y, z).Do(Seq(w1, w2, w3))
```

#### Cond

```python
Cond([c1, x1, x2, x3],
     [c2, y1, y2, y3])
# is equivalent to
Cond([c1, Seq(x1, x2, x3)],
     [c2, Seq(y1, y2, y3)])
```

#### Assert

```python
Assert(x, y, z)
# is equivalent to
Seq(Assert(x), Assert(y), Assert(z))
```