### PR TITLE
Add `NamedTuple` field annotation

### DIFF
--- a/docs/abi.rst
+++ b/docs/abi.rst
@@ -324,14 +324,13 @@ The supported methods are:
 * :any:`abi.Tuple.__getitem__(index: int) <abi.Tuple.__getitem__>`, used for :any:`abi.Tuple` and :any:`abi.NamedTuple`\*
 
 .. note::
+    Be aware that these methods return a :any:`ComputedValue`, similar to other PyTeal operations which return ABI types. More information about why that is necessary and how to use a :any:`ComputedValue` can be found in the :ref:`Computed Values` section.
+
+.. note::
     \*For :any:`abi.NamedTuple`, one can access tuple elements through both methods
 
     * :any:`abi.Tuple.__getitem__(index: int) <abi.Tuple.__getitem__>`
     * :any:`abi.NamedTuple.__getattr__(name: str) <abi.NamedTuple.__getattr__>`
-
-    Be aware that, though the fields in a :any:`abi.NamedTuple` are annotated in ABI types, the return values from the annotated fields are :any:`ComputedValues <abi.ComputedValue>`.
-
-    Also be aware that these methods return a :any:`ComputedValue`, similar to other PyTeal operations which return ABI types. More information about why that is necessary and how to use a :any:`ComputedValue` can be found in the :ref:`Computed Values` section.
 
 A brief example is below. Please consult the documentation linked above for each method to learn more about specific usage and behavior.
 

--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -32,6 +32,7 @@ from pyteal.ast.abi.tuple import (
     Tuple5,
     NamedTuple,
     NamedTupleTypeSpec,
+    Field,
 )
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
 from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray
@@ -120,6 +121,7 @@ __all__ = [
     "Tuple5",
     "NamedTuple",
     "NamedTupleTypeSpec",
+    "Field",
     "ArrayTypeSpec",
     "Array",
     "ArrayElement",

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -8,6 +8,9 @@ from typing import (
     cast,
     overload,
     Any,
+    TypeAlias,
+    get_args,
+    get_origin,
 )
 from collections import OrderedDict
 
@@ -488,6 +491,9 @@ class Tuple5(Tuple, Generic[T1, T2, T3, T4, T5]):
 Tuple5.__module__ = "pyteal.abi"
 
 
+Field: TypeAlias = TupleElement[T]
+
+
 class NamedTupleTypeSpec(TupleTypeSpec):
     """A NamedTupleType inherits from TupleTypeSpec, allowing for more than 5 elements."""
 
@@ -513,18 +519,35 @@ NamedTupleTypeSpec.__module__ = "pyteal.abi"
 
 
 class NamedTuple(Tuple):
-    """A NamedTuple is a Tuple with all its elements named.
+    """A NamedTuple is a :any:`Tuple` that has named elements, inspired by Python's `typing.NamedTuple <https://docs.python.org/3/library/typing.html#typing.NamedTuple>`_.
+
+    A new NamedTuple type can be created by subclassing this class and adding field annotations.
+    Every field annotation must be an instantiable ABI type wrapped in the :code:`abi.Field` annotation.
+
+    For example:
+
+        .. code-block:: python
+
+            from pyteal import *
+
+            class User(abi.NamedTuple):
+                address: abi.Field[abi.Address]
+                balance: abi.Field[abi.Uint64]
+
+            # User is equivalent to abi.Tuple2[abi.Address, abi.Uint64]
+
+            my_user = User()
 
     .. automethod:: __getattr__
     """
 
     def __init__(self):
         if type(self) is NamedTuple:
-            raise TealInputError("NamedTuple must be subclassed.")
+            raise TealInputError("NamedTuple must be subclassed")
 
         anns = get_annotations(type(self))
         if not anns:
-            raise Exception("Expected fields to be declared but found none")
+            raise TealInputError("Expected fields to be declared but found none")
 
         # NOTE: this `_ready` variable enables `__setattr__` during `__init__` execution,
         # while after `__init__`, we cannot use `__setattr__` to set fields in `NamedTuple`.
@@ -536,7 +559,21 @@ class NamedTuple(Tuple):
         self.__field_index: dict[str, int] = {}
 
         for index, (name, annotation) in enumerate(anns.items()):
-            self.__type_specs[name] = type_spec_from_annotation(annotation)
+            origin = get_origin(annotation)
+            if origin is None:
+                origin = annotation
+            if origin is not get_origin(Field):
+                raise TealInputError(
+                    f'Type annotation for attribute "{name}" must be a Field. Got {origin}'
+                )
+
+            args = get_args(annotation)
+            if len(args) != 1:
+                raise TealInputError(
+                    f'Type annotation for attribute "{name}" must have a single argument. Got {args}'
+                )
+
+            self.__type_specs[name] = type_spec_from_annotation(args[0])
             self.__field_index[name] = index
 
         super().__init__(
@@ -545,8 +582,24 @@ class NamedTuple(Tuple):
 
         self._ready = True
 
-    def __getattr__(self, field: str) -> TupleElement:
+    def __getattr__(self, field: str) -> TupleElement[Any]:
         """Retrieve an element by its field in this NamedTuple.
+
+        For example:
+
+        .. code-block:: python
+
+            from pyteal import *
+
+            class User(abi.NamedTuple):
+                address: abi.Field[abi.Address]
+                balance: abi.Field[abi.Uint64]
+
+            @ABIReturnSubroutine
+            def get_user_balance(user: User, *, output: abi.Uint64) -> Expr:
+                return output.set(user.balance)
+
+
 
         Args:
             field: a Python string containing the field to access.

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -599,8 +599,6 @@ class NamedTuple(Tuple):
             def get_user_balance(user: User, *, output: abi.Uint64) -> Expr:
                 return output.set(user.balance)
 
-
-
         Args:
             field: a Python string containing the field to access.
                 This function will raise an KeyError if the field is not available in the defined NamedTuple.

--- a/pyteal/ast/abi/tuple_test.py
+++ b/pyteal/ast/abi/tuple_test.py
@@ -826,38 +826,65 @@ def test_TupleElement_store_into():
                 assert actual == expected, "Test at index {} failed".format(i)
 
 
+def test_NamedTuple_init():
+    with pytest.raises(pt.TealInputError, match=r"NamedTuple must be subclassed$"):
+        abi.NamedTuple()
+
+    class Empty(abi.NamedTuple):
+        pass
+
+    with pytest.raises(
+        pt.TealInputError, match=r"Expected fields to be declared but found none$"
+    ):
+        Empty()
+
+    class ValidField(abi.NamedTuple):
+        name: abi.Field[abi.Uint16]
+
+    ValidField()
+
+    class NoField(abi.NamedTuple):
+        name: abi.Uint16
+
+    with pytest.raises(
+        pt.TealInputError,
+        match=r'Type annotation for attribute "name" must be a Field. Got ',
+    ):
+        NoField()
+
+
 class NT_0(abi.NamedTuple):
-    f0: abi.Uint64
-    f1: abi.Uint32
-    f2: abi.Uint16
-    f3: abi.Uint8
+    f0: abi.Field[abi.Uint64]
+    f1: abi.Field[abi.Uint32]
+    f2: abi.Field[abi.Uint16]
+    f3: abi.Field[abi.Uint8]
 
 
 class NT_1(abi.NamedTuple):
-    f0: abi.StaticArray[abi.Bool, Literal[4]]
-    f1: abi.DynamicArray[abi.String]
-    f2: abi.String
-    f3: abi.Bool
-    f4: abi.Address
-    f5: NT_0
+    f0: abi.Field[abi.StaticArray[abi.Bool, Literal[4]]]
+    f1: abi.Field[abi.DynamicArray[abi.String]]
+    f2: abi.Field[abi.String]
+    f3: abi.Field[abi.Bool]
+    f4: abi.Field[abi.Address]
+    f5: abi.Field[NT_0]
 
 
 class NT_2(abi.NamedTuple):
-    f0: abi.Bool
-    f1: abi.Bool
-    f2: abi.Bool
-    f3: abi.Bool
-    f4: abi.Bool
-    f5: abi.Bool
-    f6: abi.Bool
-    f7: abi.Bool
-    f8: NT_1
+    f0: abi.Field[abi.Bool]
+    f1: abi.Field[abi.Bool]
+    f2: abi.Field[abi.Bool]
+    f3: abi.Field[abi.Bool]
+    f4: abi.Field[abi.Bool]
+    f5: abi.Field[abi.Bool]
+    f6: abi.Field[abi.Bool]
+    f7: abi.Field[abi.Bool]
+    f8: abi.Field[NT_1]
 
 
 class NT_3(abi.NamedTuple):
-    f0: NT_0
-    f1: NT_1
-    f2: NT_2
+    f0: abi.Field[NT_0]
+    f1: abi.Field[NT_1]
+    f2: abi.Field[NT_2]
 
 
 @pytest.mark.parametrize("test_case", [NT_0, NT_1, NT_2, NT_3])

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -304,7 +304,7 @@ def test_type_spec_from_annotation_is_exhaustive():
 
         if subclass is pt.abi.NamedTuple:
             with pytest.raises(
-                TealInputError, match=r"^NamedTuple must be subclassed."
+                TealInputError, match=r"^NamedTuple must be subclassed$"
             ):
                 type_spec_from_annotation(subclass)
             continue

--- a/tests/integration/abi_roundtrip_test.py
+++ b/tests/integration/abi_roundtrip_test.py
@@ -36,12 +36,12 @@ BAD_TYPES = {
 
 
 class NamedTupleInherit(abi.NamedTuple):
-    a: abi.Bool
-    b: abi.Address
-    c: abi.Tuple2[abi.Uint64, abi.Bool]
-    d: abi.StaticArray[abi.Byte, Literal[10]]
-    e: abi.StaticArray[abi.Bool, Literal[4]]
-    f: abi.Uint64
+    a: abi.Field[abi.Bool]
+    b: abi.Field[abi.Address]
+    c: abi.Field[abi.Tuple2[abi.Uint64, abi.Bool]]
+    d: abi.Field[abi.StaticArray[abi.Byte, Literal[10]]]
+    e: abi.Field[abi.StaticArray[abi.Bool, Literal[4]]]
+    f: abi.Field[abi.Uint64]
 
 
 PATH = Path.cwd() / "tests" / "integration"

--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -922,12 +922,12 @@ def blackbox_pyteal_named_tupleness_test():
     )
 
     class NamedTupleExample(abi.NamedTuple):
-        a: abi.Bool
-        b: abi.Address
-        c: abi.Tuple2[abi.Uint64, abi.Bool]
-        d: abi.StaticArray[abi.Byte, L[10]]
-        e: abi.StaticArray[abi.Bool, L[4]]
-        f: abi.Uint64
+        a: abi.Field[abi.Bool]
+        b: abi.Field[abi.Address]
+        c: abi.Field[abi.Tuple2[abi.Uint64, abi.Bool]]
+        d: abi.Field[abi.StaticArray[abi.Byte, L[10]]]
+        e: abi.Field[abi.StaticArray[abi.Bool, L[4]]]
+        f: abi.Field[abi.Uint64]
 
     @Blackbox(input_types=[None] * 6)
     @Subroutine(TealType.uint64)


### PR DESCRIPTION
In this PR I've attempted to solve the problem of mypy thinking `NamedTuple` field values are not instances of `ComputedValue`.

I did this by making a new type `Field` which is actually just an alias of `TupleElement`. Additionally, I made `NamedTuple` require that every annotation use `Field`.

This is my attempt at a compromise between brevity and readability vs type correctness.