### PR TITLE
`OpUp` inner fee setting and tests.

### DIFF
--- a/pyteal/ast/opup_test.py
+++ b/pyteal/ast/opup_test.py
@@ -14,44 +14,81 @@ def test_opup_explicit():
     with pytest.raises(pt.TealTypeError):
         opup = OpUp(mode, target_app_id=pt.Bytes("appid"))
 
-    with pytest.raises(pt.TealTypeError):
-        opup = OpUp(mode, target_app_id=pt.Int(1), inner_fee=pt.Bytes("min_fee"))
-
     opup = OpUp(mode, target_app_id=pt.Int(1))
 
     with pytest.raises(pt.TealTypeError):
-        opup.ensure_budget(pt.Bytes("budget"))
+        opup.ensure_budget(required_budget=pt.Bytes("budget"))
 
     with pytest.raises(pt.TealTypeError):
-        opup.maximize_budget(pt.Bytes("fee"))
+        opup.ensure_budget(required_budget=pt.Int(1_000), inner_fee=pt.Bytes("min_fee"))
+
+    with pytest.raises(pt.TealTypeError):
+        opup.maximize_budget(fee=pt.Bytes("fee"))
+
+    with pytest.raises(pt.TealTypeError):
+        opup.maximize_budget(fee=pt.Int(1_000), inner_fee=pt.Bytes("min_fee"))
 
     assert opup.target_app_id == pt.Int(1)
 
     # verify correct usage doesn't cause an error
-    opup = OpUp(mode, target_app_id=pt.Int(1), inner_fee=pt.Global.min_txn_fee())
-    _ = pt.Seq(opup.ensure_budget(pt.Int(500) + pt.Int(1000)), pt.Return(pt.Int(1)))
+    opup = OpUp(mode, target_app_id=pt.Int(1))
+    _ = pt.Seq(
+        opup.ensure_budget(required_budget=pt.Int(500) + pt.Int(1000)),
+        pt.Return(pt.Int(1)),
+    )
+    _ = pt.Seq(
+        opup.ensure_budget(
+            required_budget=pt.Int(500) + pt.Int(1000),
+            inner_fee=pt.Global.min_txn_fee(),
+        ),
+        pt.Return(pt.Int(1)),
+    )
 
-    opup = OpUp(mode, target_app_id=pt.Int(1), inner_fee=pt.Int(1_000))
-    _ = pt.Seq(opup.maximize_budget(pt.Txn.fee() - pt.Int(100)), pt.Return(pt.Int(1)))
+    opup = OpUp(mode, target_app_id=pt.Int(1))
+    _ = pt.Seq(
+        opup.maximize_budget(fee=pt.Txn.fee() - pt.Int(100)), pt.Return(pt.Int(1))
+    )
+    _ = pt.Seq(
+        opup.maximize_budget(fee=pt.Txn.fee() - pt.Int(100), inner_fee=pt.Int(1_000)),
+        pt.Return(pt.Int(1)),
+    )
 
 
 def test_opup_oncall():
     mode = OpUpMode.OnCall
-
-    with pytest.raises(pt.TealTypeError):
-        opup = OpUp(mode, inner_fee=pt.Bytes("min_fee"))
-
     opup = OpUp(mode)
 
     with pytest.raises(pt.TealTypeError):
-        opup.ensure_budget(pt.Bytes("budget"))
+        opup.ensure_budget(required_budget=pt.Bytes("budget"))
 
     with pytest.raises(pt.TealTypeError):
-        opup.maximize_budget(pt.Bytes("fee"))
+        opup.ensure_budget(required_budget=pt.Int(1_000), inner_fee=pt.Bytes("min_fee"))
+
+    with pytest.raises(pt.TealTypeError):
+        opup.maximize_budget(fee=pt.Bytes("fee"))
+
+    with pytest.raises(pt.TealTypeError):
+        opup.maximize_budget(fee=pt.Int(1_000), inner_fee=pt.Bytes("min_fee"))
 
     # verify correct usage doesn't cause an error
-    opup = OpUp(mode, inner_fee=pt.Global.min_txn_fee())
-    _ = pt.Seq(opup.ensure_budget(pt.Int(500) + pt.Int(1000)), pt.Return(pt.Int(1)))
+    opup = OpUp(mode)
+    _ = pt.Seq(
+        opup.ensure_budget(required_budget=pt.Int(500) + pt.Int(1000)),
+        pt.Return(pt.Int(1)),
+    )
+    _ = pt.Seq(
+        opup.ensure_budget(
+            required_budget=pt.Int(500) + pt.Int(1000),
+            inner_fee=pt.Global.min_txn_fee(),
+        ),
+        pt.Return(pt.Int(1)),
+    )
 
     opup = OpUp(mode)
-    _ = pt.Seq(opup.maximize_budget(pt.Txn.fee() - pt.Int(100)), pt.Return(pt.Int(1)))
+    _ = pt.Seq(
+        opup.maximize_budget(fee=pt.Txn.fee() - pt.Int(100)), pt.Return(pt.Int(1))
+    )
+    _ = pt.Seq(
+        opup.maximize_budget(fee=pt.Txn.fee() - pt.Int(100), inner_fee=pt.Int(1_000)),
+        pt.Return(pt.Int(1)),
+    )

--- a/pyteal/ast/opup_test.py
+++ b/pyteal/ast/opup_test.py
@@ -12,9 +12,12 @@ def test_opup_explicit():
     assert "target_app_id must be specified in Explicit OpUp mode" in str(err.value)
 
     with pytest.raises(pt.TealTypeError):
-        opup = OpUp(mode, pt.Bytes("appid"))
+        opup = OpUp(mode, target_app_id=pt.Bytes("appid"))
 
-    opup = OpUp(mode, pt.Int(1))
+    with pytest.raises(pt.TealTypeError):
+        opup = OpUp(mode, target_app_id=pt.Int(1), inner_fee=pt.Bytes("min_fee"))
+
+    opup = OpUp(mode, target_app_id=pt.Int(1))
 
     with pytest.raises(pt.TealTypeError):
         opup.ensure_budget(pt.Bytes("budget"))
@@ -25,13 +28,19 @@ def test_opup_explicit():
     assert opup.target_app_id == pt.Int(1)
 
     # verify correct usage doesn't cause an error
+    opup = OpUp(mode, target_app_id=pt.Int(1), inner_fee=pt.Global.min_txn_fee())
     _ = pt.Seq(opup.ensure_budget(pt.Int(500) + pt.Int(1000)), pt.Return(pt.Int(1)))
 
+    opup = OpUp(mode, target_app_id=pt.Int(1), inner_fee=pt.Int(1_000))
     _ = pt.Seq(opup.maximize_budget(pt.Txn.fee() - pt.Int(100)), pt.Return(pt.Int(1)))
 
 
 def test_opup_oncall():
     mode = OpUpMode.OnCall
+
+    with pytest.raises(pt.TealTypeError):
+        opup = OpUp(mode, inner_fee=pt.Bytes("min_fee"))
+
     opup = OpUp(mode)
 
     with pytest.raises(pt.TealTypeError):
@@ -41,6 +50,8 @@ def test_opup_oncall():
         opup.maximize_budget(pt.Bytes("fee"))
 
     # verify correct usage doesn't cause an error
+    opup = OpUp(mode, inner_fee=pt.Global.min_txn_fee())
     _ = pt.Seq(opup.ensure_budget(pt.Int(500) + pt.Int(1000)), pt.Return(pt.Int(1)))
 
+    opup = OpUp(mode)
     _ = pt.Seq(opup.maximize_budget(pt.Txn.fee() - pt.Int(100)), pt.Return(pt.Int(1)))


### PR DESCRIPTION
This is a little PR with a proposal to address https://github.com/algorand/pyteal/issues/545

The intuition is that _unless explicitly specified_ `OpUp` assumes that Inner Transactions fee for the budget top-up operations are backed by the upper call.