### PR TITLE
Static/Dynamic-Bytes Convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@
 
 * Static and Dynamic Byte Array convenience classes ([#500](https://github.com/algorand/pyteal/pull/500))
 
-## Fixed
-
-
-## Changed
-
 
 # 0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 ## Added
+
 * Add the ability to pass foreign reference arrays directly into inner transactions ([#384](https://github.com/algorand/pyteal/pull/384))
 * NamedTuple Implementation ([#473](https://github.com/algorand/pyteal/pull/473))
+* Static and Dynamic Byte Array convenience classes ([#500](https://github.com/algorand/pyteal/pull/500))
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Unreleased
 
+## Added
+
+* Static and Dynamic Byte Array convenience classes ([#500](https://github.com/algorand/pyteal/pull/500))
+
+## Fixed
+
+
+## Changed
+
+
 # 0.16.0
 
 ## Added
@@ -7,7 +17,6 @@
 * Add the ability to pass foreign reference arrays directly into inner transactions ([#384](https://github.com/algorand/pyteal/pull/384))
 
 * NamedTuple Implementation ([#473](https://github.com/algorand/pyteal/pull/473))
-* Static and Dynamic Byte Array convenience classes ([#500](https://github.com/algorand/pyteal/pull/500))
 
 * ExecuteMethodCall helper ([#501](https://github.com/algorand/pyteal/pull/501))
 

--- a/docs/abi.rst
+++ b/docs/abi.rst
@@ -208,7 +208,9 @@ PyTeal Type                                    ARC-4 Type             Dynamic / 
 :any:`abi.Byte`                                :code:`byte`           Static                              An 8-bit unsigned integer. This is an alias for :code:`abi.Uint8` that should be used to indicate non-numeric data, such as binary arrays.
 :any:`abi.StaticArray[T,N] <abi.StaticArray>`  :code:`T[N]`           Static when :code:`T` is static     A fixed-length array of :code:`T` with :code:`N` elements
 :any:`abi.Address`                             :code:`address`        Static                              A 32-byte Algorand address. This is an alias for :code:`abi.StaticArray[abi.Byte, Literal[32]]`.
+:any:`abi.StaticBytes[N] <abi.StaticBytes>`    :code:`byte[N]`        Static                              A fixed-length array with :code:`N` elements of :code:`abi.Byte`.
 :any:`abi.DynamicArray[T] <abi.DynamicArray>`  :code:`T[]`            Dynamic                             A variable-length array of :code:`T`
+:any:`abi.DynamicBytes`                        :code:`byte[]`         Dynamic                             A variable-length array of :code:`abi.Byte`.
 :any:`abi.String`                              :code:`string`         Dynamic                             A variable-length byte array assumed to contain UTF-8 encoded content. This is an alias for :code:`abi.DynamicArray[abi.Byte]`.
 :any:`abi.Tuple`\*, :any:`abi.NamedTuple`      :code:`(...)`          Static when all elements are static A tuple of multiple types
 ============================================== ====================== =================================== =======================================================================================================================================================
@@ -263,7 +265,9 @@ All basic types have a :code:`set()` method which can be used to assign a value.
 * :any:`abi.Bool.set(...) <abi.Bool.set>`
 * :any:`abi.StaticArray[T, N].set(...) <abi.StaticArray.set>`
 * :any:`abi.Address.set(...) <abi.Address.set>`
+* :any:`abi.StaticBytes[N].set(...) <abi.StaticBytes.set>`
 * :any:`abi.DynamicArray[T].set(...) <abi.DynamicArray.set>`
+* :any:`abi.DynamicBytes.set(...) <abi.DynamicBytes.set>`
 * :any:`abi.String.set(...) <abi.String.set>`
 * :any:`abi.Tuple.set(...) <abi.Tuple.set>`
 

--- a/pyteal/ast/abi/__init__.py
+++ b/pyteal/ast/abi/__init__.py
@@ -35,8 +35,12 @@ from pyteal.ast.abi.tuple import (
     Field,
 )
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
-from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray
-from pyteal.ast.abi.array_dynamic import DynamicArrayTypeSpec, DynamicArray
+from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray, StaticBytes
+from pyteal.ast.abi.array_dynamic import (
+    DynamicArrayTypeSpec,
+    DynamicArray,
+    DynamicBytes,
+)
 from pyteal.ast.abi.reference_type import (
     ReferenceTypeSpec,
     ReferenceType,
@@ -128,8 +132,10 @@ __all__ = [
     "ArrayElement",
     "StaticArrayTypeSpec",
     "StaticArray",
+    "StaticBytes",
     "DynamicArrayTypeSpec",
     "DynamicArray",
+    "DynamicBytes",
     "MethodReturn",
     "Transaction",
     "TransactionTypeSpec",

--- a/pyteal/ast/abi/array_dynamic.py
+++ b/pyteal/ast/abi/array_dynamic.py
@@ -1,16 +1,11 @@
-from typing import (
-    Union,
-    Sequence,
-    TypeVar,
-    cast,
-)
-
+from typing import Union, Sequence, TypeVar, cast
 
 from pyteal.errors import TealInputError
 from pyteal.ast.expr import Expr
 from pyteal.ast.seq import Seq
 
 from pyteal.ast.abi.type import ComputedValue, BaseType
+from pyteal.ast.bytes import Bytes
 from pyteal.ast.abi.uint import Uint16, Byte, ByteTypeSpec
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array
 
@@ -109,6 +104,28 @@ class DynamicBytes(DynamicArray[Byte]):
 
     def __init__(self) -> None:
         super().__init__(DynamicArrayTypeSpec(ByteTypeSpec()))
+
+    def set(
+        self,
+        values: Union[
+            bytes,
+            bytearray,
+            Expr,
+            Sequence[Byte],
+            DynamicArray[Byte],
+            ComputedValue[DynamicArray[Byte]],
+        ],
+    ) -> Expr:
+        # NOTE: the import here is to avoid importing in partial initialized module abi
+        from pyteal.ast.abi.string import _encoded_string
+
+        match values:
+            case bytes() | bytearray():
+                return self.stored_value.store(_encoded_string(Bytes(values)))
+            case Expr():
+                return self.stored_value.store(_encoded_string(values))
+
+        return super().set(values)
 
 
 DynamicBytes.__module__ = "pyteal.abi"

--- a/pyteal/ast/abi/array_dynamic.py
+++ b/pyteal/ast/abi/array_dynamic.py
@@ -11,7 +11,7 @@ from pyteal.ast.expr import Expr
 from pyteal.ast.seq import Seq
 
 from pyteal.ast.abi.type import ComputedValue, BaseType
-from pyteal.ast.abi.uint import Uint16
+from pyteal.ast.abi.uint import Uint16, Byte, ByteTypeSpec
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array
 
 
@@ -102,3 +102,13 @@ class DynamicArray(Array[T]):
 
 
 DynamicArray.__module__ = "pyteal.abi"
+
+
+class DynamicBytes(DynamicArray[Byte]):
+    """The convenience class that represents ABI static byte array."""
+
+    def __init__(self) -> None:
+        super().__init__(DynamicArrayTypeSpec(ByteTypeSpec()))
+
+
+DynamicBytes.__module__ = "pyteal.abi"

--- a/pyteal/ast/abi/array_dynamic.py
+++ b/pyteal/ast/abi/array_dynamic.py
@@ -100,7 +100,7 @@ DynamicArray.__module__ = "pyteal.abi"
 
 
 class DynamicBytes(DynamicArray[Byte]):
-    """The convenience class that represents ABI static byte array."""
+    """The convenience class that represents ABI dynamic byte array."""
 
     def __init__(self) -> None:
         super().__init__(DynamicArrayTypeSpec(ByteTypeSpec()))

--- a/pyteal/ast/abi/array_dynamic_test.py
+++ b/pyteal/ast/abi/array_dynamic_test.py
@@ -274,6 +274,28 @@ def test_DynamicBytes_set_expr(test_case: bytes | bytearray):
         assert actual == expected
 
 
+def test_DynamicBytes_get():
+    value = abi.DynamicBytes()
+
+    expr = value.get()
+    assert expr.type_of() == pt.TealType.bytes
+    assert not expr.has_return()
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = actual.NormalizeBlocks(actual)
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(None, pt.Op.load, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.extract, 2, 0),
+        ]
+    )
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+
 def test_DynamicArray_encode():
     dynamicArrayType = abi.DynamicArrayTypeSpec(abi.Uint64TypeSpec())
     value = dynamicArrayType.new_instance()

--- a/pyteal/ast/abi/array_dynamic_test.py
+++ b/pyteal/ast/abi/array_dynamic_test.py
@@ -204,7 +204,7 @@ def test_DynamicArray_set_computed():
 
 
 # AACS key recovery
-BYTE_HEX_TEST_CASE = "09F911029D74E35BD84156C5635688C0"
+BYTE_HEX_TEST_CASE = "09f911029d74e35bd84156c5635688c0"
 
 
 BYTES_SET_TESTCASES = [
@@ -227,11 +227,11 @@ def test_DynamicBytes_set_py_bytes(test_case: bytes | bytearray):
 
     expected = pt.TealSimpleBlock(
         [
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
             pt.TealOp(None, pt.Op.len),
             pt.TealOp(None, pt.Op.itob),
             pt.TealOp(None, pt.Op.extract, 6, 0),
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
             pt.TealOp(None, pt.Op.concat),
             pt.TealOp(None, pt.Op.store, value.stored_value.slot),
         ]
@@ -257,14 +257,14 @@ def test_DynamicBytes_set_expr(test_case: bytes | bytearray):
 
     expected = pt.TealSimpleBlock(
         [
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
             pt.TealOp(None, pt.Op.concat),
             pt.TealOp(None, pt.Op.len),
             pt.TealOp(None, pt.Op.itob),
             pt.TealOp(None, pt.Op.extract, 6, 0),
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
             pt.TealOp(None, pt.Op.concat),
             pt.TealOp(None, pt.Op.concat),
             pt.TealOp(None, pt.Op.store, value.stored_value.slot),

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -166,6 +166,23 @@ class StaticBytes(StaticArray[Byte, N], Generic[N]):
             ComputedValue[StaticArray[Byte, N]],
         ],
     ) -> Expr:
+        """Set the elements of this StaticBytes to the input values.
+
+        The behavior of this method depends on the input argument type:
+
+            * :code:`bytes`: set the value to the Python byte string.
+            * :code:`bytearray`: set the value to the Python byte array.
+            * :code:`Expr`: set the value to the result of a PyTeal expression, which must evaluate to a TealType.bytes.
+            * :code:`Sequence[Byte]`: set the bytes of this String to those contained in this Python sequence (e.g. a list or tuple).
+            * :code:`StaticArray[Byte, N]`: copy the bytes from another StaticArray. The argument's element type and length must exactly match Byte and this StaticBytes' length, otherwise an error will occur.
+            * :code:`ComputedValue[StaticArray[Byte, N]]`: copy the bytes from a StaticArray produced by a ComputedType. The argument's element type and length must exactly match Byte and this StaticBytes' length, otherwise an error will occur.
+
+        Args:
+            values: The new elements this StaticBytes should have. This must follow the above constraints.
+
+        Returns:
+            An expression which stores the given value into this StaticBytes.
+        """
         match values:
             case bytes() | bytearray():
                 if len(values) != self.type_spec().length_static():
@@ -180,6 +197,14 @@ class StaticBytes(StaticArray[Byte, N], Generic[N]):
                 )
 
         return super().set(values)
+
+    def get(self) -> Expr:
+        """Get the byte encoding of this StaticBytes.
+
+        Returns:
+            A Pyteal expression that loads byte encoding of this StaticBytes.
+        """
+        return self.stored_value.load()
 
 
 StaticBytes.__module__ = "pyteal.abi"

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -6,6 +6,7 @@ from pyteal.ast.int import Int
 
 from pyteal.ast.abi.type import ComputedValue, TypeSpec, BaseType
 from pyteal.ast.abi.bool import BoolTypeSpec, _bool_sequence_length
+from pyteal.ast.abi.uint import Byte, ByteTypeSpec
 from pyteal.ast.abi.array_base import ArrayTypeSpec, Array, ArrayElement
 
 
@@ -142,3 +143,13 @@ class StaticArray(Array[T], Generic[T, N]):
 
 
 StaticArray.__module__ = "pyteal.abi"
+
+
+class StaticBytes(StaticArray[Byte, N], Generic[N]):
+    """The convenience class that represents ABI static byte array."""
+
+    def __init__(self, static_len: N) -> None:
+        super().__init__(StaticArrayTypeSpec(ByteTypeSpec(), static_len))
+
+
+StaticBytes.__module__ = "pyteal.abi"

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -243,6 +243,73 @@ def test_StaticArray_set_computed():
         )
 
 
+# AACS key recovery
+BYTE_HEX_TEST_CASE = "09F911029D74E35BD84156C5635688C0"
+
+
+BYTES_SET_TESTCASES = [
+    bytes.fromhex(BYTE_HEX_TEST_CASE),
+    bytearray.fromhex(BYTE_HEX_TEST_CASE),
+]
+
+
+@pytest.mark.parametrize("test_case", BYTES_SET_TESTCASES)
+def test_StaticBytes_set_py_bytes(test_case: bytes | bytearray):
+    value = abi.StaticBytes(len(test_case))
+
+    expr = value.set(test_case)
+    assert expr.type_of() == pt.TealType.none
+    assert not expr.has_return()
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = actual.NormalizeBlocks(actual)
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
+        ]
+    )
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+    with pytest.raises(pt.TealInputError):
+        value.set(test_case[:-1])
+
+
+@pytest.mark.parametrize("test_case", BYTES_SET_TESTCASES)
+def test_StaticBytes_expr(test_case: bytes | bytearray):
+    value = abi.StaticBytes(len(test_case) * 2)
+    set_expr = pt.Concat(pt.Bytes(test_case), pt.Bytes(test_case))
+
+    expr = value.set(set_expr)
+    assert expr.type_of() == pt.TealType.none
+    assert not expr.has_return()
+
+    actual, _ = expr.__teal__(options)
+    actual.addIncoming()
+    actual = actual.NormalizeBlocks(actual)
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.concat),
+            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.int, 32),
+            pt.TealOp(None, pt.Op.load, value.stored_value.slot),
+            pt.TealOp(None, pt.Op.len),
+            pt.TealOp(None, pt.Op.eq),
+            pt.TealOp(None, pt.Op.assert_),
+        ]
+    )
+
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+
 def test_StaticArray_encode():
     value = abi.StaticArray(abi.StaticArrayTypeSpec(abi.Uint64TypeSpec(), 10))
     expr = value.encode()

--- a/pyteal/ast/abi/array_static_test.py
+++ b/pyteal/ast/abi/array_static_test.py
@@ -244,7 +244,7 @@ def test_StaticArray_set_computed():
 
 
 # AACS key recovery
-BYTE_HEX_TEST_CASE = "09F911029D74E35BD84156C5635688C0"
+BYTE_HEX_TEST_CASE = "09f911029d74e35bd84156c5635688c0"
 
 
 BYTES_SET_TESTCASES = [
@@ -267,7 +267,7 @@ def test_StaticBytes_set_py_bytes(test_case: bytes | bytearray):
 
     expected = pt.TealSimpleBlock(
         [
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
             pt.TealOp(None, pt.Op.store, value.stored_value.slot),
         ]
     )
@@ -294,8 +294,8 @@ def test_StaticBytes_expr(test_case: bytes | bytearray):
 
     expected = pt.TealSimpleBlock(
         [
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
-            pt.TealOp(None, pt.Op.byte, "0x" + pt.Bytes(test_case).byte_str),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
+            pt.TealOp(None, pt.Op.byte, "0x" + BYTE_HEX_TEST_CASE),
             pt.TealOp(None, pt.Op.concat),
             pt.TealOp(None, pt.Op.store, value.stored_value.slot),
             pt.TealOp(None, pt.Op.int, 32),

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -107,8 +107,16 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
         Uint64TypeSpec,
         Uint64,
     )
-    from pyteal.ast.abi.array_dynamic import DynamicArrayTypeSpec, DynamicArray
-    from pyteal.ast.abi.array_static import StaticArrayTypeSpec, StaticArray
+    from pyteal.ast.abi.array_dynamic import (
+        DynamicArrayTypeSpec,
+        DynamicArray,
+        DynamicBytes,
+    )
+    from pyteal.ast.abi.array_static import (
+        StaticArrayTypeSpec,
+        StaticArray,
+        StaticBytes,
+    )
     from pyteal.ast.abi.tuple import (
         TupleTypeSpec,
         Tuple,
@@ -209,6 +217,11 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
             raise TypeError("Address expects 0 arguments. Got: {}".format(args))
         return AddressTypeSpec()
 
+    if origin is DynamicBytes:
+        if len(args) != 0:
+            raise TypeError(f"DynamicBytes expect 0 type argument. Got: {args}")
+        return DynamicArrayTypeSpec(ByteTypeSpec())
+
     if origin is DynamicArray:
         if len(args) != 1:
             raise TypeError(
@@ -216,6 +229,12 @@ def type_spec_from_annotation(annotation: Any) -> TypeSpec:
             )
         value_type_spec = type_spec_from_annotation(args[0])
         return DynamicArrayTypeSpec(value_type_spec)
+
+    if origin is StaticBytes:
+        if len(args) != 1:
+            raise TypeError(f"StaticBytes expect 1 type argument. Got: {args}")
+        array_length = int_literal_from_annotation(args[0])
+        return StaticArrayTypeSpec(ByteTypeSpec(), array_length)
 
     if origin is StaticArray:
         if len(args) != 2:

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -275,6 +275,14 @@ def test_type_spec_from_annotation():
             annotation=List[abi.Uint16],
             expected=TypeError,
         ),
+        TypeAnnotationTest(
+            annotation=abi.StaticBytes[Literal[10]],
+            expected=abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 10),
+        ),
+        TypeAnnotationTest(
+            annotation=abi.DynamicBytes,
+            expected=abi.DynamicArrayTypeSpec(abi.ByteTypeSpec()),
+        ),
     ]
 
     for i, test in enumerate(tests):
@@ -332,6 +340,7 @@ def test_size_of():
         (abi.Uint8, 1),
         (abi.Address, 32),
         (abi.StaticArray[abi.Uint16, Literal[10]], 2 * 10),
+        (abi.StaticBytes[Literal[36]], 36),
     ]
 
     for (t, s) in values:
@@ -339,6 +348,9 @@ def test_size_of():
 
     with pytest.raises(TealInputError):
         abi.size_of(abi.String)
+
+    with pytest.raises(TealInputError):
+        abi.size_of(abi.DynamicBytes)
 
 
 ABI_TRANSLATION_TEST_CASES = [

--- a/tests/integration/abi_roundtrip_test.py
+++ b/tests/integration/abi_roundtrip_test.py
@@ -88,6 +88,7 @@ ABI_TYPES = [
     abi.StaticArray[abi.Bool, Literal[42]],
     abi.StaticArray[abi.Uint64, Literal[1]],
     abi.StaticArray[abi.Uint64, Literal[42]],
+    abi.StaticBytes[Literal[16]],
     (abi.DynamicArray[abi.Bool], 0),
     (abi.DynamicArray[abi.Bool], 1),
     (abi.DynamicArray[abi.Bool], 42),
@@ -95,6 +96,7 @@ ABI_TYPES = [
     (abi.DynamicArray[abi.Uint64], 1),
     (abi.DynamicArray[abi.Uint64], 42),
     (abi.DynamicArray[abi.Address], 10),
+    (abi.DynamicBytes, 36),
     (abi.DynamicArray[abi.StaticArray[abi.Bool, Literal[3]]], 11),
     abi.StaticArray[abi.Tuple1[abi.Bool], Literal[10]],
     (

--- a/tests/integration/teal/roundtrip/app_roundtrip_byte[16].teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_byte[16].teal
@@ -1,0 +1,274 @@
+#pragma version 6
+txna ApplicationArgs 0
+store 1
+load 1
+callsub roundtripper_2
+store 0
+byte 0x151f7c75
+load 0
+concat
+log
+int 1
+return
+
+// numerical_comp
+numericalcomp_0:
+store 24
+int 255
+load 24
+-
+store 25
+load 25
+int 256
+<
+assert
+load 25
+retsub
+
+// array_complement
+arraycomplement_1:
+store 6
+load 6
+int 1
+int 0
+*
+getbyte
+store 8
+load 6
+int 1
+int 1
+*
+getbyte
+store 9
+load 6
+int 1
+int 2
+*
+getbyte
+store 10
+load 6
+int 1
+int 3
+*
+getbyte
+store 11
+load 6
+int 1
+int 4
+*
+getbyte
+store 12
+load 6
+int 1
+int 5
+*
+getbyte
+store 13
+load 6
+int 1
+int 6
+*
+getbyte
+store 14
+load 6
+int 1
+int 7
+*
+getbyte
+store 15
+load 6
+int 1
+int 8
+*
+getbyte
+store 16
+load 6
+int 1
+int 9
+*
+getbyte
+store 17
+load 6
+int 1
+int 10
+*
+getbyte
+store 18
+load 6
+int 1
+int 11
+*
+getbyte
+store 19
+load 6
+int 1
+int 12
+*
+getbyte
+store 20
+load 6
+int 1
+int 13
+*
+getbyte
+store 21
+load 6
+int 1
+int 14
+*
+getbyte
+store 22
+load 6
+int 1
+int 15
+*
+getbyte
+store 23
+load 8
+callsub numericalcomp_0
+store 8
+load 9
+callsub numericalcomp_0
+store 9
+load 10
+callsub numericalcomp_0
+store 10
+load 11
+callsub numericalcomp_0
+store 11
+load 12
+callsub numericalcomp_0
+store 12
+load 13
+callsub numericalcomp_0
+store 13
+load 14
+callsub numericalcomp_0
+store 14
+load 15
+callsub numericalcomp_0
+store 15
+load 16
+callsub numericalcomp_0
+store 16
+load 17
+callsub numericalcomp_0
+store 17
+load 18
+callsub numericalcomp_0
+store 18
+load 19
+callsub numericalcomp_0
+store 19
+load 20
+callsub numericalcomp_0
+store 20
+load 21
+callsub numericalcomp_0
+store 21
+load 22
+callsub numericalcomp_0
+store 22
+load 23
+callsub numericalcomp_0
+store 23
+byte 0x00
+int 0
+load 8
+setbyte
+byte 0x00
+int 0
+load 9
+setbyte
+concat
+byte 0x00
+int 0
+load 10
+setbyte
+concat
+byte 0x00
+int 0
+load 11
+setbyte
+concat
+byte 0x00
+int 0
+load 12
+setbyte
+concat
+byte 0x00
+int 0
+load 13
+setbyte
+concat
+byte 0x00
+int 0
+load 14
+setbyte
+concat
+byte 0x00
+int 0
+load 15
+setbyte
+concat
+byte 0x00
+int 0
+load 16
+setbyte
+concat
+byte 0x00
+int 0
+load 17
+setbyte
+concat
+byte 0x00
+int 0
+load 18
+setbyte
+concat
+byte 0x00
+int 0
+load 19
+setbyte
+concat
+byte 0x00
+int 0
+load 20
+setbyte
+concat
+byte 0x00
+int 0
+load 21
+setbyte
+concat
+byte 0x00
+int 0
+load 22
+setbyte
+concat
+byte 0x00
+int 0
+load 23
+setbyte
+concat
+store 7
+load 7
+retsub
+
+// round_tripper
+roundtripper_2:
+store 2
+load 2
+callsub arraycomplement_1
+store 4
+load 4
+callsub arraycomplement_1
+store 5
+load 2
+load 4
+concat
+load 5
+concat
+store 3
+load 3
+retsub

--- a/tests/integration/teal/roundtrip/app_roundtrip_byte[]_36.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_byte[]_36.teal
@@ -1,0 +1,680 @@
+#pragma version 6
+txna ApplicationArgs 0
+store 1
+load 1
+callsub roundtripper_2
+store 0
+byte 0x151f7c75
+load 0
+concat
+log
+int 1
+return
+
+// numerical_comp
+numericalcomp_0:
+store 44
+int 255
+load 44
+-
+store 45
+load 45
+int 256
+<
+assert
+load 45
+retsub
+
+// array_complement
+arraycomplement_1:
+store 6
+load 6
+int 1
+int 0
+*
+int 2
++
+getbyte
+store 8
+load 6
+int 1
+int 1
+*
+int 2
++
+getbyte
+store 9
+load 6
+int 1
+int 2
+*
+int 2
++
+getbyte
+store 10
+load 6
+int 1
+int 3
+*
+int 2
++
+getbyte
+store 11
+load 6
+int 1
+int 4
+*
+int 2
++
+getbyte
+store 12
+load 6
+int 1
+int 5
+*
+int 2
++
+getbyte
+store 13
+load 6
+int 1
+int 6
+*
+int 2
++
+getbyte
+store 14
+load 6
+int 1
+int 7
+*
+int 2
++
+getbyte
+store 15
+load 6
+int 1
+int 8
+*
+int 2
++
+getbyte
+store 16
+load 6
+int 1
+int 9
+*
+int 2
++
+getbyte
+store 17
+load 6
+int 1
+int 10
+*
+int 2
++
+getbyte
+store 18
+load 6
+int 1
+int 11
+*
+int 2
++
+getbyte
+store 19
+load 6
+int 1
+int 12
+*
+int 2
++
+getbyte
+store 20
+load 6
+int 1
+int 13
+*
+int 2
++
+getbyte
+store 21
+load 6
+int 1
+int 14
+*
+int 2
++
+getbyte
+store 22
+load 6
+int 1
+int 15
+*
+int 2
++
+getbyte
+store 23
+load 6
+int 1
+int 16
+*
+int 2
++
+getbyte
+store 24
+load 6
+int 1
+int 17
+*
+int 2
++
+getbyte
+store 25
+load 6
+int 1
+int 18
+*
+int 2
++
+getbyte
+store 26
+load 6
+int 1
+int 19
+*
+int 2
++
+getbyte
+store 27
+load 6
+int 1
+int 20
+*
+int 2
++
+getbyte
+store 28
+load 6
+int 1
+int 21
+*
+int 2
++
+getbyte
+store 29
+load 6
+int 1
+int 22
+*
+int 2
++
+getbyte
+store 30
+load 6
+int 1
+int 23
+*
+int 2
++
+getbyte
+store 31
+load 6
+int 1
+int 24
+*
+int 2
++
+getbyte
+store 32
+load 6
+int 1
+int 25
+*
+int 2
++
+getbyte
+store 33
+load 6
+int 1
+int 26
+*
+int 2
++
+getbyte
+store 34
+load 6
+int 1
+int 27
+*
+int 2
++
+getbyte
+store 35
+load 6
+int 1
+int 28
+*
+int 2
++
+getbyte
+store 36
+load 6
+int 1
+int 29
+*
+int 2
++
+getbyte
+store 37
+load 6
+int 1
+int 30
+*
+int 2
++
+getbyte
+store 38
+load 6
+int 1
+int 31
+*
+int 2
++
+getbyte
+store 39
+load 6
+int 1
+int 32
+*
+int 2
++
+getbyte
+store 40
+load 6
+int 1
+int 33
+*
+int 2
++
+getbyte
+store 41
+load 6
+int 1
+int 34
+*
+int 2
++
+getbyte
+store 42
+load 6
+int 1
+int 35
+*
+int 2
++
+getbyte
+store 43
+load 8
+callsub numericalcomp_0
+store 8
+load 9
+callsub numericalcomp_0
+store 9
+load 10
+callsub numericalcomp_0
+store 10
+load 11
+callsub numericalcomp_0
+store 11
+load 12
+callsub numericalcomp_0
+store 12
+load 13
+callsub numericalcomp_0
+store 13
+load 14
+callsub numericalcomp_0
+store 14
+load 15
+callsub numericalcomp_0
+store 15
+load 16
+callsub numericalcomp_0
+store 16
+load 17
+callsub numericalcomp_0
+store 17
+load 18
+callsub numericalcomp_0
+store 18
+load 19
+callsub numericalcomp_0
+store 19
+load 20
+callsub numericalcomp_0
+store 20
+load 21
+callsub numericalcomp_0
+store 21
+load 22
+callsub numericalcomp_0
+store 22
+load 23
+callsub numericalcomp_0
+store 23
+load 24
+callsub numericalcomp_0
+store 24
+load 25
+callsub numericalcomp_0
+store 25
+load 26
+callsub numericalcomp_0
+store 26
+load 27
+callsub numericalcomp_0
+store 27
+load 28
+callsub numericalcomp_0
+store 28
+load 29
+callsub numericalcomp_0
+store 29
+load 30
+callsub numericalcomp_0
+store 30
+load 31
+callsub numericalcomp_0
+store 31
+load 32
+callsub numericalcomp_0
+store 32
+load 33
+callsub numericalcomp_0
+store 33
+load 34
+callsub numericalcomp_0
+store 34
+load 35
+callsub numericalcomp_0
+store 35
+load 36
+callsub numericalcomp_0
+store 36
+load 37
+callsub numericalcomp_0
+store 37
+load 38
+callsub numericalcomp_0
+store 38
+load 39
+callsub numericalcomp_0
+store 39
+load 40
+callsub numericalcomp_0
+store 40
+load 41
+callsub numericalcomp_0
+store 41
+load 42
+callsub numericalcomp_0
+store 42
+load 43
+callsub numericalcomp_0
+store 43
+int 36
+store 46
+load 46
+itob
+extract 6 0
+byte 0x00
+int 0
+load 8
+setbyte
+byte 0x00
+int 0
+load 9
+setbyte
+concat
+byte 0x00
+int 0
+load 10
+setbyte
+concat
+byte 0x00
+int 0
+load 11
+setbyte
+concat
+byte 0x00
+int 0
+load 12
+setbyte
+concat
+byte 0x00
+int 0
+load 13
+setbyte
+concat
+byte 0x00
+int 0
+load 14
+setbyte
+concat
+byte 0x00
+int 0
+load 15
+setbyte
+concat
+byte 0x00
+int 0
+load 16
+setbyte
+concat
+byte 0x00
+int 0
+load 17
+setbyte
+concat
+byte 0x00
+int 0
+load 18
+setbyte
+concat
+byte 0x00
+int 0
+load 19
+setbyte
+concat
+byte 0x00
+int 0
+load 20
+setbyte
+concat
+byte 0x00
+int 0
+load 21
+setbyte
+concat
+byte 0x00
+int 0
+load 22
+setbyte
+concat
+byte 0x00
+int 0
+load 23
+setbyte
+concat
+byte 0x00
+int 0
+load 24
+setbyte
+concat
+byte 0x00
+int 0
+load 25
+setbyte
+concat
+byte 0x00
+int 0
+load 26
+setbyte
+concat
+byte 0x00
+int 0
+load 27
+setbyte
+concat
+byte 0x00
+int 0
+load 28
+setbyte
+concat
+byte 0x00
+int 0
+load 29
+setbyte
+concat
+byte 0x00
+int 0
+load 30
+setbyte
+concat
+byte 0x00
+int 0
+load 31
+setbyte
+concat
+byte 0x00
+int 0
+load 32
+setbyte
+concat
+byte 0x00
+int 0
+load 33
+setbyte
+concat
+byte 0x00
+int 0
+load 34
+setbyte
+concat
+byte 0x00
+int 0
+load 35
+setbyte
+concat
+byte 0x00
+int 0
+load 36
+setbyte
+concat
+byte 0x00
+int 0
+load 37
+setbyte
+concat
+byte 0x00
+int 0
+load 38
+setbyte
+concat
+byte 0x00
+int 0
+load 39
+setbyte
+concat
+byte 0x00
+int 0
+load 40
+setbyte
+concat
+byte 0x00
+int 0
+load 41
+setbyte
+concat
+byte 0x00
+int 0
+load 42
+setbyte
+concat
+byte 0x00
+int 0
+load 43
+setbyte
+concat
+concat
+store 7
+load 7
+retsub
+
+// round_tripper
+roundtripper_2:
+store 2
+load 2
+callsub arraycomplement_1
+store 4
+load 4
+callsub arraycomplement_1
+store 5
+load 2
+store 50
+load 50
+store 49
+int 6
+store 47
+load 47
+load 50
+len
++
+store 48
+load 48
+int 65536
+<
+assert
+load 47
+itob
+extract 6 0
+load 4
+store 50
+load 49
+load 50
+concat
+store 49
+load 48
+store 47
+load 47
+load 50
+len
++
+store 48
+load 48
+int 65536
+<
+assert
+load 47
+itob
+extract 6 0
+concat
+load 5
+store 50
+load 49
+load 50
+concat
+store 49
+load 48
+store 47
+load 47
+itob
+extract 6 0
+concat
+load 49
+concat
+store 3
+load 3
+retsub


### PR DESCRIPTION
Per #498 issue, we created a pair of helper classes `StaticBytes` and `DynamicBytes` in `abi`, and hopefully the implementation resolves #495 too.

~~Some TODOs down the road: make `set` method easier to use by accepting `bytes`/`bytearray` and `pyteal.bytes`.~~