### PR TITLE
Specify dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/algorand/pyteal",
     packages=setuptools.find_packages(),
-    install_requires=["py-algorand-sdk", "semantic-version"],
+    install_requires=[
+        "py-algorand-sdk>=1.9.0,<2.0.0",
+        "semantic-version>=2.9.0,<3.0.0",
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Add version constraints for our runtime dependencies.

* For `py-algorand-sdk`, version [1.9.0](https://github.com/algorand/py-algorand-sdk/releases/tag/v1.9.0) is the first with ABI support
* For `semantic-version`, version [2.9.0](https://github.com/rbarrois/python-semanticversion/blob/master/ChangeLog#290-2022-02-06) is the first that supports Python 3.10