### PR TITLE
Proposing API minor change on `ABIReturnSubroutine` for name overriding

### DIFF
--- a/pyteal/ast/abi/uint.py
+++ b/pyteal/ast/abi/uint.py
@@ -224,7 +224,7 @@ class Uint64TypeSpec(UintTypeSpec):
         return Uint64
 
 
-Uint32TypeSpec.__module__ = "pyteal.abi"
+Uint64TypeSpec.__module__ = "pyteal.abi"
 
 
 class Uint(BaseType):

--- a/pyteal/ast/subroutine.py
+++ b/pyteal/ast/subroutine.py
@@ -519,6 +519,9 @@ class ABIReturnSubroutine:
     def __init__(
         self,
         fn_implementation: Callable[..., Expr],
+        /,
+        *,
+        overriding_name: Optional[str] = None,
     ) -> None:
         self.output_kwarg_info: Optional[OutputKwArgInfo] = self._get_output_kwarg_info(
             fn_implementation
@@ -526,8 +529,16 @@ class ABIReturnSubroutine:
         self.subroutine = SubroutineDefinition(
             fn_implementation,
             return_type=TealType.none,
+            name_str=overriding_name,
             has_abi_output=self.output_kwarg_info is not None,
         )
+
+    @staticmethod
+    def name_override(name: str) -> Callable[..., "ABIReturnSubroutine"]:
+        def wrapper(fn_impl: Callable[..., Expr]) -> ABIReturnSubroutine:
+            return ABIReturnSubroutine(fn_impl, overriding_name=name)
+
+        return wrapper
 
     @classmethod
     def _get_output_kwarg_info(


### PR DESCRIPTION
Ben proposed a PR for `ABIReturnSubroutine` name overriding in #550 , which is assumed to be suggested by https://github.com/algorand-devrel/beaker/pull/84/.

The bug fix change in #550 looks good, but it also suggest that we are explicitly passing override name in both `method_signature` and `method_spec` methods, and it doesn't smell good.

I propose a small API change, such that one can specify the override name on construction for `ABIReturnSubroutine`.
We should probably ignore `overriding_name` argument in `method_signature`, but I haven't thought through how that method should change.