### PR TITLE
v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+# 0.17.0
+
 ## Added
-* Add the ability to insert comments in TEAL source file with the Comment method ([#410](https://github.com/algorand/pyteal/pull/410))
 * Static and Dynamic Byte Array convenience classes ([#500](https://github.com/algorand/pyteal/pull/500))
+* Add the ability to insert comments in TEAL source file with the `Comment` method ([#410](https://github.com/algorand/pyteal/pull/410))
 * Add a `comment` keyword argument to the Assert expression that will place the comment immediately above the `assert` op in the resulting TEAL ([#510](https://github.com/algorand/pyteal/pull/510))
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 # 0.17.0
 
 ## Added
-* Static and Dynamic Byte Array convenience classes ([#500](https://github.com/algorand/pyteal/pull/500))
+* Static and Dynamic Byte Array convenience classes ([#500](https://github.com/algorand/pyteal/pull/500), [#514](https://github.com/algorand/pyteal/pull/514))
 * Add the ability to insert comments in TEAL source file with the `Comment` method ([#410](https://github.com/algorand/pyteal/pull/410))
 * Add a `comment` keyword argument to the Assert expression that will place the comment immediately above the `assert` op in the resulting TEAL ([#510](https://github.com/algorand/pyteal/pull/510))
 
 ## Fixed
 * Fix AST duplication bug in `String.set` when called with an `Expr` argument ([#508](https://github.com/algorand/pyteal/pull/508))
-* Modify ABI `DynamicBytes` and `StaticBytes` to support `router`/`subroutine` ([#514](https://github.com/algorand/pyteal/pull/514))
 
 # 0.16.0
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyteal",
-    version="0.16.0",
+    version="0.17.0",
     author="Algorand",
     author_email="pypiservice@algorand.com",
     description="Algorand Smart Contracts in Python",


### PR DESCRIPTION
## Added
* Static and Dynamic Byte Array convenience classes ([#500](https://github.com/algorand/pyteal/pull/500))
* Add the ability to insert comments in TEAL source file with the `Comment` method ([#410](https://github.com/algorand/pyteal/pull/410))
* Add a `comment` keyword argument to the Assert expression that will place the comment immediately above the `assert` op in the resulting TEAL ([#510](https://github.com/algorand/pyteal/pull/510))

## Fixed
* Fix AST duplication bug in `String.set` when called with an `Expr` argument ([#508](https://github.com/algorand/pyteal/pull/508))