### PR TITLE
Update `docs/requirements.txt` with new dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 sphinx==4.2.0
 sphinx-rtd-theme==1.0.0
-py-algorand-sdk
+# dependencies from setup.py
+py-algorand-sdk>=1.9.0,<2.0.0
+semantic-version>=2.9.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     url="https://github.com/algorand/pyteal",
     packages=setuptools.find_packages(),
     install_requires=[
+        # when changing this list, also update docs/requirements.txt
         "py-algorand-sdk>=1.9.0,<2.0.0",
         "semantic-version>=2.9.0,<3.0.0",
     ],


### PR DESCRIPTION
The master branch is currently "passing" docs builds, but it is unable to generate the [PyTeal Package API](https://pyteal.readthedocs.io/en/latest/api.html) page. As a result, every link to a class/function/variable introduced in that API page does not work in the rest of the documentation.

An example build output (look at the final step to see warnings): https://readthedocs.org/projects/pyteal/builds/17514820/

The cause of this issue is that we have a new runtime dependency, `semantic-version`, which the docs build is not aware of.

This PR adds the new dependency to the `docs/requirements.txt` file which is installed during the docs build, plus it adds a comment in `setup.py` to remind us to keep the file up to date.

This may not be the best solution, but it's the simplest one I can think of that fixes the immediate issue.