### PR TITLE
allow passing router description to Contract constructor

### DIFF
--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -510,6 +510,7 @@ class Router:
         """
         Args:
             name: the name of the smart contract, used in the JSON object.
+            descr: a description of the smart contract, used in the JSON object.
             bare_calls: the bare app call registered for each on_completion.
         """
 
@@ -665,7 +666,7 @@ class Router:
 
         Returns:
             contract: a dictified `Contract` object constructed from
-                approval program's method specs and `self.name`.
+                approval program's method specs, `self.name`, and `self.descr`.
         """
 
         return sdk_abi.Contract(self.name, self.methods, self.descr)

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -504,14 +504,14 @@ class Router:
     def __init__(
         self,
         name: str,
-        descr: str = None,
         bare_calls: BareCallActions = None,
+        descr: str = None,
     ) -> None:
         """
         Args:
             name: the name of the smart contract, used in the JSON object.
-            descr: a description of the smart contract, used in the JSON object.
             bare_calls: the bare app call registered for each on_completion.
+            descr: a description of the smart contract, used in the JSON object.
         """
 
         self.name: str = name

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -515,7 +515,7 @@ class Router:
         """
 
         self.name: str = name
-        self.descr: str = descr
+        self.descr = descr
 
         self.approval_ast = ASTBuilder()
         self.clear_state_ast = ASTBuilder()

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -504,6 +504,7 @@ class Router:
     def __init__(
         self,
         name: str,
+        descr: str = None,
         bare_calls: BareCallActions = None,
     ) -> None:
         """
@@ -513,6 +514,8 @@ class Router:
         """
 
         self.name: str = name
+        self.descr: str = descr
+
         self.approval_ast = ASTBuilder()
         self.clear_state_ast = ASTBuilder()
 
@@ -665,7 +668,7 @@ class Router:
                 approval program's method specs and `self.name`.
         """
 
-        return sdk_abi.Contract(self.name, self.methods)
+        return sdk_abi.Contract(self.name, self.methods, self.descr)
 
     def build_program(self) -> tuple[Expr, Expr, sdk_abi.Contract]:
         """


### PR DESCRIPTION
Adding an optional arg to Router to allow a description to be passed through to Contract constructor