### PR TITLE
Fix bug where `String.set` duplicates the argument `Expr` in the AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 ## Fixed
-* TODO
+* Fix AST duplication bug in `String.set` when called with an `Expr` argument ([#508](https://github.com/algorand/pyteal/pull/508))
 
 # 0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Fixed
+* TODO
+
 # 0.16.0
 
 ## Added

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -2813,12 +2813,7 @@ retsub
 
 // log_creation
 logcreation_8:
-byte "logging creation"
-len
-itob
-extract 6 0
-byte "logging creation"
-concat
+byte 0x00106c6f6767696e67206372656174696f6e
 store 68
 load 68
 retsub""".strip()
@@ -3341,12 +3336,7 @@ retsub
 
 // log_creation
 logcreation_8:
-byte "logging creation"
-len
-itob
-extract 6 0
-byte "logging creation"
-concat
+byte 0x00106c6f6767696e67206372656174696f6e
 store 68
 load 68
 retsub""".strip()


### PR DESCRIPTION
When called with an `Expr`, the existing `_encoded_string` helper function includes the argument twice in the returned AST. For idempotent expressions, this is fine, but this is not acceptable for expressions whose execution has side effects.

For example, this code would produce an unintuitive result:

```python
value = abi.String()

program = value.set(
    Seq(
        Log(Bytes("hello")),
        Bytes("value")
    )
)
```

Because the current implementation duplicates the argument `Expr` in the AST, the example code above would actually log "hello" twice.

---

As a side effect of the fix in this PR, the implementation of `String.set` when called with a Python string or byte array is now more efficient, since the encoding is computed at compile time.