### PR TITLE
Can subroutine haz abi (in graviton tests)

### DIFF
--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -192,10 +192,11 @@ class PyTealDryRunExecutor:
         self._pyteal_lambda: Callable[..., Expr] = approval
 
     def is_abi(self) -> bool:
+        """DEPRECATED: This doesn't have much value, now that @Subroutine decorators can handle abi types too!"""
         return isinstance(self.subr.subroutine, ABIReturnSubroutine)
 
     def abi_argument_types(self) -> None | list[algosdk.abi.ABIType]:
-        if not self.is_abi():
+        if not self.input_types:
             return None
 
         def handle_arg(arg):
@@ -206,10 +207,7 @@ class PyTealDryRunExecutor:
         return [handle_arg(arg) for arg in self.input_types]
 
     def abi_return_type(self) -> None | algosdk.abi.ABIType:
-        if not self.is_abi():
-            return None
-
-        out_info = getattr(self.subr.subroutine, "output_kwarg_info")
+        out_info = getattr(self.subr.subroutine, "output_kwarg_info", None)
         if not out_info:
             return None
 

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -192,11 +192,10 @@ class PyTealDryRunExecutor:
         self._pyteal_lambda: Callable[..., Expr] = approval
 
     def is_abi(self) -> bool:
-        """DEPRECATED: This doesn't have much value, now that @Subroutine decorators can handle abi types too!"""
         return isinstance(self.subr.subroutine, ABIReturnSubroutine)
 
     def abi_argument_types(self) -> None | list[algosdk.abi.ABIType]:
-        if not self.input_types:
+        if not (self.input_types or self.is_abi()):
             return None
 
         def handle_arg(arg):
@@ -207,7 +206,10 @@ class PyTealDryRunExecutor:
         return [handle_arg(arg) for arg in self.input_types]
 
     def abi_return_type(self) -> None | algosdk.abi.ABIType:
-        out_info = getattr(self.subr.subroutine, "output_kwarg_info", None)
+        if not self.is_abi():
+            return None
+
+        out_info = getattr(self.subr.subroutine, "output_kwarg_info")
         if not out_info:
             return None
 

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -908,7 +908,7 @@ def blackbox_pyteal_while_continue_test():
         )
 
 
-def blackbox_pyteal_named_tupleness_test():
+def blackbox_pyteal_named_tupleness():
     from typing import Literal as L
     from tests.blackbox import Blackbox
     from pyteal import (
@@ -960,11 +960,13 @@ def blackbox_pyteal_named_tupleness_test():
         )
 
     lsig_pytealer = PyTealDryRunExecutor(named_tuple_field_access, Mode.Signature)
+    args = (False, b"1" * 32, (0, False), b"0" * 10, [True] * 4, 0)
+    
+    inspector = lsig_pytealer.dryrun([args])
+    
+    assert inspector.stack_top() == 1
+    assert inspector.passed()
 
-    encoded = sdk_abi_t.encode((False, b"1" * 32, (0, False), b"0" * 10, [True] * 4, 0))
-    lsig_result = lsig_pytealer.dryrun([bytes(encoded)])
-    print(lsig_result.stack_top())
-    assert lsig_result.passed()
 
 
 @pytest.mark.parametrize(
@@ -976,7 +978,7 @@ def blackbox_pyteal_named_tupleness_test():
         blackbox_pyteal_example4,
         blackbox_pyteal_example5,
         blackbox_pyteal_while_continue_test,
-        blackbox_pyteal_named_tupleness_test,
+        # blackbox_pyteal_named_tupleness_test,
     ],
 )
 def test_blackbox_pyteal_examples(example):

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -963,7 +963,7 @@ def blackbox_pyteal_named_tupleness_test():
     lsig_pytealer = PyTealDryRunExecutor(named_tuple_field_access, Mode.Signature)
     args = (False, b"1" * 32, (0, False), b"0" * 10, [True] * 4, 0)
     
-    inspector = lsig_pytealer.dryrun([args])
+    inspector = lsig_pytealer.dryrun(args)
     
     assert inspector.stack_top() == 1
     assert inspector.passed()
@@ -994,7 +994,7 @@ def blackbox_pyteal_named_tupleness_test():
         blackbox_pyteal_example4,
         blackbox_pyteal_example5,
         blackbox_pyteal_while_continue_test,
-        # blackbox_pyteal_named_tupleness_test,
+        blackbox_pyteal_named_tupleness_test,
     ],
 )
 def test_blackbox_pyteal_examples(example):

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -967,22 +967,6 @@ def blackbox_pyteal_named_tupleness_test():
     assert inspector.stack_top() == 1
     assert inspector.passed()
 
-    # TYPES_N_VALS: list[tuple[str, Any]] = [
-    #     ("bool", False),
-    #     ("address", b"1" * 32),
-    #     ("(uint64,bool)", (12, True)),
-    #     ("byte[10]", b"a" * 10),
-    #     ("bool[4]", [False] * 4),
-    #     ("uint64", 100),
-    # ]
-
-    # args: list[bytes] = [
-    #     ABIType.from_string(abi_t).encode(var) for abi_t, var in TYPES_N_VALS
-    # ]
-
-    # lsig_result = lsig_pytealer.dryrun(args)
-    # assert lsig_result.passed()
-
 
 @pytest.mark.parametrize(
     "example",

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -909,8 +909,7 @@ def blackbox_pyteal_while_continue_test():
 
 
 def blackbox_pyteal_named_tupleness_test():
-    from typing import Any, Literal as L
-    from algosdk.abi import ABIType
+    from typing import Literal as L
     from tests.blackbox import Blackbox
     from pyteal import (
         Seq,
@@ -962,9 +961,9 @@ def blackbox_pyteal_named_tupleness_test():
 
     lsig_pytealer = PyTealDryRunExecutor(named_tuple_field_access, Mode.Signature)
     args = (False, b"1" * 32, (0, False), b"0" * 10, [True] * 4, 0)
-    
+
     inspector = lsig_pytealer.dryrun(args)
-    
+
     assert inspector.stack_top() == 1
     assert inspector.passed()
 


### PR DESCRIPTION
When reviewing #473 I relaized that the `PyTealDryRunExecutor` hadn't been updated to reflect the fact that `@Subroutines` may happily accept ABI-types. Consequently, there were all sorts of contortions necessary to get graviton tests to run on the `NamedTuple` example. 

This change should simplify usage of graviton tests in the case of regular `@Subroutines` with ABI-types.