### PR TITLE
Rename pyteal/ast/abi/tuple.py functions to follow PEP 8 conventions

### DIFF
--- a/pyteal/ast/abi/array_base.py
+++ b/pyteal/ast/abi/array_base.py
@@ -19,7 +19,7 @@ from pyteal.ast.binaryexpr import ExtractUint16
 from pyteal.ast.naryexpr import Concat
 
 from pyteal.ast.abi.type import TypeSpec, BaseType, ComputedValue
-from pyteal.ast.abi.tuple import encodeTuple
+from pyteal.ast.abi.tuple import _encode_tuple
 from pyteal.ast.abi.bool import Bool, BoolTypeSpec
 from pyteal.ast.abi.uint import Uint16, Uint16TypeSpec
 from pyteal.ast.abi.util import substringForDecoding
@@ -135,7 +135,7 @@ class Array(BaseType, Generic[T]):
                     )
                 )
 
-        encoded = encodeTuple(values)
+        encoded = _encode_tuple(values)
 
         if self.type_spec().is_length_dynamic():
             length_tmp = Uint16()

--- a/pyteal/ast/abi/array_dynamic_test.py
+++ b/pyteal/ast/abi/array_dynamic_test.py
@@ -4,7 +4,7 @@ import pytest
 import pyteal as pt
 from pyteal import abi
 from pyteal.ast.abi.util import substringForDecoding
-from pyteal.ast.abi.tuple import encodeTuple
+from pyteal.ast.abi.tuple import _encode_tuple
 from pyteal.ast.abi.array_base_test import STATIC_TYPES, DYNAMIC_TYPES
 from pyteal.ast.abi.type_test import ContainerType
 
@@ -121,7 +121,7 @@ def test_DynamicArray_set_values():
         expectedExpr = value.stored_value.store(
             pt.Concat(
                 pt.Seq(length_tmp.set(len(values)), length_tmp.encode()),
-                encodeTuple(values),
+                _encode_tuple(values),
             )
         )
         expected, _ = expectedExpr.__teal__(options)

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -3,7 +3,7 @@ import pytest
 import pyteal as pt
 from pyteal import abi
 from pyteal.ast.abi.util import substringForDecoding
-from pyteal.ast.abi.tuple import encodeTuple
+from pyteal.ast.abi.tuple import _encode_tuple
 from pyteal.ast.abi.bool import boolSequenceLength
 from pyteal.ast.abi.type_test import ContainerType
 from pyteal.ast.abi.array_base_test import STATIC_TYPES, DYNAMIC_TYPES
@@ -167,7 +167,7 @@ def test_StaticArray_set_values():
     assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expectedExpr = value.stored_value.store(encodeTuple(values))
+    expectedExpr = value.stored_value.store(_encode_tuple(values))
     expected, _ = expectedExpr.__teal__(options)
     expected.addIncoming()
     expected = pt.TealBlock.NormalizeBlocks(expected)

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -3,7 +3,7 @@ import pytest
 
 import pyteal as pt
 from pyteal import abi
-from pyteal.ast.abi.tuple import encodeTuple, indexTuple, TupleElement
+from pyteal.ast.abi.tuple import _encode_tuple, _index_tuple, TupleElement
 from pyteal.ast.abi.bool import encodeBoolSequence
 from pyteal.ast.abi.util import substringForDecoding
 from pyteal.ast.abi.type_test import ContainerType
@@ -192,7 +192,7 @@ def test_encodeTuple():
     ]
 
     for i, test in enumerate(tests):
-        expr = encodeTuple(test.types)
+        expr = _encode_tuple(test.types)
         assert expr.type_of() == pt.TealType.bytes
         assert not expr.has_return()
 
@@ -426,7 +426,7 @@ def test_indexTuple():
 
     for i, test in enumerate(tests):
         output = test.types[test.typeIndex].new_instance()
-        expr = indexTuple(test.types, encoded, test.typeIndex, output)
+        expr = _index_tuple(test.types, encoded, test.typeIndex, output)
         assert expr.type_of() == pt.TealType.none
         assert not expr.has_return()
 
@@ -442,17 +442,17 @@ def test_indexTuple():
             assert actual == expected, "Test at index {} failed".format(i)
 
         with pytest.raises(ValueError):
-            indexTuple(test.types, encoded, len(test.types), output)
+            _index_tuple(test.types, encoded, len(test.types), output)
 
         with pytest.raises(ValueError):
-            indexTuple(test.types, encoded, -1, output)
+            _index_tuple(test.types, encoded, -1, output)
 
         otherType = abi.Uint64()
         if output.type_spec() == otherType.type_spec():
             otherType = abi.Uint16()
 
         with pytest.raises(TypeError):
-            indexTuple(test.types, encoded, test.typeIndex, otherType)
+            _index_tuple(test.types, encoded, test.typeIndex, otherType)
 
 
 def test_TupleTypeSpec_eq():
@@ -668,7 +668,7 @@ def test_Tuple_set():
     assert expr.type_of() == pt.TealType.none
     assert not expr.has_return()
 
-    expectedExpr = tupleValue.stored_value.store(encodeTuple([uint8, uint16, uint32]))
+    expectedExpr = tupleValue.stored_value.store(_encode_tuple([uint8, uint16, uint32]))
     expected, _ = expectedExpr.__teal__(options)
     expected.addIncoming()
     expected = pt.TealBlock.NormalizeBlocks(expected)
@@ -809,7 +809,7 @@ def test_TupleElement_store_into():
             assert expr.type_of() == pt.TealType.none
             assert not expr.has_return()
 
-            expectedExpr = indexTuple(test, tupleValue.encode(), j, output)
+            expectedExpr = _index_tuple(test, tupleValue.encode(), j, output)
             expected, _ = expectedExpr.__teal__(options)
             expected.addIncoming()
             expected = pt.TealBlock.NormalizeBlocks(expected)


### PR DESCRIPTION
Renames `pyteal/ast/abi/bool.py` functions to follow PEP 8 conventions. Adds leading _ to demarcate internal functions.

If reviewers feel the internal usage does not apply, let me know and I'll adjust.