### PR TITLE
Rework internals of `Comment`

### DIFF
--- a/pyteal/ast/comment.py
+++ b/pyteal/ast/comment.py
@@ -1,31 +1,63 @@
 from typing import TYPE_CHECKING, Tuple
 
+from pyteal.errors import TealInputError
+from pyteal.types import TealType
 from pyteal.ir import TealBlock, TealSimpleBlock, TealOp, Op
 from pyteal.ast.expr import Expr
+from pyteal.ast.seq import Seq
 
 if TYPE_CHECKING:
     from pyteal.compiler import CompileOptions
 
 
-class Comment(Expr):
-    def __init__(self, expr: Expr, comment: str):
-        self.expr = expr
-        self.comment = " ".join(
-            [i.strip() for i in comment.split("\n") if not (i.isspace() or len(i) == 0)]
-        )
+class CommentExpr(Expr):
+    """Represents a single line comment in TEAL source code.
+
+    This class is intentionally hidden because it's too basic to directly expose. Anything exposed
+    to users should be able to handle multi-line comments by breaking them apart and using this
+    class.
+    """
+
+    def __init__(self, single_line_comment: str) -> None:
+        super().__init__()
+        if "\n" in single_line_comment or "\r" in single_line_comment:
+            raise TealInputError(
+                "Newlines should not be present in the CommentExpr constructor"
+            )
+        self.comment = single_line_comment
 
     def __teal__(self, options: "CompileOptions") -> Tuple[TealBlock, TealSimpleBlock]:
         op = TealOp(self, Op.comment, self.comment)
-        return TealBlock.FromOp(options, op, self.expr)
+        return TealBlock.FromOp(options, op)
 
     def __str__(self):
-        return f"(Comment {self.comment} ({self.expr}))"
+        return f'(Comment "{self.comment}")'
 
     def type_of(self):
-        return self.expr.type_of()
+        return TealType.none
 
     def has_return(self):
-        return self.expr.has_return()
+        return False
 
 
-Comment.__module__ = "pyteal"
+CommentExpr.__module__ = "pyteal"
+
+
+def Comment(expr: Expr, comment: str) -> Expr:
+    """Wrap an existing expression with a comment.
+
+    This comment will be present in the compiled TEAL source immediately before the first op of the
+    expression.
+
+    Note that when TEAL source is assembled into bytes, all comments are omitted.
+
+    Args:
+        expr: The expression to be commented.
+        comment: The comment that will be associated with the expression.
+
+    Returns:
+        A new expression which is functionally equivalent to the input expression, but which will
+        compile with the given comment string.
+    """
+    lines = comment.splitlines()
+    return Seq(*[CommentExpr(line) for line in lines], expr)

--- a/pyteal/ast/comment_test.py
+++ b/pyteal/ast/comment_test.py
@@ -1,76 +1,107 @@
+import pytest
+
 import pyteal as pt
+from pyteal.ast.comment import CommentExpr
 
 options = pt.CompileOptions()
 
 
-def test_comment():
+def test_CommentExpr():
+    for comment in ("", "hello world", " // a b c //    \t . "):
+        expr = CommentExpr(comment)
+        assert expr.comment == comment
+        assert expr.type_of() == pt.TealType.none
+        assert expr.has_return() is False
+
+        expected = pt.TealSimpleBlock(
+            [
+                pt.TealOp(expr, pt.Op.comment, comment),
+            ]
+        )
+
+        actual, _ = expr.__teal__(options)
+        actual.addIncoming()
+        actual = pt.TealBlock.NormalizeBlocks(actual)
+
+        assert actual == expected
+
+    for newline in ("\n", "\r\n", "\r"):
+        with pytest.raises(
+            pt.TealInputError,
+            match=r"Newlines should not be present in the CommentExpr constructor$",
+        ):
+            CommentExpr(f"one line{newline}two lines")
+
+
+def test_Comment_empty():
+    to_wrap = pt.Int(1)
+    comment = ""
+    expr = pt.Comment(to_wrap, comment)
+    assert type(expr) is pt.Seq
+    assert len(expr.args) == 1
+
+    assert expr.args[0] is to_wrap
+
+
+def test_Comment_single_line():
     to_wrap = pt.Int(1)
     comment = "just an int"
     expr = pt.Comment(to_wrap, comment)
-    assert expr.type_of() == to_wrap.type_of()
-    assert expr.has_return() == to_wrap.has_return()
+    assert type(expr) is pt.Seq
+    assert len(expr.args) == 2
+
+    assert type(expr.args[0]) is CommentExpr
+    assert expr.args[0].comment == comment
+
+    assert expr.args[1] is to_wrap
 
     version = 6
-    expected_teal = f"#pragma version {version};int 1;// {comment};return".replace(
-        ";", "\n"
-    )
+    expected_teal = f"""#pragma version {version}
+// {comment}
+int 1
+return"""
     actual_teal = pt.compileTeal(
         pt.Return(expr), version=version, mode=pt.Mode.Application
     )
     assert actual_teal == expected_teal
 
 
-def test_long_comment():
+def test_Comment_multi_line():
     to_wrap = pt.Int(1)
     comment = """just an int
-     but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? 
-     You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`
-     since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details 
-    """
-    expr = pt.Comment(to_wrap, comment)
-    assert expr.type_of() == to_wrap.type_of()
-    assert expr.has_return() == to_wrap.has_return()
+but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? 
+You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`
+since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details 
+"""
 
-    comment = " ".join(
-        [i.strip() for i in comment.split("\n") if not (i.isspace() or len(i) == 0)]
-    )
+    comment_parts = [
+        "just an int",
+        "but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? ",
+        "You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`",
+        "since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details ",
+    ]
+
+    expr = pt.Comment(to_wrap, comment)
+    assert type(expr) is pt.Seq
+    assert len(expr.args) == 5
+
+    for i, part in enumerate(comment_parts):
+        arg = expr.args[i]
+        assert type(arg) is CommentExpr
+        assert arg.comment == part
+
+    assert expr.args[4] is to_wrap
 
     version = 6
-    expected_teal = f"#pragma version {version};int 1;// {comment};return".replace(
-        ";", "\n"
-    )
+    expected_teal = f"""#pragma version {version}
+// just an int
+// but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? 
+// You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`
+// since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details 
+int 1
+return"""
     actual_teal = pt.compileTeal(
         pt.Return(expr), version=version, mode=pt.Mode.Application
     )
     print(actual_teal)
     assert actual_teal == expected_teal
-
-
-def test_comment_no_simple():
-    to_wrap = pt.Seq(pt.Int(1))
-    comment = "just an int"
-    expr = pt.Comment(to_wrap, comment)
-    assert expr.type_of() == to_wrap.type_of()
-    assert expr.has_return() == to_wrap.has_return()
-
-    version = 6
-    expected_teal = f"#pragma version {version};int 1;// {comment};return".replace(
-        ";", "\n"
-    )
-    actual_teal = pt.compileTeal(
-        pt.Return(expr), version=version, mode=pt.Mode.Application
-    )
-    assert actual_teal == expected_teal
-
-
-# def test_comment_empty_expr():
-#     to_wrap = pt.Seq()
-#     comment = "should fail"
-#     expr = pt.Comment(to_wrap, comment)
-#     assert expr.type_of() == to_wrap.type_of()
-#
-#     print(expr.__teal__(options))
-#
-#     with pytest.raises(pt.TealInputError):
-#         expr.__teal__(options)
-#


### PR DESCRIPTION
Child PR to #410 which reworks `Comment` internals.

Now, `Comment` is a function which returns a `Seq`. That `Seq` will contain one `CommentExpr` class instance for each line of the comment.

@barnjamin let me know what you think.