### PR TITLE
removing error thrown if seq contains something other than an expression

### DIFF
--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -47,13 +47,16 @@ class Seq(Expr):
         if len(exprs) == 1 and isinstance(exprs[0], list):
             exprs = exprs[0]
 
+        filtered_exprs: list[Expr] = []
         for i, expr in enumerate(exprs):
             if not isinstance(expr, Expr):
-                raise TealInputError("{} is not a pyteal expression.".format(expr))
+                continue
             if i + 1 < len(exprs):
                 require_type(expr, TealType.none)
 
-        self.args = exprs
+            filtered_exprs.append(expr)
+
+        self.args = filtered_exprs
 
     def __teal__(self, options: "CompileOptions"):
         start = TealSimpleBlock([])

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -50,6 +50,9 @@ class Seq(Expr):
         filtered_exprs: list[Expr] = []
         for i, expr in enumerate(exprs):
             if not isinstance(expr, Expr):
+                # lax evaluation of Seq so that we can do
+                # something like Seq(sv := ScratchVar(), sv.store(10))
+                # or otherwise without throwing an exception
                 continue
             if i + 1 < len(exprs):
                 require_type(expr, TealType.none)


### PR DESCRIPTION
Why not?

```py
program = Seq(
    x := ScratchVar(), 
    x.store(Int(10)), 
    x.load()
)

print(compileTeal(program, mode=Mode.Application, version=7))
```