### PR TITLE
trying assert in commented expression

### DIFF
--- a/examples/application/assert_comment.py
+++ b/examples/application/assert_comment.py
@@ -20,7 +20,7 @@ def tst_subr():
 program = Seq(
     Comment(
         """
-    
+
     Dope program section here
 
     """

--- a/examples/application/assert_comment.py
+++ b/examples/application/assert_comment.py
@@ -1,0 +1,19 @@
+from pyteal import *
+
+
+@Subroutine(TealType.uint64)
+def tst_subr():
+    return Seq(Assert((Int(0), "newp")), Int(1))
+
+
+program = Seq(
+    # Make this be
+    Assert((Int(1), "ok")),
+    # On different
+    Assert((Int(1), "no way"), (Int(1), "wow")),
+    # lines
+    tst_subr(),
+)
+
+
+print(compileTeal(program, mode=Mode.Application, version=7, debug=True))

--- a/examples/application/assert_comment.py
+++ b/examples/application/assert_comment.py
@@ -27,7 +27,7 @@ program = Seq(
     ),
     Comment("popper", Pop(Int(1))),
     # Make this be
-    Comment("ok", Assert(Int(1))),
+    Assert((Int(1), "ok")),
     # On different
     Assert((Int(1), "no way"), (Int(1), "wow")),
     # lines

--- a/examples/application/assert_comment.py
+++ b/examples/application/assert_comment.py
@@ -1,4 +1,4 @@
-from pyteal import *
+from pyteal import Seq, Subroutine, TealType, Assert, Int, compileTeal, Mode
 
 
 @Subroutine(TealType.uint64)
@@ -16,4 +16,4 @@ program = Seq(
 )
 
 
-print(compileTeal(program, mode=Mode.Application, version=7, debug=True))
+print(compileTeal(program, mode=Mode.Application, version=7, debug=False))

--- a/examples/application/assert_comment.py
+++ b/examples/application/assert_comment.py
@@ -1,14 +1,33 @@
-from pyteal import Seq, Subroutine, TealType, Assert, Int, compileTeal, Mode
+from pyteal import (
+    Seq,
+    Subroutine,
+    TealType,
+    Assert,
+    Int,
+    compileTeal,
+    Mode,
+    Comment,
+    Pop,
+)
 
 
 @Subroutine(TealType.uint64)
 def tst_subr():
+    """Subroutine commented here"""
     return Seq(Assert((Int(0), "newp")), Int(1))
 
 
 program = Seq(
+    Comment(
+        """
+    
+    Dope program section here
+
+    """
+    ),
+    Comment("popper", Pop(Int(1))),
     # Make this be
-    Assert((Int(1), "ok")),
+    Comment("ok", Assert(Int(1))),
     # On different
     Assert((Int(1), "no way"), (Int(1), "wow")),
     # lines

--- a/pyteal/__init__.pyi
+++ b/pyteal/__init__.pyi
@@ -82,6 +82,7 @@ __all__ = [
     "BytesXor",
     "BytesZero",
     "CallConfig",
+    "Comment",
     "CompileOptions",
     "Concat",
     "Cond",

--- a/pyteal/ast/__init__.py
+++ b/pyteal/ast/__init__.py
@@ -42,6 +42,7 @@ from pyteal.ast.array import Array
 from pyteal.ast.tmpl import Tmpl
 from pyteal.ast.nonce import Nonce
 from pyteal.ast.pragma import Pragma
+from pyteal.ast.comment import Comment
 
 # unary ops
 from pyteal.ast.unaryexpr import (
@@ -216,6 +217,7 @@ __all__ = [
     "Tmpl",
     "Nonce",
     "Pragma",
+    "Comment",
     "UnaryExpr",
     "Btoi",
     "Itob",

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional, cast
 from pyteal.types import TealType, require_type
 from pyteal.ir import TealOp, Op, TealBlock, TealSimpleBlock, TealConditionalBlock
 from pyteal.ast.expr import Expr
+from pyteal.ast.comment import Comment
 from pyteal.ast.seq import Seq
 
 if TYPE_CHECKING:
@@ -56,8 +57,10 @@ class Assert(Expr):
         if len(self.cond) > 1:
             asserts = []
             for idx, cond in enumerate(self.cond):
-                a = Assert((cond, self.comments[idx]))
+                a = Assert(cond)
                 a.trace = cond.trace
+                if self.comments[idx] is not None:
+                    a = cast(Assert, Comment(cast(str, self.comments[idx]), a))
                 asserts.append(a)
 
             return Seq(*asserts).__teal__(options)

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -48,14 +48,17 @@ class Assert(Expr):
             require_type(cond_single, TealType.uint64)
             extra_conds.append(cond_single)
 
-        self.cond = [cond] + list(extra_conds)
-        self.comments = comments
+        self.cond: list[Expr] = [cond] + list(extra_conds)
+        self.comments: list[str] = comments
 
     def __teal__(self, options: "CompileOptions"):
         if len(self.cond) > 1:
-            asserts = [
-                Assert((cond, self.comments[idx])) for idx, cond in enumerate(self.cond)
-            ]
+            asserts = []
+            for idx, cond in enumerate(self.cond):
+                a = Assert((cond, self.comments[idx]))
+                a.trace = cond.trace
+                asserts.append(a)
+
             return Seq(*asserts).__teal__(options)
 
         if options.version >= Op.assert_.min_version:

--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -35,6 +35,7 @@ class Assert(Expr):
 
             self.comment = comment
         else:
+            self.cond.append(cast(Expr, cond))
             # Keep matching indicies for expr/comment
             self.comments.append(None)
 

--- a/pyteal/ast/comment.py
+++ b/pyteal/ast/comment.py
@@ -24,6 +24,7 @@ class CommentExpr(Expr):
             raise TealInputError(
                 "Newlines should not be present in the CommentExpr constructor"
             )
+        # Purposely dont use `comment` since its used by the assembler
         self.comment_string = single_line_comment
 
     def __teal__(self, options: "CompileOptions") -> Tuple[TealBlock, TealSimpleBlock]:

--- a/pyteal/ast/comment.py
+++ b/pyteal/ast/comment.py
@@ -1,0 +1,63 @@
+from typing import TYPE_CHECKING, Tuple
+
+from pyteal.errors import TealInputError
+from pyteal.types import TealType
+from pyteal.ir import TealBlock, TealSimpleBlock, TealOp, Op
+from pyteal.ast.expr import Expr
+from pyteal.ast.seq import Seq
+
+if TYPE_CHECKING:
+    from pyteal.compiler import CompileOptions
+
+
+class CommentExpr(Expr):
+    """Represents a single line comment in TEAL source code.
+
+    This class is intentionally hidden because it's too basic to directly expose. Anything exposed
+    to users should be able to handle multi-line comments by breaking them apart and using this
+    class.
+    """
+
+    def __init__(self, single_line_comment: str) -> None:
+        super().__init__()
+        if "\n" in single_line_comment or "\r" in single_line_comment:
+            raise TealInputError(
+                "Newlines should not be present in the CommentExpr constructor"
+            )
+        self.comment = single_line_comment
+
+    def __teal__(self, options: "CompileOptions") -> Tuple[TealBlock, TealSimpleBlock]:
+        op = TealOp(self, Op.comment, self.comment)
+        return TealBlock.FromOp(options, op)
+
+    def __str__(self):
+        return f'(Comment "{self.comment}")'
+
+    def type_of(self):
+        return TealType.none
+
+    def has_return(self):
+        return False
+
+
+CommentExpr.__module__ = "pyteal"
+
+
+def Comment(expr: Expr, comment: str) -> Expr:
+    """Wrap an existing expression with a comment.
+
+    This comment will be present in the compiled TEAL source immediately before the first op of the
+    expression.
+
+    Note that when TEAL source is assembled into bytes, all comments are omitted.
+
+    Args:
+        expr: The expression to be commented.
+        comment: The comment that will be associated with the expression.
+
+    Returns:
+        A new expression which is functionally equivalent to the input expression, but which will
+        compile with the given comment string.
+    """
+    lines = comment.splitlines()
+    return Seq(*[CommentExpr(line) for line in lines], expr)

--- a/pyteal/ast/comment.py
+++ b/pyteal/ast/comment.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Tuple, Optional
 
 from pyteal.errors import TealInputError
 from pyteal.types import TealType
@@ -24,10 +24,10 @@ class CommentExpr(Expr):
             raise TealInputError(
                 "Newlines should not be present in the CommentExpr constructor"
             )
-        self.comment = single_line_comment
+        self.comment_string = single_line_comment
 
     def __teal__(self, options: "CompileOptions") -> Tuple[TealBlock, TealSimpleBlock]:
-        op = TealOp(self, Op.comment, self.comment)
+        op = TealOp(self, Op.comment, self.comment_string)
         return TealBlock.FromOp(options, op)
 
     def __str__(self):
@@ -43,7 +43,7 @@ class CommentExpr(Expr):
 CommentExpr.__module__ = "pyteal"
 
 
-def Comment(expr: Expr, comment: str) -> Expr:
+def Comment(comment: str, expr: Optional[Expr] = None) -> Expr:
     """Wrap an existing expression with a comment.
 
     This comment will be present in the compiled TEAL source immediately before the first op of the
@@ -59,5 +59,7 @@ def Comment(expr: Expr, comment: str) -> Expr:
         A new expression which is functionally equivalent to the input expression, but which will
         compile with the given comment string.
     """
-    lines = comment.splitlines()
-    return Seq(*[CommentExpr(line) for line in lines], expr)
+    if expr is not None:
+        expr.comment = comment
+        return expr
+    return Seq(*[CommentExpr(comment) for comment in comment.splitlines()])

--- a/pyteal/ast/comment_test.py
+++ b/pyteal/ast/comment_test.py
@@ -9,7 +9,7 @@ options = pt.CompileOptions()
 def test_CommentExpr():
     for comment in ("", "hello world", " // a b c //    \t . "):
         expr = CommentExpr(comment)
-        assert expr.comment == comment
+        assert expr.comment_string == comment
         assert expr.type_of() == pt.TealType.none
         assert expr.has_return() is False
 
@@ -36,32 +36,57 @@ def test_CommentExpr():
 def test_Comment_empty():
     to_wrap = pt.Int(1)
     comment = ""
-    expr = pt.Comment(to_wrap, comment)
-    assert type(expr) is pt.Seq
-    assert len(expr.args) == 1
+    expr = pt.Comment(comment, to_wrap)
+    assert type(expr) is pt.Int
 
-    assert expr.args[0] is to_wrap
+    assert expr is to_wrap
 
 
 def test_Comment_single_line():
     to_wrap = pt.Int(1)
     comment = "just an int"
-    expr = pt.Comment(to_wrap, comment)
-    assert type(expr) is pt.Seq
-    assert len(expr.args) == 2
+    expr = pt.Comment(comment, to_wrap)
+    assert type(expr) is pt.Int
 
-    assert type(expr.args[0]) is CommentExpr
-    assert expr.args[0].comment == comment
-
-    assert expr.args[1] is to_wrap
+    assert expr is to_wrap
 
     version = 6
     expected_teal = f"""#pragma version {version}
-// {comment}
-int 1
+int 1 // cmt;{comment}
 return"""
     actual_teal = pt.compileTeal(
         pt.Return(expr), version=version, mode=pt.Mode.Application
+    )
+    assert actual_teal == expected_teal
+
+
+def test_Comment_only():
+    comment = """
+    Sick section to follow
+    dragons abound
+    dont touch unless you want to break everything"""
+
+    comment_parts = [
+        "",
+        "Sick section to follow",
+        "dragons abound",
+        "dont touch unless you want to break everything",
+    ]
+
+    expr = pt.Comment(comment)
+    assert type(expr) is pt.Seq
+    assert len(expr.args) == len(comment_parts)
+
+    version = 6
+    expected_teal = f"""#pragma version {version}
+// 
+//     Sick section to follow
+//     dragons abound
+//     dont touch unless you want to break everything
+int 1
+return"""
+    actual_teal = pt.compileTeal(
+        pt.Return(pt.Seq(expr, pt.Int(1))), mode=pt.Mode.Application, version=version
     )
     assert actual_teal == expected_teal
 
@@ -81,27 +106,18 @@ since it has no fractional part. You might also say this run on comment has gone
         "since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details ",
     ]
 
-    expr = pt.Comment(to_wrap, comment)
-    assert type(expr) is pt.Seq
-    assert len(expr.args) == 5
-
-    for i, part in enumerate(comment_parts):
-        arg = expr.args[i]
-        assert type(arg) is CommentExpr
-        assert arg.comment == part
-
-    assert expr.args[4] is to_wrap
+    expr = pt.Comment(comment, to_wrap)
+    assert type(expr) is pt.Int
+    assert expr.comment == comment
 
     version = 6
     expected_teal = f"""#pragma version {version}
-// just an int
+int 1 // cmt;just an int
 // but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? 
 // You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`
 // since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details 
-int 1
 return"""
     actual_teal = pt.compileTeal(
         pt.Return(expr), version=version, mode=pt.Mode.Application
     )
-    print(actual_teal)
     assert actual_teal == expected_teal

--- a/pyteal/ast/comment_test.py
+++ b/pyteal/ast/comment_test.py
@@ -1,0 +1,107 @@
+import pytest
+
+import pyteal as pt
+from pyteal.ast.comment import CommentExpr
+
+options = pt.CompileOptions()
+
+
+def test_CommentExpr():
+    for comment in ("", "hello world", " // a b c //    \t . "):
+        expr = CommentExpr(comment)
+        assert expr.comment == comment
+        assert expr.type_of() == pt.TealType.none
+        assert expr.has_return() is False
+
+        expected = pt.TealSimpleBlock(
+            [
+                pt.TealOp(expr, pt.Op.comment, comment),
+            ]
+        )
+
+        actual, _ = expr.__teal__(options)
+        actual.addIncoming()
+        actual = pt.TealBlock.NormalizeBlocks(actual)
+
+        assert actual == expected
+
+    for newline in ("\n", "\r\n", "\r"):
+        with pytest.raises(
+            pt.TealInputError,
+            match=r"Newlines should not be present in the CommentExpr constructor$",
+        ):
+            CommentExpr(f"one line{newline}two lines")
+
+
+def test_Comment_empty():
+    to_wrap = pt.Int(1)
+    comment = ""
+    expr = pt.Comment(to_wrap, comment)
+    assert type(expr) is pt.Seq
+    assert len(expr.args) == 1
+
+    assert expr.args[0] is to_wrap
+
+
+def test_Comment_single_line():
+    to_wrap = pt.Int(1)
+    comment = "just an int"
+    expr = pt.Comment(to_wrap, comment)
+    assert type(expr) is pt.Seq
+    assert len(expr.args) == 2
+
+    assert type(expr.args[0]) is CommentExpr
+    assert expr.args[0].comment == comment
+
+    assert expr.args[1] is to_wrap
+
+    version = 6
+    expected_teal = f"""#pragma version {version}
+// {comment}
+int 1
+return"""
+    actual_teal = pt.compileTeal(
+        pt.Return(expr), version=version, mode=pt.Mode.Application
+    )
+    assert actual_teal == expected_teal
+
+
+def test_Comment_multi_line():
+    to_wrap = pt.Int(1)
+    comment = """just an int
+but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? 
+You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`
+since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details 
+"""
+
+    comment_parts = [
+        "just an int",
+        "but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? ",
+        "You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`",
+        "since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details ",
+    ]
+
+    expr = pt.Comment(to_wrap, comment)
+    assert type(expr) is pt.Seq
+    assert len(expr.args) == 5
+
+    for i, part in enumerate(comment_parts):
+        arg = expr.args[i]
+        assert type(arg) is CommentExpr
+        assert arg.comment == part
+
+    assert expr.args[4] is to_wrap
+
+    version = 6
+    expected_teal = f"""#pragma version {version}
+// just an int
+// but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? 
+// You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`
+// since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details 
+int 1
+return"""
+    actual_teal = pt.compileTeal(
+        pt.Return(expr), version=version, mode=pt.Mode.Application
+    )
+    print(actual_teal)
+    assert actual_teal == expected_teal

--- a/pyteal/ast/comment_test.py
+++ b/pyteal/ast/comment_test.py
@@ -52,7 +52,7 @@ def test_Comment_single_line():
 
     version = 6
     expected_teal = f"""#pragma version {version}
-int 1 // cmt;{comment}
+int 1 // {comment}
 return"""
     actual_teal = pt.compileTeal(
         pt.Return(expr), version=version, mode=pt.Mode.Application
@@ -99,20 +99,13 @@ You might say its a 64 bit representation of an element of the set Z and comes f
 since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details 
 """
 
-    comment_parts = [
-        "just an int",
-        "but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? ",
-        "You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`",
-        "since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details ",
-    ]
-
     expr = pt.Comment(comment, to_wrap)
     assert type(expr) is pt.Int
     assert expr.comment == comment
 
     version = 6
     expected_teal = f"""#pragma version {version}
-int 1 // cmt;just an int
+int 1 // just an int
 // but its really more than that isnt it? an integer here is a uint64 stack type but looking further what does that mean? 
 // You might say its a 64 bit representation of an element of the set Z and comes from the latin `integer` meaning `whole`
 // since it has no fractional part. You might also say this run on comment has gone too far. See https://en.wikipedia.org/wiki/Integer for more details 

--- a/pyteal/ast/expr.py
+++ b/pyteal/ast/expr.py
@@ -11,10 +11,11 @@ if TYPE_CHECKING:
 class Expr(ABC):
     """Abstract base class for PyTeal expressions."""
 
-    def __init__(self):
+    def __init__(self, comment: str = None):
         import traceback
 
         self.trace = traceback.format_stack()[0:-1]
+        self.comment = comment
 
     def getDefinitionTrace(self) -> List[str]:
         return self.trace

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -291,9 +291,10 @@ class SubroutineDefinition:
             self, args, output_kwarg=OutputKwArgInfo.from_dict(self.output_kwarg)
         )
 
-        decl = self.get_declaration()
-        if decl is not None and decl.trace is not None:
-            sc.trace = decl.trace
+        # TODO: this triggers infinite recursion?
+        # decl = self.get_declaration()
+        # if decl is not None and decl.trace is not None:
+        #    sc.trace = decl.trace
 
         return sc
 

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -287,9 +287,15 @@ class SubroutineDefinition:
                         f"should have ABI typespec {arg_type} but got {arg.type_spec()}"
                     )
 
-        return SubroutineCall(
+        sc = SubroutineCall(
             self, args, output_kwarg=OutputKwArgInfo.from_dict(self.output_kwarg)
         )
+
+        decl = self.get_declaration()
+        if decl is not None and decl.trace is not None:
+            sc.trace = decl.trace
+
+        return sc
 
     def __str__(self):
         return f"subroutine#{self.id}"

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -45,6 +45,7 @@ class CompileOptions:
         mode: Mode = Mode.Signature,
         version: int = DEFAULT_PROGRAM_VERSION,
         optimize: OptimizeOptions = None,
+        debug: bool = False,
     ) -> None:
         self.mode = mode
         self.version = version
@@ -54,6 +55,7 @@ class CompileOptions:
 
         self.breakBlocksStack: List[List[TealSimpleBlock]] = []
         self.continueBlocksStack: List[List[TealSimpleBlock]] = []
+        self.debug = debug
 
     def setSubroutine(self, subroutine: Optional[SubroutineDefinition]) -> None:
         self.currentSubroutine = subroutine
@@ -237,6 +239,7 @@ def compileTeal(
     version: int = DEFAULT_PROGRAM_VERSION,
     assembleConstants: bool = False,
     optimize: OptimizeOptions = None,
+    debug: bool = False,
 ) -> str:
     """Compile a PyTeal expression into TEAL assembly.
 
@@ -270,7 +273,7 @@ def compileTeal(
             )
         )
 
-    options = CompileOptions(mode=mode, version=version, optimize=optimize)
+    options = CompileOptions(mode=mode, version=version, optimize=optimize, debug=debug)
 
     subroutineGraph: Dict[SubroutineDefinition, Set[SubroutineDefinition]] = dict()
     subroutine_start_blocks: Dict[Optional[SubroutineDefinition], TealBlock] = dict()
@@ -317,5 +320,5 @@ def compileTeal(
         teal = createConstantBlocks(teal)
 
     lines = ["#pragma version {}".format(version)]
-    lines += [i.assemble() for i in teal]
+    lines += [i.assemble(options.debug) for i in teal]
     return "\n".join(lines)

--- a/pyteal/ir/ops.py
+++ b/pyteal/ir/ops.py
@@ -31,6 +31,9 @@ class Op(Enum):
         return self.value.min_version
 
     # fmt: off
+    # meta
+    comment             = OpType("//",                  Mode.Signature | Mode.Application, 1)
+    # avm 
     err                 = OpType("err",                 Mode.Signature | Mode.Application, 2)
     sha256              = OpType("sha256",              Mode.Signature | Mode.Application, 2)
     keccak256           = OpType("keccak256",           Mode.Signature | Mode.Application, 2)

--- a/pyteal/ir/tealblock.py
+++ b/pyteal/ir/tealblock.py
@@ -14,9 +14,8 @@ if TYPE_CHECKING:
 class TealBlock(ABC):
     """Represents a basic block of TealComponents in a graph."""
 
-    def __init__(self, ops: List[TealOp], comment: str = None) -> None:
+    def __init__(self, ops: List[TealOp]) -> None:
         self.ops = ops
-        self.comment = comment
         self.incoming: List[TealBlock] = []
 
     @abstractmethod

--- a/pyteal/ir/tealblock.py
+++ b/pyteal/ir/tealblock.py
@@ -14,8 +14,9 @@ if TYPE_CHECKING:
 class TealBlock(ABC):
     """Represents a basic block of TealComponents in a graph."""
 
-    def __init__(self, ops: List[TealOp]) -> None:
+    def __init__(self, ops: List[TealOp], comment: str = None) -> None:
         self.ops = ops
+        self.comment = comment
         self.incoming: List[TealBlock] = []
 
     @abstractmethod

--- a/pyteal/ir/tealcomponent.py
+++ b/pyteal/ir/tealcomponent.py
@@ -23,7 +23,7 @@ class TealComponent(ABC):
         pass
 
     @abstractmethod
-    def assemble(self) -> str:
+    def assemble(self, debug: bool = False) -> str:
         pass
 
     @abstractmethod

--- a/pyteal/ir/teallabel.py
+++ b/pyteal/ir/teallabel.py
@@ -18,7 +18,7 @@ class TealLabel(TealComponent):
     def getLabelRef(self) -> LabelReference:
         return self.label
 
-    def assemble(self) -> str:
+    def assemble(self, debug: bool = False) -> str:
         comment = "\n// {}\n".format(self.comment) if self.comment is not None else ""
         return "{}{}:".format(comment, self.label.getLabel())
 

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -24,12 +24,12 @@ def fmt_traceback(tb: list[str]) -> str:
     line = line.replace(" line ", "l")
     file = file.replace("File ", "").replace(" ", "")  # Remove `File` and any spaces
 
-    return f"pyteal-src;{':'.join([file, line])}"
+    return f"src;{':'.join([file, line])}"
 
 
 def fmt_comment(comment: str) -> str:
     comment = comment.strip(";")
-    return f"comment;{comment}"
+    return f"cmt;{comment}"
 
 
 class TealOp(TealComponent):
@@ -66,7 +66,7 @@ class TealOp(TealComponent):
             if subroutine == arg:
                 self.args[i] = label
 
-    def assemble(self) -> str:
+    def assemble(self, debug: bool = False) -> str:
         from pyteal.ast import ScratchSlot, SubroutineDefinition
 
         parts = [str(self.op)]
@@ -91,7 +91,7 @@ class TealOp(TealComponent):
             if self.expr.comment is not None:
                 comments.append(fmt_comment(self.expr.comment))
 
-            if len(comments) > 0:
+            if len(comments) > 0 and debug:
                 parts.append(f"// {'|'.join(comments)}")
 
         return " ".join(parts)

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -29,7 +29,7 @@ def fmt_traceback(tb: list[str]) -> str:
 
 def fmt_comment(comment: str) -> str:
     comment = "\n// ".join(comment.strip(";").splitlines())
-    return f"cmt;{comment}"
+    return f"{comment}"
 
 
 class TealOp(TealComponent):

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -28,7 +28,7 @@ def fmt_traceback(tb: list[str]) -> str:
 
 
 def fmt_comment(comment: str) -> str:
-    comment = comment.strip(";")
+    comment = "\n// ".join(comment.strip(";").splitlines())
     return f"cmt;{comment}"
 
 

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -61,6 +61,9 @@ class TealOp(TealComponent):
             else:
                 parts.append(arg)
 
+        if self.expr.comment is not None:
+            parts.append("// " + self.expr.comment)
+
         return " ".join(parts)
 
     def __repr__(self) -> str:

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -1,4 +1,3 @@
-from lib2to3.pgen2.literals import simple_escapes
 from typing import Union, List, Optional, TYPE_CHECKING
 
 from pyteal.ir.tealcomponent import TealComponent

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -24,12 +24,12 @@ def fmt_traceback(tb: list[str]) -> str:
     line = line.replace(" line ", "l")
     file = file.replace("File ", "").replace(" ", "")  # Remove `File` and any spaces
 
-    return f"src;{':'.join([file, line])}"
+    return f"// {':'.join([file, line])}\n"
 
 
 def fmt_comment(comment: str) -> str:
     comment = "\n// ".join(comment.strip(";").splitlines())
-    return f"{comment}"
+    return f"// {comment}"
 
 
 class TealOp(TealComponent):
@@ -85,14 +85,10 @@ class TealOp(TealComponent):
                 parts.append(arg)
 
         if self.expr is not None:
-            comments = []
             if self.expr.trace is not None and debug:
-                comments.append(fmt_traceback(self.expr.trace))
+                parts.insert(0, fmt_traceback(self.expr.trace))
             if self.expr.comment is not None:
-                comments.append(fmt_comment(self.expr.comment))
-
-            if len(comments) > 0:
-                parts.append(f"// {'|'.join(comments)}")
+                parts.append(fmt_comment(self.expr.comment))
 
         return " ".join(parts)
 

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -61,7 +61,7 @@ class TealOp(TealComponent):
             else:
                 parts.append(arg)
 
-        if self.expr.comment is not None:
+        if self.expr is not None and self.expr.comment is not None:
             parts.append("// " + self.expr.comment)
 
         return " ".join(parts)

--- a/pyteal/ir/tealop.py
+++ b/pyteal/ir/tealop.py
@@ -86,12 +86,12 @@ class TealOp(TealComponent):
 
         if self.expr is not None:
             comments = []
-            if self.expr.trace is not None:
+            if self.expr.trace is not None and debug:
                 comments.append(fmt_traceback(self.expr.trace))
             if self.expr.comment is not None:
                 comments.append(fmt_comment(self.expr.comment))
 
-            if len(comments) > 0 and debug:
+            if len(comments) > 0:
                 parts.append(f"// {'|'.join(comments)}")
 
         return " ".join(parts)


### PR DESCRIPTION
Trying to address the comment here: https://github.com/algorand/pyteal/pull/410#issuecomment-1205148027

Should supersede #410  

Also adding the traces when in debug mode

```py
from pyteal import (
    Seq,
    Subroutine,
    TealType,
    Assert,
    Int,
    compileTeal,
    Mode,
    Comment,
    Pop,
)


@Subroutine(TealType.uint64)
def tst_subr():
    """Subroutine commented here"""
    return Seq(Assert((Int(0), "newp")), Int(1))


program = Seq(
    Comment(
        """
    
    Dope program section here

    """
    ),
    Comment("popper", Pop(Int(1))),
    # Make this be
    Assert((Int(1), "ok")),
    # On different
    Assert((Int(1), "no way"), (Int(1), "wow")),
    # lines
    tst_subr(),
)


print(compileTeal(program, mode=Mode.Application, version=7, debug=True))
```
returns
```
#pragma version 7
// "/home/ben/pyteal/pyteal/ast/comment.py":l66
 // 
// "/home/ben/pyteal/pyteal/ast/comment.py":l66
 //     
// "/home/ben/pyteal/pyteal/ast/comment.py":l66
 //     Dope program section here
// "/home/ben/pyteal/pyteal/ast/comment.py":l66
 // 
// "/home/ben/pyteal/pyteal/ast/comment.py":l66
 //     
// "/home/ben/pyteal/examples/application/assert_comment.py":l28
 int 1
// "/home/ben/pyteal/pyteal/ast/unaryexpr.py":l121
 pop // popper
// "/home/ben/pyteal/examples/application/assert_comment.py":l30
 int 1
// "/home/ben/pyteal/examples/application/assert_comment.py":l30
 assert // ok
// "/home/ben/pyteal/examples/application/assert_comment.py":l32
 int 1
// "/home/ben/pyteal/examples/application/assert_comment.py":l32
 assert // no way
// "/home/ben/pyteal/examples/application/assert_comment.py":l32
 int 1
// "/home/ben/pyteal/examples/application/assert_comment.py":l32
 assert // wow
// "/home/ben/pyteal/pyteal/ast/subroutine.py":l290
 callsub tstsubr_0
// "/home/ben/pyteal/examples/application/assert_comment.py":l20
 return

// tst_subr
tstsubr_0:
// "/home/ben/pyteal/examples/application/assert_comment.py":l17
 int 0
// "/home/ben/pyteal/examples/application/assert_comment.py":l17
 assert // newp
// "/home/ben/pyteal/examples/application/assert_comment.py":l17
 int 1
// "/home/ben/pyteal/examples/application/assert_comment.py":l17
 retsub
```

With `debug=False`

```
#pragma version 7
// 
//     
//     Dope program section here
// 
//     
int 1
pop // popper
int 1
assert // ok
int 1
assert // no way
int 1
assert // wow
callsub tstsubr_0
return

// tst_subr
tstsubr_0:
int 0
assert // newp
int 1
retsub
```