### PR TITLE
Update `Block` docs to match spec change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * CI: Fail readthedocs build on warning ([#478](https://github.com/algorand/pyteal/pull/478))
 
 ## Changed
+* Update `Block` docs to match spec change ([#503](https://github.com/algorand/pyteal/pull/503))
 
 # 0.15.0
 ## Added

--- a/pyteal/ast/block.py
+++ b/pyteal/ast/block.py
@@ -60,8 +60,8 @@ class Block(LeafExpr):
 
         Args:
             block: A block index that corresponds to the block to check,
-                must be evaluated to uint64. Fails if the block index is not less than the
-                current round or more than 1001 rounds before txn.LastValid.
+                must be evaluated to uint64. Fails if the block index is not less than
+                :code:`Txn.first_valid()` or more than 1001 rounds before :code:`Txn.last_valid()`.
         """
         return cls(BlockField.block_seed, block)
 
@@ -71,8 +71,8 @@ class Block(LeafExpr):
 
         Args:
             block: A block index that corresponds to the block to check,
-                must be evaluated to uint64. Fails if the block index is not less than the
-                current round or more than 1001 rounds before txn.LastValid.
+                must be evaluated to uint64. Fails if the block index is not less than
+                :code:`Txn.first_valid()` or more than 1001 rounds before :code:`Txn.last_valid()`.
         """
         return cls(BlockField.block_timestamp, block)
 


### PR DESCRIPTION
Update `Block` docs to match the recent spec change of the `block` opcode: https://github.com/algorandfoundation/specs/pull/71