### PR TITLE
Use new docstring features in AlgoBank

### DIFF
--- a/examples/application/abi/algobank.json
+++ b/examples/application/abi/algobank.json
@@ -6,11 +6,13 @@
             "args": [
                 {
                     "type": "pay",
-                    "name": "payment"
+                    "name": "payment",
+                    "desc": "A payment transaction containing the amount of Algos the user wishes to deposit.\nThe receiver of this transaction must be this app's escrow account."
                 },
                 {
                     "type": "account",
-                    "name": "sender"
+                    "name": "sender",
+                    "desc": "An account that is opted into this app (or will opt in during this method call).\nThe deposited funds will be recorded in this account's local state. This account must\nbe the same as the sender of the `payment` transaction."
                 }
             ],
             "returns": {
@@ -23,11 +25,13 @@
             "args": [
                 {
                     "type": "account",
-                    "name": "user"
+                    "name": "user",
+                    "desc": "The user whose balance you wish to look up. This user must be opted into this app."
                 }
             ],
             "returns": {
-                "type": "uint64"
+                "type": "uint64",
+                "desc": "The balance corresponding to the given user, in microAlgos."
             },
             "desc": "Lookup the balance of a user held by this app."
         },
@@ -36,17 +40,19 @@
             "args": [
                 {
                     "type": "uint64",
-                    "name": "amount"
+                    "name": "amount",
+                    "desc": "The amount of Algos requested to be withdraw, in microAlgos. This method will fail\nif this amount exceeds the amount of Algos held by this app for the method call sender."
                 },
                 {
                     "type": "account",
-                    "name": "recipient"
+                    "name": "recipient",
+                    "desc": "An account who will receive the withdrawn Algos. This may or may not be the same\nas the method call sender."
                 }
             ],
             "returns": {
                 "type": "void"
             },
-            "desc": "Withdraw an amount of Algos held by this app. The sender of this method call will be the source of the Algos, and the destination will be the `recipient` argument. This may or may not be the same as the sender's address.\nThis method will fail if the amount of Algos requested to be withdrawn exceeds the amount of Algos held by this app for the sender.\nThe Algos will be transferred to the recipient using an inner transaction whose fee is set to 0, meaning the caller's transaction must include a surplus fee to cover the inner transaction."
+            "desc": "Withdraw an amount of Algos held by this app. The sender of this method call will be the source of the Algos, and the destination will be the `recipient` argument.\nThe Algos will be transferred to the recipient using an inner transaction whose fee is set to 0, meaning the caller's transaction must include a surplus fee to cover the inner transaction."
         }
     ],
     "networks": {}

--- a/examples/application/abi/algobank.json
+++ b/examples/application/abi/algobank.json
@@ -18,7 +18,7 @@
             "returns": {
                 "type": "void"
             },
-            "desc": "This method receives a payment from an account opted into this app and records it in their local state.\nThe caller may opt into this app during this call."
+            "desc": "This method receives a payment from an account opted into this app and records it as a deposit.\nThe caller may opt into this app during this call."
         },
         {
             "name": "getBalance",
@@ -52,7 +52,7 @@
             "returns": {
                 "type": "void"
             },
-            "desc": "Withdraw an amount of Algos held by this app. The sender of this method call will be the source of the Algos, and the destination will be the `recipient` argument.\nThe Algos will be transferred to the recipient using an inner transaction whose fee is set to 0, meaning the caller's transaction must include a surplus fee to cover the inner transaction."
+            "desc": "Withdraw an amount of Algos held by this app.\nThe sender of this method call will be the source of the Algos, and the destination will be the `recipient` argument.\nThe Algos will be transferred to the recipient using an inner transaction whose fee is set to 0, meaning the caller's transaction must include a surplus fee to cover the inner transaction."
         }
     ],
     "networks": {}

--- a/examples/application/abi/algobank.py
+++ b/examples/application/abi/algobank.py
@@ -41,8 +41,7 @@ router = Router(
 
 @router.method(no_op=CallConfig.CALL, opt_in=CallConfig.CALL)
 def deposit(payment: abi.PaymentTransaction, sender: abi.Account) -> Expr:
-    """This method receives a payment from an account opted into this app and records it in
-    their local state.
+    """This method receives a payment from an account opted into this app and records it as a deposit.
 
     The caller may opt into this app during this call.
 

--- a/examples/application/abi/algobank.py
+++ b/examples/application/abi/algobank.py
@@ -45,6 +45,13 @@ def deposit(payment: abi.PaymentTransaction, sender: abi.Account) -> Expr:
     their local state.
 
     The caller may opt into this app during this call.
+
+    Args:
+        payment: A payment transaction containing the amount of Algos the user wishes to deposit.
+            The receiver of this transaction must be this app's escrow account.
+        sender: An account that is opted into this app (or will opt in during this method call).
+            The deposited funds will be recorded in this account's local state. This account must
+            be the same as the sender of the `payment` transaction.
     """
     return Seq(
         Assert(payment.get().sender() == sender.address()),
@@ -59,7 +66,14 @@ def deposit(payment: abi.PaymentTransaction, sender: abi.Account) -> Expr:
 
 @router.method
 def getBalance(user: abi.Account, *, output: abi.Uint64) -> Expr:
-    """Lookup the balance of a user held by this app."""
+    """Lookup the balance of a user held by this app.
+    
+    Args:
+        user: The user whose balance you wish to look up. This user must be opted into this app.
+    
+    Returns:
+        The balance corresponding to the given user, in microAlgos.
+    """
     return output.set(App.localGet(user.address(), Bytes("balance")))
 
 
@@ -68,14 +82,17 @@ def withdraw(amount: abi.Uint64, recipient: abi.Account) -> Expr:
     """Withdraw an amount of Algos held by this app.
 
     The sender of this method call will be the source of the Algos, and the destination will be
-    the `recipient` argument. This may or may not be the same as the sender's address.
-
-    This method will fail if the amount of Algos requested to be withdrawn exceeds the amount of
-    Algos held by this app for the sender.
+    the `recipient` argument.
 
     The Algos will be transferred to the recipient using an inner transaction whose fee is set
     to 0, meaning the caller's transaction must include a surplus fee to cover the inner
     transaction.
+
+    Args:
+        amount: The amount of Algos requested to be withdraw, in microAlgos. This method will fail
+            if this amount exceeds the amount of Algos held by this app for the method call sender.
+        recipient: An account who will receive the withdrawn Algos. This may or may not be the same
+            as the method call sender.
     """
     return Seq(
         # if amount is larger than App.localGet(Txn.sender(), Bytes("balance")), the subtraction

--- a/examples/application/abi/algobank.py
+++ b/examples/application/abi/algobank.py
@@ -67,10 +67,10 @@ def deposit(payment: abi.PaymentTransaction, sender: abi.Account) -> Expr:
 @router.method
 def getBalance(user: abi.Account, *, output: abi.Uint64) -> Expr:
     """Lookup the balance of a user held by this app.
-    
+
     Args:
         user: The user whose balance you wish to look up. This user must be opted into this app.
-    
+
     Returns:
         The balance corresponding to the given user, in microAlgos.
     """

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -620,11 +620,13 @@ class ABIReturnSubroutine:
             docstring = parse_docstring(self.subroutine.implementation.__doc__)
 
             # Combine short and long descriptions with newline
-            method_desc = (
-                (docstring.short_description if docstring.short_description else "")
-                + "\n"
-                + (docstring.long_description if docstring.long_description else "")
-            )
+            method_descriptions: list[str] = []
+            if docstring.short_description:
+                method_descriptions.append(docstring.short_description)
+            if docstring.long_description:
+                method_descriptions.append(docstring.long_description)
+
+            method_desc = "\n\n".join(method_descriptions)
 
             # Turn double new line into single, replacing single newline with space
             desc = "\n".join(

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -1308,20 +1308,20 @@ def test_docstring_parsing_with_different_format():
     short_desc = "Example of a ABIReturnSubroutine with short description docstring."
     a_doc = "an abi Uint64 value"
     return_doc = "A PyTeal expression that sets output Uint64 value as argument a."
-    long_desc = """
-    This is an example docstring. This first line wraps since it's too
-    long to fit in a single line of source code.
+    long_desc = """Example first line.
 
     This is a second line.
+
+    This is a third line that's so long it has to wrap in order to fit properly
+    in a line of source code.
     """
-    expected_long_desc = "This is an example docstring. This first line wraps since it's too long to fit in a single line of source code.\nThis is a second line."
+    expected_long_desc = "Example first line.\nThis is a second line.\nThis is a third line that's so long it has to wrap in order to fit properly in a line of source code."
 
     def documented_method(a: pt.abi.Uint64, *, output: pt.abi.Uint64):
         return output.set(a)
 
     # Google format
-    documented_method.__doc__ = f"""
-    {short_desc}
+    documented_method.__doc__ = f"""{short_desc}
 
     Args:
         a: {a_doc}
@@ -1349,8 +1349,7 @@ def test_docstring_parsing_with_different_format():
     assert mspec_dict["returns"]["desc"] == return_doc
 
     # numpy format
-    documented_method.__doc__ = f"""
-    {short_desc}
+    documented_method.__doc__ = f"""{short_desc}
 
     Parameters
     ----------
@@ -1371,8 +1370,7 @@ def test_docstring_parsing_with_different_format():
     assert mspec_dict["returns"]["desc"] == return_doc
 
     # rst format
-    documented_method.__doc__ = f"""
-    {short_desc}
+    documented_method.__doc__ = f"""{short_desc}
 
     :param a: {a_doc} 
     :returns: {return_doc}
@@ -1383,7 +1381,21 @@ def test_docstring_parsing_with_different_format():
     assert mspec_dict["args"][0]["desc"] == a_doc
     assert mspec_dict["returns"]["desc"] == return_doc
 
-    # Long description
+    # Short and long descriptions
+    documented_method.__doc__ = f"""{long_desc}
+
+    :param a: {a_doc} 
+    :returns: {return_doc}
+    """
+
+    mspec_dict = ABIReturnSubroutine(documented_method).method_spec().dictify()
+    assert mspec_dict["desc"] == expected_long_desc
+    assert mspec_dict["args"][0]["desc"] == a_doc
+    assert mspec_dict["returns"]["desc"] == return_doc
+
+    # Only long description
+    # Short description is defined as being on the first line, so by introducing
+    # long_desc on the second, there is no short description.
     documented_method.__doc__ = f"""
     {long_desc}
 


### PR DESCRIPTION
This is a child PR to #518

It modifies the AlgoBank docstrings to use the new features, but there are still some issues. As you can see from the argument descriptions, multi-line descriptions still have newlines in them. We should probably strip these out as well. Multi-line return descriptions likely suffer from the same problem, but I don't have an example of that here.

Also, I was suspicious of this way of combining the short and long descriptions, so I modified the tests to exploit it and then improved the implementation: https://github.com/algorand/pyteal/blob/553ab34642640280d16aee3da30275f7f0fb68e5/pyteal/ast/subroutine.py#L622-L627