### PR TITLE
Minor improvement on `Makefile` to allow local end user always have latest dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 setup-development:
 	pip install -e .
-	pip install -r requirements.txt
+	pip install -r requirements.txt --upgrade
 
 setup-docs:
 	pip install -r docs/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ pytest==7.1.1
 pytest-cov==3.0.0
 pytest-timeout==2.1.0
 pytest-xdist==2.5.0
-semantic-version==2.10.0
 types-setuptools==57.4.18


### PR DESCRIPTION
2 things:
- adding `--upgrade` option in `pip`, so local end devs can always use `make setup-development` to upgrade their dependencies
- seems `semantic-version` is a runtime dependency, but it appear again in `requirements.txt`, can be taken out?