### PR TITLE
Upgrade Sphinx to v5.1.1 to limit nitpick excludes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,27 +42,73 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-nitpick_ignore = [
-    ("py:class", "optional"),
+class NitpickIgnore:
+
+    @staticmethod
+    def optional() -> list[tuple[str, str]]:
+        """
+        Ignores parameter declarations that specify _optional_ usage.
+        """
+        return [
+            ("py:class", "optional"),
+        ]
+
+    @staticmethod
+    def standard_library() -> list[tuple[str, str]]:
+        """
+        Ignores Python standard library references that Sphinx does not track.
+        """
+        return [
     ("py:class", "abc.ABC"),
 ]
 
-nitpick_ignore_regex = [
-    ("py:class", r"algosdk\.abi\..*"),
-    ("py:class", r"contextlib\..*"),
-    ("py:class", r"enum\..*"),
-    ("py.obj", r".*\.T$"),
-    ("py.obj", r".*\.T[0-9]+$"),
-    ("py.class", r".*\.T_co$"),
-    ("py.obj", r".*\.T_co$"),
-    ("py.class", r".*\.T$"),
-    ("py.class", r"^T$"),
-    ("py.obj", r".*\.N$"),
-    ("py.class", r".*\.N$"),
-    ("py.class", r"^N$"),
-    ("py.class", r"^type\[.*"),
-    ("py.obj", r"typing\..*"),
-]
+class NitpickIgnoreRegex:
+
+    @staticmethod
+    def type_vars() -> list[tuple[str, str]]:
+        """
+        Regex ignores generic TypeVar definitions that Sphinx does not track.
+        """
+        return [
+            ("py.obj", r".*\.T$"),
+            ("py.obj", r".*\.T[0-9]+$"),
+            ("py.class", r".*\.T_co$"),
+            ("py.obj", r".*\.T_co$"),
+            ("py.class", r".*\.T$"),
+            ("py.class", r"^T$"),
+            ("py.obj", r".*\.N$"),
+            ("py.class", r".*\.N$"),
+            ("py.class", r"^N$"),
+        ]
+
+    @staticmethod
+    def standard_library() -> list[tuple[str, str]]:
+        """
+        Regex ignores Python standard library references that Sphinx does not track.
+        """
+        return [
+            ("py:class", r"contextlib\..*"),
+            ("py:class", r"enum\..*"),
+        ]
+
+    @staticmethod
+    def third_party() -> list[tuple[str, str]]:
+        """
+        Regex ignores 3rd party references that Sphinx does not track.
+        """
+        return [
+            ("py:class", r"algosdk\.abi\..*"),
+        ]
+
+nitpick_ignore = \
+    NitpickIgnore.optional() + \
+    NitpickIgnore.standard_library()
+
+nitpick_ignore_regex = \
+    NitpickIgnoreRegex.standard_library() + \
+    NitpickIgnoreRegex.third_party() + \
+    NitpickIgnoreRegex.type_vars()
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,8 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-class NitpickIgnore:
 
+class NitpickIgnore:
     @staticmethod
     def optional() -> list[tuple[str, str]]:
         """
@@ -59,11 +59,11 @@ class NitpickIgnore:
         Ignores Python standard library references that Sphinx does not track.
         """
         return [
-    ("py:class", "abc.ABC"),
-]
+            ("py:class", "abc.ABC"),
+        ]
+
 
 class NitpickIgnoreRegex:
-
     @staticmethod
     def type_vars() -> list[tuple[str, str]]:
         """
@@ -100,14 +100,14 @@ class NitpickIgnoreRegex:
             ("py:class", r"algosdk\.abi\..*"),
         ]
 
-nitpick_ignore = \
-    NitpickIgnore.optional() + \
-    NitpickIgnore.standard_library()
 
-nitpick_ignore_regex = \
-    NitpickIgnoreRegex.standard_library() + \
-    NitpickIgnoreRegex.third_party() + \
-    NitpickIgnoreRegex.type_vars()
+nitpick_ignore = NitpickIgnore.optional() + NitpickIgnore.standard_library()
+
+nitpick_ignore_regex = (
+    NitpickIgnoreRegex.standard_library()
+    + NitpickIgnoreRegex.third_party()
+    + NitpickIgnoreRegex.type_vars()
+)
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==4.2.0
+sphinx==5.1.1
 sphinx-rtd-theme==1.0.0
 # dependencies from setup.py
 py-algorand-sdk>=1.9.0,<2.0.0


### PR DESCRIPTION
Extends #478 to upgrade Sphinx.  The Sphinx upgrade enables us to remove the following nitpick ignores:
```
    ("py.class", r"^type\[.*"),
    ("py.obj", r"typing\..*"),
```

Consider the PR optional.  Feel welcomed to accept some, all or none of it.

Notes:
* Release notes:  https://www.sphinx-doc.org/en/master/changes.html#release-5-1-1-released-jul-26-2022.  
  * I scanned the v5.0.0 breaking changes and did _not_ see changes impacting us.  Admittedly, I'm unfamiliar with the library details.
  * I tested locally by building the docs and visually comparing with https://pyteal.readthedocs.io/.  I spotted no differences.
* Groups the warnings in order to add inline comments documenting _why_ the ignore is added.  Feel welcomed to suggest different groupings.  I feel more strongly that _a_ comment exists.