### PR TITLE
Concat bytes by using the + operator

### DIFF
--- a/pyteal/ast/expr.py
+++ b/pyteal/ast/expr.py
@@ -70,8 +70,11 @@ class Expr(ABC):
         return Neq(self, other)
 
     def __add__(self, other):
-        from pyteal.ast.naryexpr import Add
+        if self.type_of() == TealType.bytes:
+            from pyteal.ast.naryexpr import Concat
+            return Concat(self, other)
 
+        from pyteal.ast.naryexpr import Add
         return Add(self, other)
 
     def __sub__(self, other):


### PR DESCRIPTION
In Python, users can use the + operator to both add numbers and concatenate strings. Instead of having to write:

`
Concat(Bytes("Hello, "), Bytes("World!"))
`

You can instead write:

`
Bytes("Hello, ") + Bytes("World!")
`