### PR TITLE
Rename pyteal/ast/abi/util.py functions to follow PEP 8 conventions

### DIFF
--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -4,7 +4,7 @@ from pyteal import abi
 
 from pyteal.ast.abi.address import AddressLength
 from pyteal.ast.abi.type_test import ContainerType
-from pyteal.ast.abi.util import substringForDecoding
+from pyteal.ast.abi.util import substring_for_decoding
 
 
 options = pt.CompileOptions(version=5)
@@ -80,7 +80,7 @@ def test_Address_decode():
                 assert expr.has_return() is False
 
                 expectedExpr = value.stored_value.store(
-                    substringForDecoding(
+                    substring_for_decoding(
                         encoded,
                         start_index=start_index,
                         end_index=end_index,

--- a/pyteal/ast/abi/array_base.py
+++ b/pyteal/ast/abi/array_base.py
@@ -22,7 +22,7 @@ from pyteal.ast.abi.type import TypeSpec, BaseType, ComputedValue
 from pyteal.ast.abi.tuple import encodeTuple
 from pyteal.ast.abi.bool import Bool, BoolTypeSpec
 from pyteal.ast.abi.uint import Uint16, Uint16TypeSpec
-from pyteal.ast.abi.util import substringForDecoding
+from pyteal.ast.abi.util import substring_for_decoding
 
 T = TypeVar("T", bound=BaseType)
 
@@ -101,7 +101,7 @@ class Array(BaseType, Generic[T]):
             An expression that partitions the needed parts from given byte strings and stores into
             the scratch variable.
         """
-        extracted = substringForDecoding(
+        extracted = substring_for_decoding(
             encoded, start_index=start_index, end_index=end_index, length=length
         )
         return self.stored_value.store(extracted)

--- a/pyteal/ast/abi/array_dynamic_test.py
+++ b/pyteal/ast/abi/array_dynamic_test.py
@@ -3,7 +3,7 @@ import pytest
 
 import pyteal as pt
 from pyteal import abi
-from pyteal.ast.abi.util import substringForDecoding
+from pyteal.ast.abi.util import substring_for_decoding
 from pyteal.ast.abi.tuple import encodeTuple
 from pyteal.ast.abi.array_base_test import STATIC_TYPES, DYNAMIC_TYPES
 from pyteal.ast.abi.type_test import ContainerType
@@ -84,7 +84,7 @@ def test_DynamicArray_decode():
                 assert not expr.has_return()
 
                 expectedExpr = value.stored_value.store(
-                    substringForDecoding(
+                    substring_for_decoding(
                         encoded,
                         start_index=start_index,
                         end_index=end_index,

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -2,7 +2,7 @@ import pytest
 
 import pyteal as pt
 from pyteal import abi
-from pyteal.ast.abi.util import substringForDecoding
+from pyteal.ast.abi.util import substring_for_decoding
 from pyteal.ast.abi.tuple import encodeTuple
 from pyteal.ast.abi.bool import boolSequenceLength
 from pyteal.ast.abi.type_test import ContainerType
@@ -125,7 +125,7 @@ def test_StaticArray_decode():
                 assert not expr.has_return()
 
                 expectedExpr = value.stored_value.store(
-                    substringForDecoding(
+                    substring_for_decoding(
                         encoded,
                         start_index=start_index,
                         end_index=end_index,

--- a/pyteal/ast/abi/string_test.py
+++ b/pyteal/ast/abi/string_test.py
@@ -2,7 +2,7 @@ import pytest
 
 import pyteal as pt
 from pyteal import abi
-from pyteal.ast.abi.util import substringForDecoding
+from pyteal.ast.abi.util import substring_for_decoding
 from pyteal.ast.abi.type_test import ContainerType
 from pyteal.util import escapeStr
 
@@ -71,7 +71,7 @@ def test_DynamicArray_decode():
                 assert expr.has_return() is False
 
                 expectedExpr = value.stored_value.store(
-                    substringForDecoding(
+                    substring_for_decoding(
                         encoded,
                         start_index=start_index,
                         end_index=end_index,

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -31,7 +31,7 @@ from pyteal.ast.abi.bool import (
     boolAwareStaticByteLength,
 )
 from pyteal.ast.abi.uint import NUM_BITS_IN_BYTE, Uint16
-from pyteal.ast.abi.util import substringForDecoding
+from pyteal.ast.abi.util import substring_for_decoding
 
 
 def encodeTuple(values: Sequence[BaseType]) -> Expr:
@@ -287,7 +287,7 @@ class Tuple(BaseType):
         end_index: Expr = None,
         length: Expr = None,
     ) -> Expr:
-        extracted = substringForDecoding(
+        extracted = substring_for_decoding(
             encoded, start_index=start_index, end_index=end_index, length=length
         )
         return self.stored_value.store(extracted)

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -5,7 +5,7 @@ import pyteal as pt
 from pyteal import abi
 from pyteal.ast.abi.tuple import encodeTuple, indexTuple, TupleElement
 from pyteal.ast.abi.bool import encodeBoolSequence
-from pyteal.ast.abi.util import substringForDecoding
+from pyteal.ast.abi.util import substring_for_decoding
 from pyteal.ast.abi.type_test import ContainerType
 
 options = pt.CompileOptions(version=5)
@@ -620,7 +620,7 @@ def test_Tuple_decode():
                 assert not expr.has_return()
 
                 expectedExpr = tupleValue.stored_value.store(
-                    substringForDecoding(
+                    substring_for_decoding(
                         encoded,
                         start_index=start_index,
                         end_index=end_index,

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -19,7 +19,7 @@ from pyteal.ast.substring import Extract, Substring, Suffix
 from pyteal.ast.abi.type import TypeSpec, BaseType
 
 
-def substringForDecoding(
+def substring_for_decoding(
     encoded: Expr,
     *,
     start_index: Expr = None,

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -7,7 +7,7 @@ import algosdk.abi
 import pyteal as pt
 from pyteal import abi
 from pyteal.ast.abi.util import (
-    substringForDecoding,
+    substring_for_decoding,
     int_literal_from_annotation,
     type_spec_from_algosdk,
     type_spec_from_annotation,
@@ -76,7 +76,7 @@ def test_substringForDecoding():
     for i, test in enumerate(tests):
         if not isinstance(test.expected, pt.Expr):
             with pytest.raises(test.expected):
-                substringForDecoding(
+                substring_for_decoding(
                     encoded,
                     start_index=test.start_index,
                     end_index=test.end_index,
@@ -84,7 +84,7 @@ def test_substringForDecoding():
                 )
             continue
 
-        expr = substringForDecoding(
+        expr = substring_for_decoding(
             encoded,
             start_index=test.start_index,
             end_index=test.end_index,


### PR DESCRIPTION
Renames `pyteal/ast/abi/util.py` functions to follow PEP 8 conventions.