### PR TITLE
Typo Fix for `abi.Uint64TypeSpec`

### DIFF
--- a/pyteal/ast/abi/uint.py
+++ b/pyteal/ast/abi/uint.py
@@ -224,7 +224,7 @@ class Uint64TypeSpec(UintTypeSpec):
         return Uint64
 
 
-Uint32TypeSpec.__module__ = "pyteal.abi"
+Uint64TypeSpec.__module__ = "pyteal.abi"
 
 
 class Uint(BaseType):


### PR DESCRIPTION
When I was attempting to walk through subclasses of `TypeSpec`s in `ABI`, I was experimenting with following script, and get the following result:
```python
❯ python3
Python 3.10.6 (main, Aug 30 2022, 04:58:14) [Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyteal import *
>>> stuff = [abi.TypeSpec]
>>> while stuff:
...     now = stuff.pop()
...     print(now)
...     for i in now.__subclasses__():
...         if i not in stuff:
...             stuff.append(i)
...
<class 'pyteal.abi.TypeSpec'>
<class 'pyteal.abi.TransactionTypeSpec'>
<class 'pyteal.abi.ApplicationCallTransactionTypeSpec'>
<class 'pyteal.abi.AssetTransferTransactionTypeSpec'>
<class 'pyteal.abi.AssetFreezeTransactionTypeSpec'>
<class 'pyteal.abi.AssetConfigTransactionTypeSpec'>
<class 'pyteal.abi.KeyRegisterTransactionTypeSpec'>
<class 'pyteal.abi.PaymentTransactionTypeSpec'>
<class 'pyteal.abi.ReferenceTypeSpec'>
<class 'pyteal.abi.ApplicationTypeSpec'>
<class 'pyteal.abi.AssetTypeSpec'>
<class 'pyteal.abi.AccountTypeSpec'>
<class 'pyteal.abi.ArrayTypeSpec'>
<class 'pyteal.abi.StaticArrayTypeSpec'>
<class 'pyteal.abi.AddressTypeSpec'>
<class 'pyteal.abi.StaticBytesTypeSpec'>
<class 'pyteal.abi.DynamicArrayTypeSpec'>
<class 'pyteal.abi.StringTypeSpec'>
<class 'pyteal.abi.DynamicBytesTypeSpec'>
<class 'pyteal.abi.TupleTypeSpec'>
<class 'pyteal.abi.NamedTupleTypeSpec'>
<class 'pyteal.abi.BoolTypeSpec'>
<class 'pyteal.abi.UintTypeSpec'>
<class 'pyteal.ast.abi.uint.Uint64TypeSpec'>
<class 'pyteal.abi.Uint32TypeSpec'>
<class 'pyteal.abi.Uint16TypeSpec'>
<class 'pyteal.abi.Uint8TypeSpec'>
<class 'pyteal.abi.ByteTypeSpec'>
```

The line `<class 'pyteal.ast.abi.uint.Uint64TypeSpec'>` looks absurd, so this line one change of typo fix gives correct class name repr over command line:
```python
❯ python3
Python 3.10.6 (main, Aug 30 2022, 04:58:14) [Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyteal import *
>>> stuff = [abi.TypeSpec]
>>> while stuff:
...     now = stuff.pop()
...     print(now)
...     for i in now.__subclasses__():
...         if i not in stuff:
...             stuff.append(i)
...
<class 'pyteal.abi.TypeSpec'>
<class 'pyteal.abi.TransactionTypeSpec'>
<class 'pyteal.abi.ApplicationCallTransactionTypeSpec'>
<class 'pyteal.abi.AssetTransferTransactionTypeSpec'>
<class 'pyteal.abi.AssetFreezeTransactionTypeSpec'>
<class 'pyteal.abi.AssetConfigTransactionTypeSpec'>
<class 'pyteal.abi.KeyRegisterTransactionTypeSpec'>
<class 'pyteal.abi.PaymentTransactionTypeSpec'>
<class 'pyteal.abi.ReferenceTypeSpec'>
<class 'pyteal.abi.ApplicationTypeSpec'>
<class 'pyteal.abi.AssetTypeSpec'>
<class 'pyteal.abi.AccountTypeSpec'>
<class 'pyteal.abi.ArrayTypeSpec'>
<class 'pyteal.abi.StaticArrayTypeSpec'>
<class 'pyteal.abi.AddressTypeSpec'>
<class 'pyteal.abi.StaticBytesTypeSpec'>
<class 'pyteal.abi.DynamicArrayTypeSpec'>
<class 'pyteal.abi.StringTypeSpec'>
<class 'pyteal.abi.DynamicBytesTypeSpec'>
<class 'pyteal.abi.TupleTypeSpec'>
<class 'pyteal.abi.NamedTupleTypeSpec'>
<class 'pyteal.abi.BoolTypeSpec'>
<class 'pyteal.abi.UintTypeSpec'>
<class 'pyteal.abi.Uint64TypeSpec'>
<class 'pyteal.abi.Uint32TypeSpec'>
<class 'pyteal.abi.Uint16TypeSpec'>
<class 'pyteal.abi.Uint8TypeSpec'>
<class 'pyteal.abi.ByteTypeSpec'>
```