### PR TITLE
Unit test speed up

### DIFF
--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -244,10 +244,10 @@ def full_ordered_combination_gen(non_dup_list: list, perm_length: int):
     # by converting an index into |non_dup_list|-based number,
     # we can get the vector mapped by the index.
     for index in range(len(non_dup_list) ** perm_length):
-        index_list_basis = []
+        index_list_basis = [0] * perm_length
         temp = index
-        for _ in range(perm_length):
-            index_list_basis.append(non_dup_list[temp % len(non_dup_list)])
+        for i in range(perm_length):
+            index_list_basis[i] = non_dup_list[temp % len(non_dup_list)]
             temp //= len(non_dup_list)
         yield index_list_basis
 
@@ -321,6 +321,7 @@ def test_method_config():
         if str(oc) != str(pt.OnComplete.ClearState)
     ]
     for on_complete_set in on_complete_pow_set:
+        print(on_complete_set)
         oc_names = [camel_to_snake(oc.name) for oc in on_complete_set]
         ordered_call_configs = full_ordered_combination_gen(
             list(pt.CallConfig), len(on_complete_set)

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -265,7 +265,12 @@ class FullOrderCombinationGen:
             return
 
         for _ in range(perm_length):
-            take = secrets.randbelow(self.__basis_size**perm_length)
+            take = secrets.choice(
+                range(
+                    self.__basis_size ** (perm_length - 1),
+                    self.__basis_size**perm_length,
+                )
+            )
             yield [self.__basis_symbol[j] for j in self.__pre_gen_table[take]]
 
 

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -257,14 +257,16 @@ class FullOrderCombinationGen:
             lhs_scope = self.__basis_size**expn
             discrete_log = expn + 1
 
-    def sample_gen(self, perm_length: int):
+    def sample_gen(self, perm_length: int, sample_num: int = 10):
         if perm_length < 0:
             raise pt.TealInputError("input permutation length must be non-negative")
         elif perm_length == 0:
             yield []
             return
 
-        for _ in range(perm_length):
+        sample_num = min(sample_num, self.__basis_size ** (perm_length - 1))
+
+        for _ in range(sample_num):
             take = secrets.choice(
                 range(
                     self.__basis_size ** (perm_length - 1),

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -343,70 +343,76 @@ def test_call_config():
                 )
 
 
-def test_method_config():
+def test_method_config_call_config_never():
     never_mc = pt.MethodConfig(no_op=pt.CallConfig.NEVER)
     assert never_mc.is_never()
     assert never_mc.approval_cond() == 0
     assert never_mc.clear_state_cond() == 0
 
+
+def _gen_method_configs(sample_count: int = 10):
     on_complete_pow_set = power_set(ON_COMPLETE_CASES)
+    focg = FullOrderCombinationGen(list(pt.CallConfig), len(ON_COMPLETE_CASES))
+
+    for on_complete_set in on_complete_pow_set:
+        oc_names = [camel_to_snake(oc.name) for oc in on_complete_set]
+        for call_configs in focg.sample_gen(len(on_complete_set), sample_count):
+            yield pt.MethodConfig(**dict(zip(oc_names, call_configs)))
+
+
+@pytest.mark.parametrize("mc", _gen_method_configs())
+def test_method_config(mc: pt.MethodConfig):
     approval_check_names_n_ocs = [
         (camel_to_snake(oc.name), oc)
         for oc in ON_COMPLETE_CASES
         if str(oc) != str(pt.OnComplete.ClearState)
     ]
-    focg = FullOrderCombinationGen(list(pt.CallConfig), len(ON_COMPLETE_CASES))
-    for on_complete_set in on_complete_pow_set:
-        oc_names = [camel_to_snake(oc.name) for oc in on_complete_set]
-        for call_configs in focg.sample_gen(len(on_complete_set)):
-            mc = pt.MethodConfig(**dict(zip(oc_names, call_configs)))
-            match mc.clear_state:
-                case pt.CallConfig.NEVER:
-                    assert mc.clear_state_cond() == 0
-                case pt.CallConfig.CALL:
-                    assert mc.clear_state_cond() == 1
-                case pt.CallConfig.CREATE | pt.CallConfig.ALL:
-                    with pytest.raises(
-                        pt.TealInputError,
-                        match=r"Only CallConfig.CALL or CallConfig.NEVER are valid for a clear state CallConfig, since clear state can never be invoked during creation$",
-                    ):
-                        mc.clear_state_cond()
-            if mc.is_never() or all(
-                getattr(mc, i) == pt.CallConfig.NEVER
-                for i, _ in approval_check_names_n_ocs
+
+    match mc.clear_state:
+        case pt.CallConfig.NEVER:
+            assert mc.clear_state_cond() == 0
+        case pt.CallConfig.CALL:
+            assert mc.clear_state_cond() == 1
+        case pt.CallConfig.CREATE | pt.CallConfig.ALL:
+            with pytest.raises(
+                pt.TealInputError,
+                match=r"Only CallConfig.CALL or CallConfig.NEVER are valid for a clear state CallConfig, since clear state can never be invoked during creation$",
             ):
-                assert mc.approval_cond() == 0
-                continue
-            elif all(
-                getattr(mc, i) == pt.CallConfig.ALL
-                for i, _ in approval_check_names_n_ocs
-            ):
-                assert mc.approval_cond() == 1
-                continue
-            list_of_cc = [
-                (
-                    typing.cast(
-                        pt.CallConfig, getattr(mc, i)
-                    ).approval_condition_under_config(),
-                    oc,
+                mc.clear_state_cond()
+    if mc.is_never() or all(
+        getattr(mc, i) == pt.CallConfig.NEVER for i, _ in approval_check_names_n_ocs
+    ):
+        assert mc.approval_cond() == 0
+        return
+    elif all(
+        getattr(mc, i) == pt.CallConfig.ALL for i, _ in approval_check_names_n_ocs
+    ):
+        assert mc.approval_cond() == 1
+        return
+    list_of_cc = [
+        (
+            typing.cast(
+                pt.CallConfig, getattr(mc, i)
+            ).approval_condition_under_config(),
+            oc,
+        )
+        for i, oc in approval_check_names_n_ocs
+    ]
+    list_of_expressions: list[pt.Expr] = []
+    for expr_or_int, oc in list_of_cc:
+        match expr_or_int:
+            case pt.Expr():
+                list_of_expressions.append(
+                    pt.And(pt.Txn.on_completion() == oc, expr_or_int)
                 )
-                for i, oc in approval_check_names_n_ocs
-            ]
-            list_of_expressions = []
-            for expr_or_int, oc in list_of_cc:
-                match expr_or_int:
-                    case pt.Expr():
-                        list_of_expressions.append(
-                            pt.And(pt.Txn.on_completion() == oc, expr_or_int)
-                        )
-                    case 0:
-                        continue
-                    case 1:
-                        list_of_expressions.append(pt.Txn.on_completion() == oc)
-            with pt.TealComponent.Context.ignoreExprEquality():
-                assert assemble_helper(mc.approval_cond()) == assemble_helper(
-                    pt.Or(*list_of_expressions)
-                )
+            case 0:
+                continue
+            case 1:
+                list_of_expressions.append(pt.Txn.on_completion() == oc)
+    with pt.TealComponent.Context.ignoreExprEquality():
+        ac = mc.approval_cond()
+        assert isinstance(ac, pt.Expr)
+        assert assemble_helper(ac) == assemble_helper(pt.Or(*list_of_expressions))
 
 
 def test_on_complete_action():


### PR DESCRIPTION
Relying on randomness, randomly take some testcases from full permutation to test method config.

Test duration from 100+s to about 3s.

Closes #526 

No CHANGELOG for changes are not reflected to lib usage.