### PR TITLE
Minor improvement on testcase coverage in util.py inside pyteal.abi

### DIFF
--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -18,6 +18,8 @@ from pyteal.ast.int import Int
 from pyteal.ast.substring import Extract, Substring, Suffix
 from pyteal.ast.abi.type import TypeSpec, BaseType
 
+from pyteal.ast.abi.uint import Uint64
+
 
 def substring_for_decoding(
     encoded: Expr,
@@ -499,3 +501,7 @@ def type_specs_from_signature(sig: str) -> tuple[list[TypeSpec], Optional[TypeSp
         return_type = type_spec_from_algosdk(sdk_method.returns.type)
 
     return [type_spec_from_algosdk(arg.type) for arg in sdk_method.args], return_type
+
+
+class BadIntentionUncoveredCase(Uint64):
+    pass

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -18,8 +18,6 @@ from pyteal.ast.int import Int
 from pyteal.ast.substring import Extract, Substring, Suffix
 from pyteal.ast.abi.type import TypeSpec, BaseType
 
-from pyteal.ast.abi.uint import Uint64
-
 
 def substring_for_decoding(
     encoded: Expr,
@@ -501,7 +499,3 @@ def type_specs_from_signature(sig: str) -> tuple[list[TypeSpec], Optional[TypeSp
         return_type = type_spec_from_algosdk(sdk_method.returns.type)
 
     return [type_spec_from_algosdk(arg.type) for arg in sdk_method.args], return_type
-
-
-class BadIntentionUncoveredCase(Uint64):
-    pass


### PR DESCRIPTION
Extract out bfs iteration logic from `test_type_spec_from_annotation_is_exhaustive` and make it generic.

Rewrite `test_type_spec_from_annotation_is_exhaustive` to make it rely on `pytest.mark.parametrize` for better error msg.

I see this to be potentially helpful for future testing on full coverage of test.