### PR TITLE
Add Execute Method

### DIFF
--- a/pyteal/ast/itxn.py
+++ b/pyteal/ast/itxn.py
@@ -182,7 +182,23 @@ class InnerTxnBuilder:
 
     @classmethod
     def Execute(cls, fields: Dict[TxnField, Union[Expr, List[Expr]]]) -> Expr:
-        """Performs a single transaction given fields passed in"""
+        """Performs a single transaction given fields passed in.
+
+        A convenience method that accepts fields to submit a single inner transaction, which is equivalent to:
+
+        .. code-block:: python
+
+            InnerTxnBuilder.Begin()
+            InnerTxnBuilder.SetFields(fields)
+            InnerTxnBuilder.End()
+
+        Requires TEAL version 5 or higher. This operation is only permitted in application mode.
+
+        Args:
+            fields: A dictionary whose keys are fields to set and whose values are the value each
+                field should take. Each value must evaluate to a type that is compatible with the
+                field being set.
+        """
         return Seq(cls.Begin(), cls.SetFields(fields), cls.Submit())
 
     @classmethod

--- a/pyteal/ast/itxn.py
+++ b/pyteal/ast/itxn.py
@@ -181,6 +181,11 @@ class InnerTxnBuilder:
             )
 
     @classmethod
+    def Execute(cls, fields: Dict[TxnField, Union[Expr, List[Expr]]]) -> Expr:
+        """Performs a single transaction given fields passed in"""
+        return Seq(cls.Begin(), cls.SetFields(fields), cls.Submit())
+
+    @classmethod
     def SetFields(cls, fields: Dict[TxnField, Union[Expr, List[Expr]]]) -> Expr:
         """Set multiple fields of the current inner transaction.
 


### PR DESCRIPTION
A very common use case is to fire off a single transaction, we can make this even easier by offering an `Execute` method that accepts the same arguments as `SetFields` and performing the Begin/Submit 

```py
Seq(
    InnerTxnBuilder.Begin(),
    InnerTxnBuilder.SetFields(
        {
            TxnField.type_enum: TxnType.ApplicationCall,
            TxnField.application_id: OpUp.opup_app_id,
        }
    ),
    InnerTxnBuilder.Submit(),
)
```
becomes
```py
 InnerTxnBuilder.Execute({
    TxnField.type_enum: TxnType.ApplicationCall,
    TxnField.application_id: OpUp.opup_app_id,
})
```

Not sold on name, maybe `Perform`?