### PR TITLE
Rename pyteal/ast/abi/bool.py functions to follow PEP 8 conventions

### DIFF
--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -5,7 +5,7 @@ from pyteal.ast.expr import Expr
 from pyteal.ast.int import Int
 
 from pyteal.ast.abi.type import ComputedValue, TypeSpec, BaseType
-from pyteal.ast.abi.bool import BoolTypeSpec, boolSequenceLength
+from pyteal.ast.abi.bool import BoolTypeSpec, _bool_sequence_length
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
 
 
@@ -52,7 +52,7 @@ class StaticArrayTypeSpec(ArrayTypeSpec[T], Generic[T, N]):
         length = self.length_static()
 
         if value_type == BoolTypeSpec():
-            return boolSequenceLength(length)
+            return _bool_sequence_length(length)
         return length * value_type.byte_length_static()
 
     def __eq__(self, other: object) -> bool:

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -4,7 +4,7 @@ import pyteal as pt
 from pyteal import abi
 from pyteal.ast.abi.util import substringForDecoding
 from pyteal.ast.abi.tuple import encodeTuple
-from pyteal.ast.abi.bool import boolSequenceLength
+from pyteal.ast.abi.bool import _bool_sequence_length
 from pyteal.ast.abi.type_test import ContainerType
 from pyteal.ast.abi.array_base_test import STATIC_TYPES, DYNAMIC_TYPES
 
@@ -84,7 +84,7 @@ def test_StaticArrayTypeSpec_byte_length_static():
             actual = staticArrayType.byte_length_static()
 
             if elementType == abi.BoolTypeSpec():
-                expected = boolSequenceLength(length)
+                expected = _bool_sequence_length(length)
             else:
                 expected = elementType.byte_length_static() * length
 

--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -116,7 +116,7 @@ class Bool(BaseType):
 Bool.__module__ = "pyteal.abi"
 
 
-def boolAwareStaticByteLength(types: Sequence[TypeSpec]) -> int:
+def _bool_aware_static_byte_length(types: Sequence[TypeSpec]) -> int:
     length = 0
     ignoreNext = 0
     for i, t in enumerate(types):
@@ -124,9 +124,9 @@ def boolAwareStaticByteLength(types: Sequence[TypeSpec]) -> int:
             ignoreNext -= 1
             continue
         if t == BoolTypeSpec():
-            numBools = consecutiveBoolTypeSpecNum(types, i)
+            numBools = _consecutive_bool_type_spec_num(types, i)
             ignoreNext = numBools - 1
-            length += boolSequenceLength(numBools)
+            length += _bool_sequence_length(numBools)
             continue
         length += t.byte_length_static()
     return length
@@ -135,7 +135,7 @@ def boolAwareStaticByteLength(types: Sequence[TypeSpec]) -> int:
 T = TypeVar("T")
 
 
-def consecutiveThingNum(
+def _consecutive_thing_num(
     things: Sequence[T], start_index: int, condition: Callable[[T], bool]
 ) -> int:
     numConsecutiveThings = 0
@@ -146,28 +146,28 @@ def consecutiveThingNum(
     return numConsecutiveThings
 
 
-def consecutiveBoolTypeSpecNum(types: Sequence[TypeSpec], start_index: int) -> int:
+def _consecutive_bool_type_spec_num(types: Sequence[TypeSpec], start_index: int) -> int:
     if len(types) != 0 and not isinstance(types[0], TypeSpec):
         raise TypeError("Sequence of types expected")
-    return consecutiveThingNum(types, start_index, lambda t: t == BoolTypeSpec())
+    return _consecutive_thing_num(types, start_index, lambda t: t == BoolTypeSpec())
 
 
-def consecutiveBoolInstanceNum(values: Sequence[BaseType], start_index: int) -> int:
+def _consecutive_bool_instance_num(values: Sequence[BaseType], start_index: int) -> int:
     if len(values) != 0 and not isinstance(values[0], BaseType):
         raise TypeError(
             "Sequence of types expected, but got {}".format(type(values[0]))
         )
-    return consecutiveThingNum(
+    return _consecutive_thing_num(
         values, start_index, lambda t: t.type_spec() == BoolTypeSpec()
     )
 
 
-def boolSequenceLength(num_bools: int) -> int:
+def _bool_sequence_length(num_bools: int) -> int:
     """Get the length in bytes of an encoding of `num_bools` consecutive booleans values."""
     return (num_bools + NUM_BITS_IN_BYTE - 1) // NUM_BITS_IN_BYTE
 
 
-def encodeBoolSequence(values: Sequence[Bool]) -> Expr:
+def _encode_bool_sequence(values: Sequence[Bool]) -> Expr:
     """Encoding a sequences of boolean values into a byte string.
 
     Args:
@@ -176,7 +176,7 @@ def encodeBoolSequence(values: Sequence[Bool]) -> Expr:
     Returns:
         An expression which creates an encoded byte string with the input boolean values.
     """
-    length = boolSequenceLength(len(values))
+    length = _bool_sequence_length(len(values))
     expr: Expr = Bytes(b"\x00" * length)
 
     for i, value in enumerate(values):

--- a/pyteal/ast/abi/bool_test.py
+++ b/pyteal/ast/abi/bool_test.py
@@ -5,11 +5,11 @@ import pyteal as pt
 from pyteal import abi
 from pyteal.ast.abi.type_test import ContainerType
 from pyteal.ast.abi.bool import (
-    boolAwareStaticByteLength,
-    consecutiveBoolInstanceNum,
-    consecutiveBoolTypeSpecNum,
-    boolSequenceLength,
-    encodeBoolSequence,
+    _bool_aware_static_byte_length,
+    _consecutive_bool_instance_num,
+    _consecutive_bool_type_spec_num,
+    _bool_sequence_length,
+    _encode_bool_sequence,
 )
 
 options = pt.CompileOptions(version=5)
@@ -272,7 +272,7 @@ def test_boolAwareStaticByteLength():
     ]
 
     for i, test in enumerate(tests):
-        actual = boolAwareStaticByteLength(test.types)
+        actual = _bool_aware_static_byte_length(test.types)
         assert actual == test.expectedLength, "Test at index {} failed".format(i)
 
 
@@ -352,10 +352,10 @@ def test_consecutiveBool():
     ]
 
     for i, test in enumerate(tests):
-        actual = consecutiveBoolTypeSpecNum(test.types, test.start)
+        actual = _consecutive_bool_type_spec_num(test.types, test.start)
         assert actual == test.expected, "Test at index {} failed".format(i)
 
-        actual = consecutiveBoolInstanceNum(
+        actual = _consecutive_bool_instance_num(
             [t.new_instance() for t in test.types], test.start
         )
         assert actual == test.expected, "Test at index {} failed".format(i)
@@ -377,7 +377,7 @@ def test_boolSequenceLength():
     ]
 
     for i, test in enumerate(tests):
-        actual = boolSequenceLength(test.numBools)
+        actual = _bool_sequence_length(test.numBools)
         assert actual == test.expectedLength, "Test at index {} failed".format(i)
 
 
@@ -396,7 +396,7 @@ def test_encodeBoolSequence():
     ]
 
     for i, test in enumerate(tests):
-        expr = encodeBoolSequence(test.types)
+        expr = _encode_bool_sequence(test.types)
         assert expr.type_of() == pt.TealType.bytes
         assert not expr.has_return()
 

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -24,11 +24,11 @@ from pyteal.ast.abi.type import TypeSpec, BaseType, ComputedValue
 from pyteal.ast.abi.bool import (
     Bool,
     BoolTypeSpec,
-    consecutiveBoolInstanceNum,
-    consecutiveBoolTypeSpecNum,
-    boolSequenceLength,
-    encodeBoolSequence,
-    boolAwareStaticByteLength,
+    _consecutive_bool_instance_num,
+    _consecutive_bool_type_spec_num,
+    _bool_sequence_length,
+    _encode_bool_sequence,
+    _bool_aware_static_byte_length,
 )
 from pyteal.ast.abi.uint import NUM_BITS_IN_BYTE, Uint16
 from pyteal.ast.abi.util import substringForDecoding
@@ -48,11 +48,11 @@ def encodeTuple(values: Sequence[BaseType]) -> Expr:
         elemType = elem.type_spec()
 
         if elemType == BoolTypeSpec():
-            numBools = consecutiveBoolInstanceNum(values, i)
+            numBools = _consecutive_bool_instance_num(values, i)
             ignoreNext = numBools - 1
-            head_length_static += boolSequenceLength(numBools)
+            head_length_static += _bool_sequence_length(numBools)
             heads.append(
-                encodeBoolSequence(cast(Sequence[Bool], values[i : i + numBools]))
+                _encode_bool_sequence(cast(Sequence[Bool], values[i : i + numBools]))
             )
             continue
 
@@ -129,8 +129,8 @@ def indexTuple(
 
         if typeBefore == BoolTypeSpec():
             lastBoolStart = offset
-            lastBoolLength = consecutiveBoolTypeSpecNum(valueTypes, i)
-            offset += boolSequenceLength(lastBoolLength)
+            lastBoolLength = _consecutive_bool_type_spec_num(valueTypes, i)
+            offset += _bool_sequence_length(lastBoolLength)
             ignoreNext = lastBoolLength - 1
             continue
 
@@ -164,8 +164,8 @@ def indexTuple(
                 continue
 
             if type(typeAfter) is BoolTypeSpec:
-                boolLength = consecutiveBoolTypeSpecNum(valueTypes, i)
-                nextDynamicValueOffset += boolSequenceLength(boolLength)
+                boolLength = _consecutive_bool_type_spec_num(valueTypes, i)
+                nextDynamicValueOffset += _bool_sequence_length(boolLength)
                 ignoreNext = boolLength - 1
                 continue
 
@@ -254,7 +254,7 @@ class TupleTypeSpec(TypeSpec):
     def byte_length_static(self) -> int:
         if self.is_dynamic():
             raise ValueError("Type is dynamic")
-        return boolAwareStaticByteLength(self.value_type_specs())
+        return _bool_aware_static_byte_length(self.value_type_specs())
 
     def storage_type(self) -> TealType:
         return TealType.bytes

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -4,7 +4,7 @@ import pytest
 import pyteal as pt
 from pyteal import abi
 from pyteal.ast.abi.tuple import encodeTuple, indexTuple, TupleElement
-from pyteal.ast.abi.bool import encodeBoolSequence
+from pyteal.ast.abi.bool import _encode_bool_sequence
 from pyteal.ast.abi.util import substringForDecoding
 from pyteal.ast.abi.type_test import ContainerType
 
@@ -39,21 +39,25 @@ def test_encodeTuple():
         ),
         EncodeTest(types=[bool_a], expected=bool_a.encode()),
         EncodeTest(
-            types=[bool_a, bool_b], expected=encodeBoolSequence([bool_a, bool_b])
+            types=[bool_a, bool_b], expected=_encode_bool_sequence([bool_a, bool_b])
         ),
         EncodeTest(
             types=[bool_a, bool_b, uint64_a],
-            expected=pt.Concat(encodeBoolSequence([bool_a, bool_b]), uint64_a.encode()),
+            expected=pt.Concat(
+                _encode_bool_sequence([bool_a, bool_b]), uint64_a.encode()
+            ),
         ),
         EncodeTest(
             types=[uint64_a, bool_a, bool_b],
-            expected=pt.Concat(uint64_a.encode(), encodeBoolSequence([bool_a, bool_b])),
+            expected=pt.Concat(
+                uint64_a.encode(), _encode_bool_sequence([bool_a, bool_b])
+            ),
         ),
         EncodeTest(
             types=[uint64_a, bool_a, bool_b, uint64_b],
             expected=pt.Concat(
                 uint64_a.encode(),
-                encodeBoolSequence([bool_a, bool_b]),
+                _encode_bool_sequence([bool_a, bool_b]),
                 uint64_b.encode(),
             ),
         ),
@@ -69,7 +73,7 @@ def test_encodeTuple():
             expected=pt.Concat(
                 uint64_a.encode(),
                 tuple_a.encode(),
-                encodeBoolSequence([bool_a, bool_b]),
+                _encode_bool_sequence([bool_a, bool_b]),
             ),
         ),
         EncodeTest(
@@ -121,7 +125,7 @@ def test_encodeTuple():
                     uint16_a.set(8 + 2 + 1),
                     uint16_a.encode(),
                 ),
-                encodeBoolSequence([bool_a, bool_b]),
+                _encode_bool_sequence([bool_a, bool_b]),
                 tail_holder.load(),
             ),
         ),
@@ -177,7 +181,7 @@ def test_encodeTuple():
                     uint16_b.set(uint16_a.get() + pt.Len(encoded_tail.load())),
                     uint16_a.encode(),
                 ),
-                encodeBoolSequence([bool_a, bool_b]),
+                _encode_bool_sequence([bool_a, bool_b]),
                 pt.Seq(
                     encoded_tail.store(dynamic_array_c.encode()),
                     tail_holder.store(


### PR DESCRIPTION
Renames `pyteal/ast/abi/bool.py` functions to follow PEP 8 conventions.  Adds leading `_` to demarcate internal functions.

If reviewers feel the internal usage does not apply, let me know and I'll adjust.