### PR TITLE
`abi.Bool` improvements

### DIFF
--- a/pyteal/ast/abi/array_base.py
+++ b/pyteal/ast/abi/array_base.py
@@ -233,7 +233,7 @@ class ArrayElement(ComputedValue[T]):
             bitIndex = self.index
             if arrayType.is_dynamic():
                 bitIndex = bitIndex + Int(Uint16TypeSpec().bit_size())
-            return cast(Bool, output).decodeBit(encodedArray, bitIndex)
+            return cast(Bool, output).decode_bit(encodedArray, bitIndex)
 
         # Compute the byteIndex (first byte indicating the element encoding)
         # (If the array is dynamic, add 2 to byte index for dynamic array length uint16 prefix)

--- a/pyteal/ast/abi/array_base_test.py
+++ b/pyteal/ast/abi/array_base_test.py
@@ -81,7 +81,7 @@ def test_ArrayElement_store_into():
         stride = pt.Int(staticArray.type_spec()._stride())
         expectedLength = staticArray.length()
         if elementType == abi.BoolTypeSpec():
-            expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index)
+            expectedExpr = cast(abi.Bool, output).decode_bit(encoded, index)
         elif not elementType.is_dynamic():
             expectedExpr = output.decode(
                 encoded, start_index=stride * index, length=stride
@@ -122,7 +122,9 @@ def test_ArrayElement_store_into():
         stride = pt.Int(dynamicArray.type_spec()._stride())
         expectedLength = dynamicArray.length()
         if elementType == abi.BoolTypeSpec():
-            expectedExpr = cast(abi.Bool, output).decodeBit(encoded, index + pt.Int(16))
+            expectedExpr = cast(abi.Bool, output).decode_bit(
+                encoded, index + pt.Int(16)
+            )
         elif not elementType.is_dynamic():
             expectedExpr = output.decode(
                 encoded, start_index=stride * index + pt.Int(2), length=stride

--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -88,7 +88,7 @@ class Bool(BaseType):
             return self.stored_value.store(value)
 
         # Not(Not(value)) coerces all values greater than 0 to 1
-        return (self.stored_value.store(Not(Not(value))),)
+        return self.stored_value.store(Not(Not(value)))
 
     def decode(
         self,

--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -88,10 +88,8 @@ class Bool(BaseType):
         if checked:
             return self.stored_value.store(value)
 
-        return Seq(
-            # Not(Not(value)) coerces all values greater than 0 to 1
-            self.stored_value.store(Not(Not(value))),
-        )
+        # Not(Not(value)) coerces all values greater than 0 to 1
+        return (self.stored_value.store(Not(Not(value))),)
 
     def decode(
         self,

--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -3,7 +3,6 @@ from typing import TypeVar, Union, Sequence, Callable
 from pyteal.types import TealType
 from pyteal.errors import TealInputError
 from pyteal.ast.expr import Expr
-from pyteal.ast.seq import Seq
 from pyteal.ast.int import Int
 from pyteal.ast.bytes import Bytes
 from pyteal.ast.unaryexpr import Not

--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -4,9 +4,9 @@ from pyteal.types import TealType
 from pyteal.errors import TealInputError
 from pyteal.ast.expr import Expr
 from pyteal.ast.seq import Seq
-from pyteal.ast.assert_ import Assert
 from pyteal.ast.int import Int
 from pyteal.ast.bytes import Bytes
+from pyteal.ast.unaryexpr import Not
 from pyteal.ast.binaryexpr import GetBit
 from pyteal.ast.ternaryexpr import SetBit
 from pyteal.ast.abi.type import ComputedValue, TypeSpec, BaseType
@@ -59,7 +59,7 @@ class Bool(BaseType):
         The behavior of this method depends on the input argument type:
 
             * :code:`bool`: set the value to a Python boolean value.
-            * :code:`Expr`: set the value to the result of a PyTeal expression, which must evaluate to a TealType.uint64. The program will fail if the evaluated value is not 0 or 1.
+            * :code:`Expr`: set the value to the result of a PyTeal expression, which must evaluate to a TealType.uint64. All values greater than 0 are considered true, while 0 is considered false.
             * :code:`Bool`: copy the value from another Bool.
             * :code:`ComputedValue[Bool]`: copy the value from a Bool produced by a ComputedValue.
 
@@ -89,9 +89,8 @@ class Bool(BaseType):
             return self.stored_value.store(value)
 
         return Seq(
-            self.stored_value.store(value),
-            # instead of failing if too high of a value is given, it's probably more consistent with the rest of the AVM to convert values >= 2 to 1 (the && and || opcodes do this)
-            Assert(self.stored_value.load() < Int(2)),
+            # Not(Not(value)) coerces all values greater than 0 to 1
+            self.stored_value.store(Not(Not(value))),
         )
 
     def decode(
@@ -104,9 +103,9 @@ class Bool(BaseType):
     ) -> Expr:
         if start_index is None:
             start_index = Int(0)
-        return self.decodeBit(encoded, start_index * Int(NUM_BITS_IN_BYTE))
+        return self.decode_bit(encoded, start_index * Int(NUM_BITS_IN_BYTE))
 
-    def decodeBit(self, encoded, bitIndex: Expr) -> Expr:
+    def decode_bit(self, encoded, bitIndex: Expr) -> Expr:
         return self.stored_value.store(GetBit(encoded, bitIndex))
 
     def encode(self) -> Expr:

--- a/pyteal/ast/abi/bool_test.py
+++ b/pyteal/ast/abi/bool_test.py
@@ -76,11 +76,9 @@ def test_Bool_set_expr():
             pt.TealOp(None, pt.Op.int, 0),
             pt.TealOp(None, pt.Op.int, 1),
             pt.TealOp(None, pt.Op.logic_or),
+            pt.TealOp(None, pt.Op.logic_not),
+            pt.TealOp(None, pt.Op.logic_not),
             pt.TealOp(None, pt.Op.store, value.stored_value.slot),
-            pt.TealOp(None, pt.Op.load, value.stored_value.slot),
-            pt.TealOp(None, pt.Op.int, 2),
-            pt.TealOp(None, pt.Op.lt),
-            pt.TealOp(None, pt.Op.assert_),
         ]
     )
 
@@ -188,11 +186,11 @@ def test_Bool_decode():
                     assert actual == expected
 
 
-def test_Bool_decodeBit():
+def test_Bool_decode_bit():
     value = abi.Bool()
     bitIndex = pt.Int(17)
     encoded = pt.Bytes("encoded")
-    expr = value.decodeBit(encoded, bitIndex)
+    expr = value.decode_bit(encoded, bitIndex)
     assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -152,7 +152,7 @@ def indexTuple(
         else:
             # value is the beginning of a bool sequence (or a single bool)
             bitOffsetInEncoded = offset * NUM_BITS_IN_BYTE
-        return output.decodeBit(encoded, Int(bitOffsetInEncoded))
+        return output.decode_bit(encoded, Int(bitOffsetInEncoded))
 
     if valueType.is_dynamic():
         hasNextDynamicValue = False

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -268,37 +268,37 @@ def test_indexTuple():
         IndexTest(
             types=[bool_t],
             typeIndex=0,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(0)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(0)),
         ),
         IndexTest(
             types=[bool_t, bool_t],
             typeIndex=0,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(0)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(0)),
         ),
         IndexTest(
             types=[bool_t, bool_t],
             typeIndex=1,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(1)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(1)),
         ),
         IndexTest(
             types=[uint64_t, bool_t],
             typeIndex=1,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(8 * 8)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(8 * 8)),
         ),
         IndexTest(
             types=[uint64_t, bool_t, bool_t],
             typeIndex=1,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(8 * 8)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(8 * 8)),
         ),
         IndexTest(
             types=[uint64_t, bool_t, bool_t],
             typeIndex=2,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(8 * 8 + 1)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(8 * 8 + 1)),
         ),
         IndexTest(
             types=[bool_t, uint64_t],
             typeIndex=0,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(0)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(0)),
         ),
         IndexTest(
             types=[bool_t, uint64_t],
@@ -308,12 +308,12 @@ def test_indexTuple():
         IndexTest(
             types=[bool_t, bool_t, uint64_t],
             typeIndex=0,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(0)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(0)),
         ),
         IndexTest(
             types=[bool_t, bool_t, uint64_t],
             typeIndex=1,
-            expected=lambda output: output.decodeBit(encoded, pt.Int(1)),
+            expected=lambda output: output.decode_bit(encoded, pt.Int(1)),
         ),
         IndexTest(
             types=[bool_t, bool_t, uint64_t],

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool).teal
@@ -52,10 +52,8 @@ boolcomp_2:
 store 9
 load 9
 !
+!
+!
 store 10
-load 10
-int 2
-<
-assert
 load 10
 retsub

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool)[10].teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool)[10].teal
@@ -178,10 +178,8 @@ boolcomp_3:
 store 21
 load 21
 !
+!
+!
 store 22
-load 22
-int 2
-<
-assert
 load 22
 retsub

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte).teal
@@ -64,11 +64,9 @@ boolcomp_2:
 store 10
 load 10
 !
+!
+!
 store 11
-load 11
-int 2
-<
-assert
 load 11
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string).teal
@@ -143,11 +143,9 @@ boolcomp_2:
 store 12
 load 12
 !
+!
+!
 store 13
-load 13
-int 2
-<
-assert
 load 13
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,(address,(uint32,string[],bool[2],(byte),uint8)[2],string,bool[]))[]_<2>.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,(address,(uint32,string[],bool[2],(byte),uint8)[2],string,bool[]))[]_<2>.teal
@@ -304,11 +304,9 @@ boolcomp_3:
 store 23
 load 23
 !
+!
+!
 store 24
-load 24
-int 2
-<
-assert
 load 24
 retsub
 
@@ -1638,11 +1636,9 @@ boolcomp_14:
 store 170
 load 170
 !
+!
+!
 store 171
-load 171
-int 2
-<
-assert
 load 171
 retsub
 
@@ -1956,11 +1952,9 @@ boolcomp_19:
 store 144
 load 144
 !
+!
+!
 store 145
-load 145
-int 2
-<
-assert
 load 145
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,uint64).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,uint64).teal
@@ -153,11 +153,9 @@ boolcomp_2:
 store 13
 load 13
 !
+!
+!
 store 14
-load 14
-int 2
-<
-assert
 load 14
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,uint64,uint32).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,uint64,uint32).teal
@@ -73,11 +73,10 @@ boolcomp_2:
 store 11
 load 11
 !
+!
+!
 store 12
 load 12
-int 2
-<
-assert
 load 12
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,uint64,uint32).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,uint64,uint32).teal
@@ -77,7 +77,6 @@ load 11
 !
 store 12
 load 12
-load 12
 retsub
 
 // numerical_comp

--- a/tests/integration/teal/roundtrip/app_roundtrip_(byte,bool,uint64).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(byte,bool,uint64).teal
@@ -88,11 +88,9 @@ boolcomp_3:
 store 13
 load 13
 !
+!
+!
 store 14
-load 14
-int 2
-<
-assert
 load 14
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_(byte[4],(bool,bool),uint64,address)[]_<7>.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(byte[4],(bool,bool),uint64,address)[]_<7>.teal
@@ -814,11 +814,9 @@ boolcomp_9:
 store 33
 load 33
 !
+!
+!
 store 34
-load 34
-int 2
-<
-assert
 load 34
 retsub
 
@@ -827,10 +825,8 @@ boolcomp_10:
 store 35
 load 35
 !
+!
+!
 store 36
-load 36
-int 2
-<
-assert
 load 36
 retsub

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint8,byte,bool).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint8,byte,bool).teal
@@ -104,10 +104,8 @@ boolcomp_4:                     // [bool]
 store 15                        // 15 -> bool
 load 15                         // [bool]
 !                               // [!bool]
+!
+!
 store 16                        // 16 -> !bool
-load 16                         // [!bool]
-int 2                           // [!bool, 2]
-<                               // [1]
-assert                          // []
 load 16                         // [!bool]
 retsub

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool.teal
@@ -20,11 +20,9 @@ boolcomp_0:
 store 6
 load 6
 !
+!
+!
 store 7
-load 7
-int 2
-<
-assert
 load 7
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[1].teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[1].teal
@@ -16,11 +16,9 @@ boolcomp_0:
 store 9
 load 9
 !
+!
+!
 store 10
-load 10
-int 2
-<
-assert
 load 10
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[3][]_<11>.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[3][]_<11>.teal
@@ -16,11 +16,9 @@ boolcomp_0:
 store 24
 load 24
 !
+!
+!
 store 25
-load 25
-int 2
-<
-assert
 load 25
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[42].teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[42].teal
@@ -16,11 +16,9 @@ boolcomp_0:
 store 50
 load 50
 !
+!
+!
 store 51
-load 51
-int 2
-<
-assert
 load 51
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[]_<1>.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[]_<1>.teal
@@ -16,11 +16,9 @@ boolcomp_0:
 store 9
 load 9
 !
+!
+!
 store 10
-load 10
-int 2
-<
-assert
 load 10
 retsub
 

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[]_<42>.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[]_<42>.teal
@@ -16,11 +16,9 @@ boolcomp_0:
 store 50
 load 50
 !
+!
+!
 store 51
-load 51
-int 2
-<
-assert
 load 51
 retsub
 


### PR DESCRIPTION
This PR makes two small improvements to `abi.Bool`:

1. When calling `abi.Bool.set` with an `Expr`, the program will no longer panic if the value is greater than 1. Instead, all values greater than 0 will be treated as true. This is more in line with other AVM opcodes which accept boolean values.
2. Rename `abi.Bool.decodeBit` to `abi.Bool.decode_bit`