### PR TITLE
NamedTuple Implementation

### DIFF
--- a/docs/abi.rst
+++ b/docs/abi.rst
@@ -210,7 +210,7 @@ PyTeal Type                                    ARC-4 Type             Dynamic / 
 :any:`abi.Address`                             :code:`address`        Static                              A 32-byte Algorand address. This is an alias for :code:`abi.StaticArray[abi.Byte, Literal[32]]`.
 :any:`abi.DynamicArray[T] <abi.DynamicArray>`  :code:`T[]`            Dynamic                             A variable-length array of :code:`T`
 :any:`abi.String`                              :code:`string`         Dynamic                             A variable-length byte array assumed to contain UTF-8 encoded content. This is an alias for :code:`abi.DynamicArray[abi.Byte]`.
-:any:`abi.Tuple`\*                             :code:`(...)`          Static when all elements are static A tuple of multiple types
+:any:`abi.Tuple`\*, :any:`abi.NamedTuple`\*    :code:`(...)`          Static when all elements are static A tuple of multiple types
 ============================================== ====================== =================================== =======================================================================================================================================================
 
 .. note::
@@ -222,6 +222,21 @@ PyTeal Type                                    ARC-4 Type             Dynamic / 
     * :any:`abi.Tuple3[T1,T2,T3] <abi.Tuple3>`: a tuple of three values, :code:`(T1,T2,T3)`
     * :any:`abi.Tuple4[T1,T2,T3,T4] <abi.Tuple4>`: a tuple of four values, :code:`(T1,T2,T3,T4)`
     * :any:`abi.Tuple5[T1,T2,T3,T4,T5] <abi.Tuple5>`: a tuple of five values, :code:`(T1,T2,T3,T4,T5)`
+
+    \*While we are still on PyTeal 3.10, we have a workaround for :any:`abi.Tuple` by :any:`abi.NamedTuple`, which allows one to define a tuple with more than 5 generic arguments, and access tuple elements by field name. For example:
+
+    .. code-block:: python
+
+        from pyteal import *
+        from typing import Literal as L
+
+        class InheritedFromNamedTuple(abi.NamedTuple):
+            acct_address: abi.Address
+            amount: abi.Uint64
+            retrivable: abi.Bool
+            desc: abi.String
+            list_of_addrs: abi.DynamicArray[abi.Address]
+            balance_list: abi.StaticArray[abi.Uint, L[10]]
 
 These ARC-4 types are not yet supported in PyTeal:
 
@@ -285,7 +300,7 @@ All basic types that represent a single value have a :code:`get()` method, which
 A brief example is below. Please consult the documentation linked above for each method to learn more about specific usage and behavior.
 
 .. code-block:: python
-    
+
     from pyteal import *
 
     @Subroutine(TealType.uint64)
@@ -306,7 +321,7 @@ The supported methods are:
 
 * :any:`abi.StaticArray.__getitem__(index: int | Expr) <abi.StaticArray.__getitem__>`, used for :any:`abi.StaticArray` and :any:`abi.Address`
 * :any:`abi.Array.__getitem__(index: int | Expr) <abi.Array.__getitem__>`, used for :any:`abi.DynamicArray` and :any:`abi.String`
-* :any:`abi.Tuple.__getitem__(index: int) <abi.Tuple.__getitem__>`
+* :any:`abi.Tuple.__getitem__(index: int) <abi.Tuple.__getitem__>`, used for :any:`abi.NamedTuple`
 
 .. note::
     Be aware that these methods return a :any:`ComputedValue`, similar to other PyTeal operations which return ABI types. More information about why that is necessary and how to use a :any:`ComputedValue` can be found in the :ref:`Computed Values` section.
@@ -759,7 +774,7 @@ Registering Methods
     **We strongly recommend** methods immediately access and validate compound type parameters *before* persisting arguments for later transactions. For validation, it is sufficient to attempt to extract each element your method will use. If there is an input error for an element, indexing into that element will fail.
 
     Notes:
-    
+
     * This recommendation applies to recursively contained compound types as well. Successfully extracting an element which is a compound type does not guarantee the extracted value is valid; you must also inspect its elements as well.
     * Because of this, :any:`abi.Address` is **not** guaranteed to have exactly 32 bytes. To defend against unintended behavior, manually verify the length is 32 bytes, i.e. :code:`Assert(Len(address.get()) == Int(32))`.
 
@@ -804,7 +819,7 @@ The first way to register a method is with the :any:`Router.add_method_handler` 
             # store the result in the sender's local state too
             App.localPut(Txn.sender(), Bytes("result", output.get())),
         )
-    
+
     # Register the `add` method with the router, using the default `MethodConfig`
     # (only no-op, non-creation calls allowed).
     router.add_method_handler(add)

--- a/docs/abi.rst
+++ b/docs/abi.rst
@@ -210,7 +210,7 @@ PyTeal Type                                    ARC-4 Type             Dynamic / 
 :any:`abi.Address`                             :code:`address`        Static                              A 32-byte Algorand address. This is an alias for :code:`abi.StaticArray[abi.Byte, Literal[32]]`.
 :any:`abi.DynamicArray[T] <abi.DynamicArray>`  :code:`T[]`            Dynamic                             A variable-length array of :code:`T`
 :any:`abi.String`                              :code:`string`         Dynamic                             A variable-length byte array assumed to contain UTF-8 encoded content. This is an alias for :code:`abi.DynamicArray[abi.Byte]`.
-:any:`abi.Tuple`\*, :any:`abi.NamedTuple`\*    :code:`(...)`          Static when all elements are static A tuple of multiple types
+:any:`abi.Tuple`\*, :any:`abi.NamedTuple`      :code:`(...)`          Static when all elements are static A tuple of multiple types
 ============================================== ====================== =================================== =======================================================================================================================================================
 
 .. note::
@@ -223,7 +223,7 @@ PyTeal Type                                    ARC-4 Type             Dynamic / 
     * :any:`abi.Tuple4[T1,T2,T3,T4] <abi.Tuple4>`: a tuple of four values, :code:`(T1,T2,T3,T4)`
     * :any:`abi.Tuple5[T1,T2,T3,T4,T5] <abi.Tuple5>`: a tuple of five values, :code:`(T1,T2,T3,T4,T5)`
 
-    \*While we are still on PyTeal 3.10, we have a workaround for :any:`abi.Tuple` by :any:`abi.NamedTuple`, which allows one to define a tuple with more than 5 generic arguments, and access tuple elements by field name. For example:
+    While we are still on PyTeal 3.10, we have a workaround for :any:`abi.Tuple` by :any:`abi.NamedTuple`, which allows one to define a tuple with more than 5 generic arguments, and access tuple elements by field name. For example:
 
     .. code-block:: python
 
@@ -236,7 +236,7 @@ PyTeal Type                                    ARC-4 Type             Dynamic / 
             retrivable: abi.Bool
             desc: abi.String
             list_of_addrs: abi.DynamicArray[abi.Address]
-            balance_list: abi.StaticArray[abi.Uint, L[10]]
+            balance_list: abi.StaticArray[abi.Uint64, L[10]]
 
 These ARC-4 types are not yet supported in PyTeal:
 
@@ -321,10 +321,17 @@ The supported methods are:
 
 * :any:`abi.StaticArray.__getitem__(index: int | Expr) <abi.StaticArray.__getitem__>`, used for :any:`abi.StaticArray` and :any:`abi.Address`
 * :any:`abi.Array.__getitem__(index: int | Expr) <abi.Array.__getitem__>`, used for :any:`abi.DynamicArray` and :any:`abi.String`
-* :any:`abi.Tuple.__getitem__(index: int) <abi.Tuple.__getitem__>`, used for :any:`abi.NamedTuple`
+* :any:`abi.Tuple.__getitem__(index: int) <abi.Tuple.__getitem__>`, used for :any:`abi.Tuple` and :any:`abi.NamedTuple`\*
 
 .. note::
-    Be aware that these methods return a :any:`ComputedValue`, similar to other PyTeal operations which return ABI types. More information about why that is necessary and how to use a :any:`ComputedValue` can be found in the :ref:`Computed Values` section.
+    \*For :any:`abi.NamedTuple`, one can access tuple elements through both methods
+
+    * :any:`abi.Tuple.__getitem__(index: int) <abi.Tuple.__getitem__>`
+    * :any:`abi.NamedTuple.__getattr__(name: str) <abi.NamedTuple.__getattr__>`
+
+    Be aware that, though the fields in a :any:`abi.NamedTuple` are annotated in ABI types, the return values from the annotated fields are :any:`ComputedValues <abi.ComputedValue>`.
+
+    Also be aware that these methods return a :any:`ComputedValue`, similar to other PyTeal operations which return ABI types. More information about why that is necessary and how to use a :any:`ComputedValue` can be found in the :ref:`Computed Values` section.
 
 A brief example is below. Please consult the documentation linked above for each method to learn more about specific usage and behavior.
 

--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -30,6 +30,7 @@ from pyteal.ast.abi.tuple import (
     Tuple3,
     Tuple4,
     Tuple5,
+    NamedTuple,
 )
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
 from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray
@@ -116,6 +117,7 @@ __all__ = [
     "Tuple3",
     "Tuple4",
     "Tuple5",
+    "NamedTuple",
     "ArrayTypeSpec",
     "Array",
     "ArrayElement",

--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -31,6 +31,7 @@ from pyteal.ast.abi.tuple import (
     Tuple4,
     Tuple5,
     NamedTuple,
+    NamedTupleTypeSpec,
 )
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
 from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray
@@ -118,6 +119,7 @@ __all__ = [
     "Tuple4",
     "Tuple5",
     "NamedTuple",
+    "NamedTupleTypeSpec",
     "ArrayTypeSpec",
     "Array",
     "ArrayElement",

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -543,6 +543,7 @@ class NamedTuple(Tuple):
         self._ready = True
 
     def __getattr__(self, field: str) -> TupleElement:
+        """Retrieve an element by its field in this NamedTuple."""
         return self.__getitem__(self.__field_index[field])
 
     def __setattr__(self, name: str, field: Any) -> None:

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -495,11 +495,9 @@ class NamedTuple(Tuple):
             raise Exception("Expected fields to be declared but found none")
 
         self.type_specs: OrderedDict[str, TypeSpec] = OrderedDict()
-        self.field_names: list[str] = []
 
         for index, (name, annotation) in enumerate(self.__annotations__.items()):
             self.type_specs[name] = type_spec_from_annotation(annotation)
-            self.field_names.append(name)
             setattr(self, name, lambda: self[index])
 
         super().__init__(TupleTypeSpec(*self.type_specs.values()))

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -513,7 +513,10 @@ NamedTupleTypeSpec.__module__ = "pyteal.abi"
 
 
 class NamedTuple(Tuple):
-    """A NamedTuple is a Tuple with all its elements named."""
+    """A NamedTuple is a Tuple with all its elements named.
+
+    .. automethod:: __getattr__
+    """
 
     def __init__(self):
         if type(self) is NamedTuple:
@@ -543,7 +546,16 @@ class NamedTuple(Tuple):
         self._ready = True
 
     def __getattr__(self, field: str) -> TupleElement:
-        """Retrieve an element by its field in this NamedTuple."""
+        """Retrieve an element by its field in this NamedTuple.
+
+        Args:
+            field: a Python string containing the field to access.
+                This function will raise an KeyError if the field is not available in the defined NamedTuple.
+
+        Returns:
+            A TupleElement that corresponds to the element at the given field name, returning a ComputedType.
+            Due to Python type limitations, the parameterized type of the TupleElement is Any.
+        """
         return self.__getitem__(self.__field_index[field])
 
     def __setattr__(self, name: str, field: Any) -> None:

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -491,6 +491,9 @@ class NamedTuple(Tuple):
     """A NamedTuple from Tuple with all it's elements named."""
 
     def __init__(self):
+        if type(self) is NamedTuple:
+            raise TealInputError("NamedTuple must be subclassed.")
+
         if not hasattr(self, "__annotations__"):
             raise Exception("Expected fields to be declared but found none")
 

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -524,16 +524,22 @@ class NamedTuple(Tuple):
             raise Exception("Expected fields to be declared but found none")
 
         self.__type_specs: OrderedDict[str, TypeSpec] = OrderedDict()
+        self.__field_index: dict[str, int] = {}
 
         for index, (name, annotation) in enumerate(anns.items()):
             self.__type_specs[name] = type_spec_from_annotation(annotation)
+            self.__field_index[name] = index
 
         super().__init__(
             NamedTupleTypeSpec(type(self), *list(self.__type_specs.values()))
         )
 
-        for index, name in enumerate(anns):
-            setattr(self, name, self[index])
+    def __getattr__(self, field: str) -> TupleElement:
+        return self.__getitem__(self.__field_index[field])
+
+    def __setattr__(self, __name: str, __value: Any) -> None:
+        # TODO need some thinking? seems we should not allow folks to set in tuple tho.
+        return super().__setattr__(__name, __value)
 
 
 NamedTuple.__module__ = "pyteal.abi"

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -528,9 +528,11 @@ class NamedTuple(Tuple):
 
         # NOTE: this `_ready` variable enables `__setattr__` during `__init__` execution,
         # while after `__init__`, we cannot use `__setattr__` to set fields in `NamedTuple`.
-        # The reason for `_ready` is that, the field naming scheme in Python would change
+        # NOTE: The reason for `_ready` is that, the field naming scheme in Python would change
         # _double underscore led field name_ to something else,
         # while _single underscore led variable names_ would stay intact.
+        # e.g., if we set variable `self.__ready`,
+        # then internally the variable name would be changed to `_NamedTuple__ready`, which is implicit.
         self._ready = False
         self.__type_specs: OrderedDict[str, TypeSpec] = OrderedDict()
         self.__field_index: dict[str, int] = {}

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -487,6 +487,27 @@ class Tuple5(Tuple, Generic[T1, T2, T3, T4, T5]):
 Tuple5.__module__ = "pyteal.abi"
 
 
+class NamedTupleTypeSpec(TupleTypeSpec):
+    """A NamedTupleType inherited from TupleTypeSpec, allowing for more than 5 elements."""
+
+    def __init__(
+        self, instance_class: type["NamedTuple"], *value_type_specs: TypeSpec
+    ) -> None:
+        if instance_class == NamedTuple:
+            raise TealInputError(
+                "NamedTupleTypeSpec must be instanced with subclassed NamedTuple class."
+            )
+
+        self.instance_class: type["NamedTuple"] = instance_class
+        super().__init__(*value_type_specs)
+
+    def annotation_type(self) -> "type[NamedTuple]":
+        return self.instance_class
+
+
+NamedTupleTypeSpec.__module__ = "pyteal.abi"
+
+
 class NamedTuple(Tuple):
     """A NamedTuple from Tuple with all it's elements named."""
 
@@ -503,7 +524,10 @@ class NamedTuple(Tuple):
             self.type_specs[name] = type_spec_from_annotation(annotation)
             setattr(self, name, lambda: self[index])
 
-        super().__init__(TupleTypeSpec(*self.type_specs.values()))
+        super().__init__(NamedTupleTypeSpec(type(self), *self.type_specs.values()))
+
+    def type_spec(self) -> TupleTypeSpec:
+        return super().type_spec()
 
 
 NamedTuple.__module__ = "pyteal.abi"

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -523,20 +523,17 @@ class NamedTuple(Tuple):
         if not anns:
             raise Exception("Expected fields to be declared but found none")
 
-        self.type_specs: OrderedDict[str, TypeSpec] = OrderedDict()
+        self.__type_specs: OrderedDict[str, TypeSpec] = OrderedDict()
 
         for index, (name, annotation) in enumerate(anns.items()):
-            self.type_specs[name] = type_spec_from_annotation(annotation)
+            self.__type_specs[name] = type_spec_from_annotation(annotation)
 
         super().__init__(
-            NamedTupleTypeSpec(type(self), *list(self.type_specs.values()))
+            NamedTupleTypeSpec(type(self), *list(self.__type_specs.values()))
         )
 
         for index, name in enumerate(anns):
             setattr(self, name, self[index])
-
-    def type_spec(self) -> TupleTypeSpec:
-        return cast(NamedTupleTypeSpec, super().type_spec())
 
 
 NamedTuple.__module__ = "pyteal.abi"

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -1,3 +1,4 @@
+from inspect import get_annotations
 from typing import (
     List,
     Sequence,
@@ -488,7 +489,7 @@ Tuple5.__module__ = "pyteal.abi"
 
 
 class NamedTupleTypeSpec(TupleTypeSpec):
-    """A NamedTupleType inherited from TupleTypeSpec, allowing for more than 5 elements."""
+    """A NamedTupleType inherits from TupleTypeSpec, allowing for more than 5 elements."""
 
     def __init__(
         self, instance_class: type["NamedTuple"], *value_type_specs: TypeSpec
@@ -509,18 +510,20 @@ NamedTupleTypeSpec.__module__ = "pyteal.abi"
 
 
 class NamedTuple(Tuple):
-    """A NamedTuple from Tuple with all it's elements named."""
+    """A NamedTuple is a Tuple with all its elements named."""
 
     def __init__(self):
         if type(self) is NamedTuple:
             raise TealInputError("NamedTuple must be subclassed.")
 
-        if not hasattr(self, "__annotations__"):
+        anns = get_annotations(type(self))
+
+        if not anns:
             raise Exception("Expected fields to be declared but found none")
 
         self.type_specs: OrderedDict[str, TypeSpec] = OrderedDict()
 
-        for index, (name, annotation) in enumerate(self.__annotations__.items()):
+        for index, (name, annotation) in enumerate(anns.items()):
             self.type_specs[name] = type_spec_from_annotation(annotation)
             setattr(self, name, lambda: self[index])
 

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -885,3 +885,6 @@ def test_NamedTuple_getitem(test_case: type[abi.NamedTuple]):
 
     with pytest.raises(KeyError):
         tuple_value.aaaaa
+
+    with pytest.raises(pt.TealInputError):
+        tuple_value.f0 = abi.Uint64()

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -866,19 +866,29 @@ def test_NamedTuple_getitem(test_case: type[abi.NamedTuple]):
     tuple_len_static = tuple_value.type_spec().length_static()
     for i in range(tuple_len_static):
         elem_by_field: abi.TupleElement = getattr(tuple_value, f"f{i}")
+        elem_by_index: abi.TupleElement = tuple_value[i]
+
         assert (
             type(elem_by_field) is abi.TupleElement
         ), f"Test case {test_case} at field f{i} must be TupleElement"
-        elem_by_index: abi.TupleElement = tuple_value[i]
         assert (
-            type(elem_by_field) is abi.TupleElement
+            type(elem_by_index) is abi.TupleElement
         ), f"Test case {test_case} at index {i} must be TupleElement"
+
         assert (
             elem_by_field.index == i
         ), f"Test case {test_case} at field f{i} should have index {i}."
         assert (
-            elem_by_field.tuple == tuple_value
+            elem_by_index.index == i
+        ), f"Test case {test_case} at index {i} should have index {i}."
+
+        assert (
+            elem_by_field.tuple is tuple_value
         ), f"Test case {test_case} at field f{i} should have attr tuple == {test_case}."
+        assert (
+            elem_by_index.tuple is tuple_value
+        ), f"Test case {test_case} at index {i} should have attr tuple == {test_case}."
+
         assert (
             elem_by_field.produced_type_spec() == elem_by_index.produced_type_spec()
         ), f"Test case {test_case} at field f{i} type spec unmatching: {elem_by_field.produced_type_spec()} != {elem_by_index.produced_type_spec()}."

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, List, Callable
+from typing import NamedTuple, List, Callable, Literal
 import pytest
 
 import pyteal as pt
@@ -824,3 +824,64 @@ def test_TupleElement_store_into():
 
             with pt.TealComponent.Context.ignoreExprEquality():
                 assert actual == expected, "Test at index {} failed".format(i)
+
+
+class NT_0(abi.NamedTuple):
+    f0: abi.Uint64
+    f1: abi.Uint32
+    f2: abi.Uint16
+    f3: abi.Uint8
+
+
+class NT_1(abi.NamedTuple):
+    f0: abi.StaticArray[abi.Bool, Literal[4]]
+    f1: abi.DynamicArray[abi.String]
+    f2: abi.String
+    f3: abi.Bool
+    f4: abi.Address
+    f5: NT_0
+
+
+class NT_2(abi.NamedTuple):
+    f0: abi.Bool
+    f1: abi.Bool
+    f2: abi.Bool
+    f3: abi.Bool
+    f4: abi.Bool
+    f5: abi.Bool
+    f6: abi.Bool
+    f7: abi.Bool
+    f8: NT_1
+
+
+class NT_3(abi.NamedTuple):
+    f0: NT_0
+    f1: NT_1
+    f2: NT_2
+
+
+@pytest.mark.parametrize("test_case", [NT_0, NT_1, NT_2, NT_3])
+def test_NamedTuple_getitem(test_case: type[abi.NamedTuple]):
+    tuple_value = test_case()
+    tuple_len_static = tuple_value.type_spec().length_static()
+    for i in range(tuple_len_static):
+        elem_by_field: abi.TupleElement = getattr(tuple_value, f"f{i}")
+        assert (
+            type(elem_by_field) is abi.TupleElement
+        ), f"Test case {test_case} at field f{i} must be TupleElement"
+        elem_by_index: abi.TupleElement = tuple_value[i]
+        assert (
+            type(elem_by_field) is abi.TupleElement
+        ), f"Test case {test_case} at index {i} must be TupleElement"
+        assert (
+            elem_by_field.index == i
+        ), f"Test case {test_case} at field f{i} should have index {i}."
+        assert (
+            elem_by_field.tuple == tuple_value
+        ), f"Test case {test_case} at field f{i} should have attr tuple == {test_case}."
+        assert (
+            elem_by_field.produced_type_spec() == elem_by_index.produced_type_spec()
+        ), f"Test case {test_case} at field f{i} type spec unmatching: {elem_by_field.produced_type_spec()} != {elem_by_index.produced_type_spec()}."
+
+    with pytest.raises(KeyError):
+        tuple_value.aaaaa

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -223,8 +223,11 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         array_length = int_literal_from_annotation(args[1])
         return StaticArrayTypeSpec(value_type_spec, array_length)
 
-    if origin is Tuple or origin is NamedTuple:
+    if origin is Tuple:
         return TupleTypeSpec(*(type_spec_from_annotation(arg) for arg in args))
+
+    if issubclass(origin, NamedTuple):
+        return origin().type_spec()
 
     if origin is Tuple0:
         if len(args) != 0:

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -228,7 +228,7 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         return TupleTypeSpec(*(type_spec_from_annotation(arg) for arg in args))
 
     if issubclass(origin, NamedTuple):
-        return NamedTupleTypeSpec(origin, *origin().type_specs.values())
+        return cast(NamedTupleTypeSpec, origin().type_spec())
 
     if origin is Tuple0:
         if len(args) != 0:

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -118,6 +118,7 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         Tuple3,
         Tuple4,
         Tuple5,
+        NamedTuple,
     )
     from pyteal.ast.abi.string import StringTypeSpec, String
     from pyteal.ast.abi.address import AddressTypeSpec, Address
@@ -222,7 +223,7 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         array_length = int_literal_from_annotation(args[1])
         return StaticArrayTypeSpec(value_type_spec, array_length)
 
-    if origin is Tuple:
+    if origin is Tuple or origin is NamedTuple:
         return TupleTypeSpec(*(type_spec_from_annotation(arg) for arg in args))
 
     if origin is Tuple0:

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -119,6 +119,7 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         Tuple4,
         Tuple5,
         NamedTuple,
+        NamedTupleTypeSpec,
     )
     from pyteal.ast.abi.string import StringTypeSpec, String
     from pyteal.ast.abi.address import AddressTypeSpec, Address
@@ -227,7 +228,7 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         return TupleTypeSpec(*(type_spec_from_annotation(arg) for arg in args))
 
     if issubclass(origin, NamedTuple):
-        return origin().type_spec()
+        return NamedTupleTypeSpec(origin, *origin().type_specs.values())
 
     if origin is Tuple0:
         if len(args) != 0:

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -302,6 +302,13 @@ def test_type_spec_from_annotation_is_exhaustive():
                 type_spec_from_annotation(subclass)
             continue
 
+        if subclass is pt.abi.NamedTuple:
+            with pytest.raises(
+                TealInputError, match=r"^NamedTuple must be subclassed."
+            ):
+                type_spec_from_annotation(subclass)
+            continue
+
         try:
             # if subclass is not generic, this will succeed
             type_spec_from_annotation(subclass)

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -195,7 +195,7 @@ class PyTealDryRunExecutor:
         return isinstance(self.subr.subroutine, ABIReturnSubroutine)
 
     def abi_argument_types(self) -> None | list[algosdk.abi.ABIType]:
-        if not self.is_abi():
+        if not (self.input_types or self.is_abi()):
             return None
 
         def handle_arg(arg):

--- a/tests/integration/abi_roundtrip_test.py
+++ b/tests/integration/abi_roundtrip_test.py
@@ -41,6 +41,7 @@ class NamedTupleInherit(abi.NamedTuple):
     c: abi.Tuple2[abi.Uint64, abi.Bool]
     d: abi.StaticArray[abi.Byte, Literal[10]]
     e: abi.StaticArray[abi.Bool, Literal[4]]
+    f: abi.Uint64
 
 
 PATH = Path.cwd() / "tests" / "integration"

--- a/tests/integration/abi_roundtrip_test.py
+++ b/tests/integration/abi_roundtrip_test.py
@@ -150,7 +150,7 @@ def roundtrip_setup(abi_type):
             abi.make(abi_type), length=dynamic_length
         ).pytealer()
 
-    return (abi_type, abi_type_str, dynamic_length, roundtrip_or_none)
+    return abi_type, abi_type_str, dynamic_length, roundtrip_or_none
 
 
 def test_abi_types_comprehensive():
@@ -167,8 +167,6 @@ def test_abi_types_comprehensive():
         tli = tli.split("[")[0] if tli.startswith("pyteal") else tli.split("'")[1]
 
         top_level_names.add(tli)
-
-    print(top_level_names)
 
     def get_subclasses(cls):
         for subclass in cls.__subclasses__():

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -909,7 +909,8 @@ def blackbox_pyteal_while_continue_test():
 
 
 def blackbox_pyteal_named_tupleness_test():
-    from typing import Literal as L
+    from typing import Any, Literal as L
+    from algosdk.abi import ABIType
     from tests.blackbox import Blackbox
     from pyteal import (
         Seq,
@@ -929,41 +930,52 @@ def blackbox_pyteal_named_tupleness_test():
         e: abi.StaticArray[abi.Bool, L[4]]
         f: abi.Uint64
 
-    sdk_abi_t = abi.algosdk_from_annotation(NamedTupleExample)
-
-    @Blackbox(input_types=[None])
+    @Blackbox(input_types=[None] * 6)
     @Subroutine(TealType.uint64)
-    def named_tuple_field_access(v_temp: NamedTupleExample):
+    def named_tuple_field_access(
+        a_0: abi.Bool,
+        a_1: abi.Address,
+        a_2: abi.Tuple2[abi.Uint64, abi.Bool],
+        a_3: abi.StaticArray[abi.Byte, L[10]],
+        a_4: abi.StaticArray[abi.Bool, L[4]],
+        a_5: abi.Uint64,
+    ):
         return Seq(
-            (v_a0 := abi.Bool()).set(v_temp[0]),
-            (v_a1 := abi.Bool()).set(v_temp.a),
-            (v_b0 := abi.Address()).set(v_temp[1]),
-            (v_b1 := abi.Address()).set(v_temp.b),
-            (v_c0 := abi.make(abi.Tuple2[abi.Uint64, abi.Bool])).set(v_temp[2]),
-            (v_c1 := abi.make(abi.Tuple2[abi.Uint64, abi.Bool])).set(v_temp.c),
-            (v_d0 := abi.make(abi.StaticArray[abi.Byte, L[10]])).set(v_temp[3]),
-            (v_d1 := abi.make(abi.StaticArray[abi.Byte, L[10]])).set(v_temp.d),
-            (v_e0 := abi.make(abi.StaticArray[abi.Bool, L[4]])).set(v_temp[4]),
-            (v_e1 := abi.make(abi.StaticArray[abi.Bool, L[4]])).set(v_temp.e),
-            (v_f0 := abi.Uint64()).set(v_temp[5]),
-            (v_f1 := abi.Uint64()).set(v_temp.f),
+            (v_tuple := NamedTupleExample()).set(a_0, a_1, a_2, a_3, a_4, a_5),
+            (v_a := abi.Bool()).set(v_tuple.a),
+            (v_b := abi.Address()).set(v_tuple.b),
+            (v_c := abi.make(abi.Tuple2[abi.Uint64, abi.Bool])).set(v_tuple.c),
+            (v_d := abi.make(abi.StaticArray[abi.Byte, L[10]])).set(v_tuple.d),
+            (v_e := abi.make(abi.StaticArray[abi.Bool, L[4]])).set(v_tuple.e),
+            (v_f := abi.Uint64()).set(v_tuple.f),
             Return(
                 And(
-                    v_a0.get() == v_a1.get(),
-                    v_b0.get() == v_b1.get(),
-                    v_c0.encode() == v_c1.encode(),
-                    v_d0.encode() == v_d1.encode(),
-                    v_e0.encode() == v_e1.encode(),
-                    v_f0.get() == v_f1.get(),
+                    a_0.get() == v_a.get(),
+                    a_1.get() == v_b.get(),
+                    a_2.encode() == v_c.encode(),
+                    a_3.encode() == v_d.encode(),
+                    a_4.encode() == v_e.encode(),
+                    a_5.get() == v_f.get(),
                 )
             ),
         )
 
     lsig_pytealer = PyTealDryRunExecutor(named_tuple_field_access, Mode.Signature)
 
-    encoded = sdk_abi_t.encode((False, b"1" * 32, (0, False), b"0" * 10, [True] * 4, 0))
-    lsig_result = lsig_pytealer.dryrun([bytes(encoded)])
-    print(lsig_result.stack_top())
+    TYPES_N_VALS: list[tuple[str, Any]] = [
+        ("bool", False),
+        ("address", b"1" * 32),
+        ("(uint64,bool)", (12, True)),
+        ("byte[10]", b"a" * 10),
+        ("bool[4]", [False] * 4),
+        ("uint64", 100),
+    ]
+
+    args: list[bytes] = [
+        ABIType.from_string(abi_t).encode(var) for abi_t, var in TYPES_N_VALS
+    ]
+
+    lsig_result = lsig_pytealer.dryrun(args)
     assert lsig_result.passed()
 
 

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -909,8 +909,7 @@ def blackbox_pyteal_while_continue_test():
 
 
 def blackbox_pyteal_named_tupleness_test():
-    from typing import Any, Literal as L
-    from algosdk.abi import ABIType
+    from typing import Literal as L
     from tests.blackbox import Blackbox
     from pyteal import (
         Seq,
@@ -961,22 +960,12 @@ def blackbox_pyteal_named_tupleness_test():
         )
 
     lsig_pytealer = PyTealDryRunExecutor(named_tuple_field_access, Mode.Signature)
+    args = (False, b"1" * 32, (0, False), b"0" * 10, [True] * 4, 0)
 
-    TYPES_N_VALS: list[tuple[str, Any]] = [
-        ("bool", False),
-        ("address", b"1" * 32),
-        ("(uint64,bool)", (12, True)),
-        ("byte[10]", b"a" * 10),
-        ("bool[4]", [False] * 4),
-        ("uint64", 100),
-    ]
+    inspector = lsig_pytealer.dryrun(args)
 
-    args: list[bytes] = [
-        ABIType.from_string(abi_t).encode(var) for abi_t, var in TYPES_N_VALS
-    ]
-
-    lsig_result = lsig_pytealer.dryrun(args)
-    assert lsig_result.passed()
+    assert inspector.stack_top() == 1
+    assert inspector.passed()
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,address,(uint64,bool),byte[10],bool[4]).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,address,(uint64,bool),byte[10],bool[4]).teal
@@ -1,0 +1,827 @@
+#pragma version 6
+txna ApplicationArgs 0
+store 6
+load 6
+callsub roundtripper_1
+store 5
+byte 0x151f7c75
+load 5
+concat
+log
+int 1
+return
+
+// tuple_complement
+tuplecomplement_0:
+store 11
+load 11
+int 0
+getbit
+store 0
+load 11
+extract 1 32
+store 1
+load 11
+extract 33 9
+store 2
+load 11
+extract 42 10
+store 3
+load 11
+extract 52 0
+store 4
+load 0
+callsub boolcomp_2
+store 0
+load 1
+callsub arraycomplement_4
+store 1
+load 2
+callsub tuplecomplement_5
+store 2
+load 3
+callsub arraycomplement_7
+store 3
+load 4
+callsub arraycomplement_9
+store 4
+byte 0x00
+int 0
+load 0
+setbit
+load 1
+concat
+load 2
+concat
+load 3
+concat
+load 4
+concat
+store 12
+load 12
+retsub
+
+// round_tripper
+roundtripper_1:
+store 7
+load 7
+callsub tuplecomplement_0
+store 9
+load 9
+callsub tuplecomplement_0
+store 10
+load 7
+load 9
+concat
+load 10
+concat
+store 8
+load 8
+retsub
+
+// bool_comp
+boolcomp_2:
+store 15
+load 15
+!
+!
+!
+store 16
+load 16
+retsub
+
+// numerical_comp
+numericalcomp_3:
+store 51
+int 255
+load 51
+-
+store 52
+load 52
+int 256
+<
+assert
+load 52
+retsub
+
+// array_complement
+arraycomplement_4:
+store 17
+load 17
+int 1
+int 0
+*
+getbyte
+store 19
+load 17
+int 1
+int 1
+*
+getbyte
+store 20
+load 17
+int 1
+int 2
+*
+getbyte
+store 21
+load 17
+int 1
+int 3
+*
+getbyte
+store 22
+load 17
+int 1
+int 4
+*
+getbyte
+store 23
+load 17
+int 1
+int 5
+*
+getbyte
+store 24
+load 17
+int 1
+int 6
+*
+getbyte
+store 25
+load 17
+int 1
+int 7
+*
+getbyte
+store 26
+load 17
+int 1
+int 8
+*
+getbyte
+store 27
+load 17
+int 1
+int 9
+*
+getbyte
+store 28
+load 17
+int 1
+int 10
+*
+getbyte
+store 29
+load 17
+int 1
+int 11
+*
+getbyte
+store 30
+load 17
+int 1
+int 12
+*
+getbyte
+store 31
+load 17
+int 1
+int 13
+*
+getbyte
+store 32
+load 17
+int 1
+int 14
+*
+getbyte
+store 33
+load 17
+int 1
+int 15
+*
+getbyte
+store 34
+load 17
+int 1
+int 16
+*
+getbyte
+store 35
+load 17
+int 1
+int 17
+*
+getbyte
+store 36
+load 17
+int 1
+int 18
+*
+getbyte
+store 37
+load 17
+int 1
+int 19
+*
+getbyte
+store 38
+load 17
+int 1
+int 20
+*
+getbyte
+store 39
+load 17
+int 1
+int 21
+*
+getbyte
+store 40
+load 17
+int 1
+int 22
+*
+getbyte
+store 41
+load 17
+int 1
+int 23
+*
+getbyte
+store 42
+load 17
+int 1
+int 24
+*
+getbyte
+store 43
+load 17
+int 1
+int 25
+*
+getbyte
+store 44
+load 17
+int 1
+int 26
+*
+getbyte
+store 45
+load 17
+int 1
+int 27
+*
+getbyte
+store 46
+load 17
+int 1
+int 28
+*
+getbyte
+store 47
+load 17
+int 1
+int 29
+*
+getbyte
+store 48
+load 17
+int 1
+int 30
+*
+getbyte
+store 49
+load 17
+int 1
+int 31
+*
+getbyte
+store 50
+load 19
+callsub numericalcomp_3
+store 19
+load 20
+callsub numericalcomp_3
+store 20
+load 21
+callsub numericalcomp_3
+store 21
+load 22
+callsub numericalcomp_3
+store 22
+load 23
+callsub numericalcomp_3
+store 23
+load 24
+callsub numericalcomp_3
+store 24
+load 25
+callsub numericalcomp_3
+store 25
+load 26
+callsub numericalcomp_3
+store 26
+load 27
+callsub numericalcomp_3
+store 27
+load 28
+callsub numericalcomp_3
+store 28
+load 29
+callsub numericalcomp_3
+store 29
+load 30
+callsub numericalcomp_3
+store 30
+load 31
+callsub numericalcomp_3
+store 31
+load 32
+callsub numericalcomp_3
+store 32
+load 33
+callsub numericalcomp_3
+store 33
+load 34
+callsub numericalcomp_3
+store 34
+load 35
+callsub numericalcomp_3
+store 35
+load 36
+callsub numericalcomp_3
+store 36
+load 37
+callsub numericalcomp_3
+store 37
+load 38
+callsub numericalcomp_3
+store 38
+load 39
+callsub numericalcomp_3
+store 39
+load 40
+callsub numericalcomp_3
+store 40
+load 41
+callsub numericalcomp_3
+store 41
+load 42
+callsub numericalcomp_3
+store 42
+load 43
+callsub numericalcomp_3
+store 43
+load 44
+callsub numericalcomp_3
+store 44
+load 45
+callsub numericalcomp_3
+store 45
+load 46
+callsub numericalcomp_3
+store 46
+load 47
+callsub numericalcomp_3
+store 47
+load 48
+callsub numericalcomp_3
+store 48
+load 49
+callsub numericalcomp_3
+store 49
+load 50
+callsub numericalcomp_3
+store 50
+byte 0x00
+int 0
+load 19
+setbyte
+byte 0x00
+int 0
+load 20
+setbyte
+concat
+byte 0x00
+int 0
+load 21
+setbyte
+concat
+byte 0x00
+int 0
+load 22
+setbyte
+concat
+byte 0x00
+int 0
+load 23
+setbyte
+concat
+byte 0x00
+int 0
+load 24
+setbyte
+concat
+byte 0x00
+int 0
+load 25
+setbyte
+concat
+byte 0x00
+int 0
+load 26
+setbyte
+concat
+byte 0x00
+int 0
+load 27
+setbyte
+concat
+byte 0x00
+int 0
+load 28
+setbyte
+concat
+byte 0x00
+int 0
+load 29
+setbyte
+concat
+byte 0x00
+int 0
+load 30
+setbyte
+concat
+byte 0x00
+int 0
+load 31
+setbyte
+concat
+byte 0x00
+int 0
+load 32
+setbyte
+concat
+byte 0x00
+int 0
+load 33
+setbyte
+concat
+byte 0x00
+int 0
+load 34
+setbyte
+concat
+byte 0x00
+int 0
+load 35
+setbyte
+concat
+byte 0x00
+int 0
+load 36
+setbyte
+concat
+byte 0x00
+int 0
+load 37
+setbyte
+concat
+byte 0x00
+int 0
+load 38
+setbyte
+concat
+byte 0x00
+int 0
+load 39
+setbyte
+concat
+byte 0x00
+int 0
+load 40
+setbyte
+concat
+byte 0x00
+int 0
+load 41
+setbyte
+concat
+byte 0x00
+int 0
+load 42
+setbyte
+concat
+byte 0x00
+int 0
+load 43
+setbyte
+concat
+byte 0x00
+int 0
+load 44
+setbyte
+concat
+byte 0x00
+int 0
+load 45
+setbyte
+concat
+byte 0x00
+int 0
+load 46
+setbyte
+concat
+byte 0x00
+int 0
+load 47
+setbyte
+concat
+byte 0x00
+int 0
+load 48
+setbyte
+concat
+byte 0x00
+int 0
+load 49
+setbyte
+concat
+byte 0x00
+int 0
+load 50
+setbyte
+concat
+store 18
+load 18
+retsub
+
+// tuple_complement
+tuplecomplement_5:
+store 53
+load 53
+int 0
+extract_uint64
+store 13
+load 53
+int 64
+getbit
+store 14
+load 13
+callsub numericalcomp_10
+store 13
+load 14
+callsub boolcomp_11
+store 14
+load 13
+itob
+byte 0x00
+int 0
+load 14
+setbit
+concat
+store 54
+load 54
+retsub
+
+// numerical_comp
+numericalcomp_6:
+store 71
+int 255
+load 71
+-
+store 72
+load 72
+int 256
+<
+assert
+load 72
+retsub
+
+// array_complement
+arraycomplement_7:
+store 59
+load 59
+int 1
+int 0
+*
+getbyte
+store 61
+load 59
+int 1
+int 1
+*
+getbyte
+store 62
+load 59
+int 1
+int 2
+*
+getbyte
+store 63
+load 59
+int 1
+int 3
+*
+getbyte
+store 64
+load 59
+int 1
+int 4
+*
+getbyte
+store 65
+load 59
+int 1
+int 5
+*
+getbyte
+store 66
+load 59
+int 1
+int 6
+*
+getbyte
+store 67
+load 59
+int 1
+int 7
+*
+getbyte
+store 68
+load 59
+int 1
+int 8
+*
+getbyte
+store 69
+load 59
+int 1
+int 9
+*
+getbyte
+store 70
+load 61
+callsub numericalcomp_6
+store 61
+load 62
+callsub numericalcomp_6
+store 62
+load 63
+callsub numericalcomp_6
+store 63
+load 64
+callsub numericalcomp_6
+store 64
+load 65
+callsub numericalcomp_6
+store 65
+load 66
+callsub numericalcomp_6
+store 66
+load 67
+callsub numericalcomp_6
+store 67
+load 68
+callsub numericalcomp_6
+store 68
+load 69
+callsub numericalcomp_6
+store 69
+load 70
+callsub numericalcomp_6
+store 70
+byte 0x00
+int 0
+load 61
+setbyte
+byte 0x00
+int 0
+load 62
+setbyte
+concat
+byte 0x00
+int 0
+load 63
+setbyte
+concat
+byte 0x00
+int 0
+load 64
+setbyte
+concat
+byte 0x00
+int 0
+load 65
+setbyte
+concat
+byte 0x00
+int 0
+load 66
+setbyte
+concat
+byte 0x00
+int 0
+load 67
+setbyte
+concat
+byte 0x00
+int 0
+load 68
+setbyte
+concat
+byte 0x00
+int 0
+load 69
+setbyte
+concat
+byte 0x00
+int 0
+load 70
+setbyte
+concat
+store 60
+load 60
+retsub
+
+// bool_comp
+boolcomp_8:
+store 79
+load 79
+!
+!
+!
+store 80
+load 80
+retsub
+
+// array_complement
+arraycomplement_9:
+store 73
+load 73
+int 0
+getbit
+store 75
+load 73
+int 1
+getbit
+store 76
+load 73
+int 2
+getbit
+store 77
+load 73
+int 3
+getbit
+store 78
+load 75
+callsub boolcomp_8
+store 75
+load 76
+callsub boolcomp_8
+store 76
+load 77
+callsub boolcomp_8
+store 77
+load 78
+callsub boolcomp_8
+store 78
+byte 0x00
+int 0
+load 75
+setbit
+int 1
+load 76
+setbit
+int 2
+load 77
+setbit
+int 3
+load 78
+setbit
+store 74
+load 74
+retsub
+
+// numerical_comp
+numericalcomp_10:
+store 55
+int 18446744073709551615
+load 55
+-
+store 56
+load 56
+retsub
+
+// bool_comp
+boolcomp_11:
+store 57
+load 57
+!
+!
+!
+store 58
+load 58
+retsub

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,address,(uint64,bool),byte[10],bool[4],uint64).teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,address,(uint64,bool),byte[10],bool[4],uint64).teal
@@ -1,11 +1,11 @@
 #pragma version 6
 txna ApplicationArgs 0
-store 6
-load 6
+store 7
+load 7
 callsub roundtripper_1
-store 5
+store 6
 byte 0x151f7c75
-load 5
+load 6
 concat
 log
 int 1
@@ -13,23 +13,27 @@ return
 
 // tuple_complement
 tuplecomplement_0:
-store 11
-load 11
+store 12
+load 12
 int 0
 getbit
 store 0
-load 11
+load 12
 extract 1 32
 store 1
-load 11
+load 12
 extract 33 9
 store 2
-load 11
+load 12
 extract 42 10
 store 3
-load 11
-extract 52 0
+load 12
+extract 52 1
 store 4
+load 12
+int 53
+extract_uint64
+store 5
 load 0
 callsub boolcomp_2
 store 0
@@ -45,6 +49,9 @@ store 3
 load 4
 callsub arraycomplement_9
 store 4
+load 5
+callsub numericalcomp_10
+store 5
 byte 0x00
 int 0
 load 0
@@ -57,251 +64,251 @@ load 3
 concat
 load 4
 concat
-store 12
-load 12
+load 5
+itob
+concat
+store 13
+load 13
 retsub
 
 // round_tripper
 roundtripper_1:
-store 7
-load 7
-callsub tuplecomplement_0
-store 9
-load 9
-callsub tuplecomplement_0
-store 10
-load 7
-load 9
-concat
-load 10
-concat
 store 8
 load 8
+callsub tuplecomplement_0
+store 10
+load 10
+callsub tuplecomplement_0
+store 11
+load 8
+load 10
+concat
+load 11
+concat
+store 9
+load 9
 retsub
 
 // bool_comp
 boolcomp_2:
-store 15
-load 15
-!
-!
-!
 store 16
 load 16
+!
+!
+!
+store 17
+load 17
 retsub
 
 // numerical_comp
 numericalcomp_3:
-store 51
-int 255
-load 51
--
 store 52
+int 255
 load 52
+-
+store 53
+load 53
 int 256
 <
 assert
-load 52
+load 53
 retsub
 
 // array_complement
 arraycomplement_4:
-store 17
-load 17
+store 18
+load 18
 int 1
 int 0
 *
 getbyte
-store 19
-load 17
+store 20
+load 18
 int 1
 int 1
 *
 getbyte
-store 20
-load 17
+store 21
+load 18
 int 1
 int 2
 *
 getbyte
-store 21
-load 17
+store 22
+load 18
 int 1
 int 3
 *
 getbyte
-store 22
-load 17
+store 23
+load 18
 int 1
 int 4
 *
 getbyte
-store 23
-load 17
+store 24
+load 18
 int 1
 int 5
 *
 getbyte
-store 24
-load 17
+store 25
+load 18
 int 1
 int 6
 *
 getbyte
-store 25
-load 17
+store 26
+load 18
 int 1
 int 7
 *
 getbyte
-store 26
-load 17
+store 27
+load 18
 int 1
 int 8
 *
 getbyte
-store 27
-load 17
+store 28
+load 18
 int 1
 int 9
 *
 getbyte
-store 28
-load 17
+store 29
+load 18
 int 1
 int 10
 *
 getbyte
-store 29
-load 17
+store 30
+load 18
 int 1
 int 11
 *
 getbyte
-store 30
-load 17
+store 31
+load 18
 int 1
 int 12
 *
 getbyte
-store 31
-load 17
+store 32
+load 18
 int 1
 int 13
 *
 getbyte
-store 32
-load 17
+store 33
+load 18
 int 1
 int 14
 *
 getbyte
-store 33
-load 17
+store 34
+load 18
 int 1
 int 15
 *
 getbyte
-store 34
-load 17
+store 35
+load 18
 int 1
 int 16
 *
 getbyte
-store 35
-load 17
+store 36
+load 18
 int 1
 int 17
 *
 getbyte
-store 36
-load 17
+store 37
+load 18
 int 1
 int 18
 *
 getbyte
-store 37
-load 17
+store 38
+load 18
 int 1
 int 19
 *
 getbyte
-store 38
-load 17
+store 39
+load 18
 int 1
 int 20
 *
 getbyte
-store 39
-load 17
+store 40
+load 18
 int 1
 int 21
 *
 getbyte
-store 40
-load 17
+store 41
+load 18
 int 1
 int 22
 *
 getbyte
-store 41
-load 17
+store 42
+load 18
 int 1
 int 23
 *
 getbyte
-store 42
-load 17
+store 43
+load 18
 int 1
 int 24
 *
 getbyte
-store 43
-load 17
+store 44
+load 18
 int 1
 int 25
 *
 getbyte
-store 44
-load 17
+store 45
+load 18
 int 1
 int 26
 *
 getbyte
-store 45
-load 17
+store 46
+load 18
 int 1
 int 27
 *
 getbyte
-store 46
-load 17
+store 47
+load 18
 int 1
 int 28
 *
 getbyte
-store 47
-load 17
+store 48
+load 18
 int 1
 int 29
 *
 getbyte
-store 48
-load 17
+store 49
+load 18
 int 1
 int 30
 *
 getbyte
-store 49
-load 17
+store 50
+load 18
 int 1
 int 31
 *
 getbyte
-store 50
-load 19
-callsub numericalcomp_3
-store 19
+store 51
 load 20
 callsub numericalcomp_3
 store 20
@@ -395,15 +402,13 @@ store 49
 load 50
 callsub numericalcomp_3
 store 50
-byte 0x00
-int 0
-load 19
-setbyte
+load 51
+callsub numericalcomp_3
+store 51
 byte 0x00
 int 0
 load 20
 setbyte
-concat
 byte 0x00
 int 0
 load 21
@@ -554,118 +559,120 @@ int 0
 load 50
 setbyte
 concat
-store 18
-load 18
+byte 0x00
+int 0
+load 51
+setbyte
+concat
+store 19
+load 19
 retsub
 
 // tuple_complement
 tuplecomplement_5:
-store 53
-load 53
+store 54
+load 54
 int 0
 extract_uint64
-store 13
-load 53
+store 14
+load 54
 int 64
 getbit
-store 14
-load 13
-callsub numericalcomp_10
-store 13
+store 15
 load 14
-callsub boolcomp_11
+callsub numericalcomp_11
 store 14
-load 13
+load 15
+callsub boolcomp_12
+store 15
+load 14
 itob
 byte 0x00
 int 0
-load 14
+load 15
 setbit
 concat
-store 54
-load 54
+store 55
+load 55
 retsub
 
 // numerical_comp
 numericalcomp_6:
-store 71
-int 255
-load 71
--
 store 72
+int 255
 load 72
+-
+store 73
+load 73
 int 256
 <
 assert
-load 72
+load 73
 retsub
 
 // array_complement
 arraycomplement_7:
-store 59
-load 59
+store 60
+load 60
 int 1
 int 0
 *
 getbyte
-store 61
-load 59
+store 62
+load 60
 int 1
 int 1
 *
 getbyte
-store 62
-load 59
+store 63
+load 60
 int 1
 int 2
 *
 getbyte
-store 63
-load 59
+store 64
+load 60
 int 1
 int 3
 *
 getbyte
-store 64
-load 59
+store 65
+load 60
 int 1
 int 4
 *
 getbyte
-store 65
-load 59
+store 66
+load 60
 int 1
 int 5
 *
 getbyte
-store 66
-load 59
+store 67
+load 60
 int 1
 int 6
 *
 getbyte
-store 67
-load 59
+store 68
+load 60
 int 1
 int 7
 *
 getbyte
-store 68
-load 59
+store 69
+load 60
 int 1
 int 8
 *
 getbyte
-store 69
-load 59
+store 70
+load 60
 int 1
 int 9
 *
 getbyte
-store 70
-load 61
-callsub numericalcomp_6
-store 61
+store 71
 load 62
 callsub numericalcomp_6
 store 62
@@ -693,15 +700,13 @@ store 69
 load 70
 callsub numericalcomp_6
 store 70
-byte 0x00
-int 0
-load 61
-setbyte
+load 71
+callsub numericalcomp_6
+store 71
 byte 0x00
 int 0
 load 62
 setbyte
-concat
 byte 0x00
 int 0
 load 63
@@ -742,86 +747,101 @@ int 0
 load 70
 setbyte
 concat
-store 60
-load 60
+byte 0x00
+int 0
+load 71
+setbyte
+concat
+store 61
+load 61
 retsub
 
 // bool_comp
 boolcomp_8:
-store 79
-load 79
-!
-!
-!
 store 80
 load 80
+!
+!
+!
+store 81
+load 81
 retsub
 
 // array_complement
 arraycomplement_9:
-store 73
-load 73
-int 0
-getbit
-store 75
-load 73
-int 1
-getbit
-store 76
-load 73
-int 2
-getbit
-store 77
-load 73
-int 3
-getbit
-store 78
-load 75
-callsub boolcomp_8
-store 75
-load 76
-callsub boolcomp_8
-store 76
-load 77
-callsub boolcomp_8
-store 77
-load 78
-callsub boolcomp_8
-store 78
-byte 0x00
-int 0
-load 75
-setbit
-int 1
-load 76
-setbit
-int 2
-load 77
-setbit
-int 3
-load 78
-setbit
 store 74
 load 74
+int 0
+getbit
+store 76
+load 74
+int 1
+getbit
+store 77
+load 74
+int 2
+getbit
+store 78
+load 74
+int 3
+getbit
+store 79
+load 76
+callsub boolcomp_8
+store 76
+load 77
+callsub boolcomp_8
+store 77
+load 78
+callsub boolcomp_8
+store 78
+load 79
+callsub boolcomp_8
+store 79
+byte 0x00
+int 0
+load 76
+setbit
+int 1
+load 77
+setbit
+int 2
+load 78
+setbit
+int 3
+load 79
+setbit
+store 75
+load 75
 retsub
 
 // numerical_comp
 numericalcomp_10:
-store 55
+store 82
 int 18446744073709551615
-load 55
+load 82
 -
+store 83
+load 83
+retsub
+
+// numerical_comp
+numericalcomp_11:
 store 56
+int 18446744073709551615
 load 56
+-
+store 57
+load 57
 retsub
 
 // bool_comp
-boolcomp_11:
-store 57
-load 57
-!
-!
-!
+boolcomp_12:
 store 58
 load 58
+!
+!
+!
+store 59
+load 59
 retsub


### PR DESCRIPTION
Take implementation and designs from `vex` and `beaker` for #180 implementation.

The implementation is still minimum, and the limit for length (5) in `Tuple` is still unrelieved, for we want to generate annotation at some point.