### PR TITLE
remove null descr on contract since sdk changed

### DIFF
--- a/examples/application/abi/algobank.json
+++ b/examples/application/abi/algobank.json
@@ -49,6 +49,5 @@
             "desc": "Withdraw an amount of Algos held by this app. The sender of this method call will be the source of the Algos, and the destination will be the `recipient` argument. This may or may not be the same as the sender's address. This method will fail if the amount of Algos requested to be withdrawn exceeds the amount of Algos held by this app for the sender. The Algos will be transferred to the recipient using an inner transaction whose fee is set to 0, meaning the caller's transaction must include a surplus fee to cover the inner transaction."
         }
     ],
-    "desc": null,
     "networks": {}
 }


### PR DESCRIPTION
Fixes the `desc` attribute on the contract since the SDK changed to skip writing it if its `None`.

Relevant PR for sdk
https://github.com/algorand/py-algorand-sdk/pull/368