### PR TITLE
Add illustrative testing DSL for type_spec_is_assignable_to

### DIFF
--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -1,6 +1,5 @@
 from typing import cast, Callable, NamedTuple, Literal, Optional, Any, get_origin
 from inspect import isabstract
-from dataclasses import dataclass
 import pytest
 
 import algosdk.abi
@@ -797,24 +796,20 @@ class NamedTComp2(abi.NamedTuple):
     b0: abi.Field[abi.DynamicBytes]
 
 
-@dataclass
-class SafeBidirectional:
+class SafeBidirectional(NamedTuple):
     xs: list[abi.TypeSpec]
 
 
-@dataclass
-class UnsafeBidirectional:
+class UnsafeBidirectional(NamedTuple):
     xs: list[abi.TypeSpec]
 
 
-@dataclass
-class SafeAssignment:
+class SafeAssignment(NamedTuple):
     a: abi.TypeSpec
     bs: list[abi.TypeSpec]
 
 
-@dataclass
-class UnsafeAssignment:
+class UnsafeAssignment(NamedTuple):
     a: abi.TypeSpec
     bs: list[abi.TypeSpec]
 

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -1010,3 +1010,6 @@ def test_type_spec_assignable_example(tc):
             z = cast(UnsafeAssignment, tc)
             for b in z.bs:
                 assert abi.type_spec_is_assignable_to(z.a, b) is False
+
+        case _:
+            assert False, f"Unknown testcase group {type(tc)}."


### PR DESCRIPTION
Extends #540 with an optional idea that _may_ simplify test case definition for `type_spec_is_assignable_to`.

The intent is to provide a more expressive way to define test cases, which _hopefully_ simplifies test maintainer comprehension and improves test coverage.

The PR is presented assuming there'll be discussion + modification prior to being accepted (if at all).