### PR TITLE
Support new AVM 8 account parameters

### DIFF
--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -96,6 +96,8 @@ class AccountParam:
     def totalNumUint(cls, acct: Expr) -> MaybeValue:
         """Get the total number of uint64 values allocated by the account in Global and Local States.
 
+        Requires program version 8 or higher.
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -105,6 +107,8 @@ class AccountParam:
     @classmethod
     def totalNumByteSlice(cls, acct: Expr) -> MaybeValue:
         """Get the total number of byte array values allocated by the account in Global and Local States.
+
+        Requires program version 8 or higher.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
@@ -116,6 +120,8 @@ class AccountParam:
     def totalExtraAppPages(cls, acct: Expr) -> MaybeValue:
         """Get the number of extra app code pages used by the account.
 
+        Requires program version 8 or higher.
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -125,6 +131,8 @@ class AccountParam:
     @classmethod
     def totalAppsCreated(cls, acct: Expr) -> MaybeValue:
         """Get the number of existing apps created by the account.
+
+        Requires program version 8 or higher.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
@@ -136,6 +144,8 @@ class AccountParam:
     def totalAppsOptedIn(cls, acct: Expr) -> MaybeValue:
         """Get the number of apps the account is opted into.
 
+        Requires program version 8 or higher.
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -145,6 +155,8 @@ class AccountParam:
     @classmethod
     def totalAssetsCreated(cls, acct: Expr) -> MaybeValue:
         """Get the number of existing ASAs created by the account.
+
+        Requires program version 8 or higher.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
@@ -156,6 +168,8 @@ class AccountParam:
     def totalAssets(cls, acct: Expr) -> MaybeValue:
         """Get the number of ASAs held by the account (including ASAs the account created).
 
+        Requires program version 8 or higher.
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -166,6 +180,8 @@ class AccountParam:
     def totalBoxes(cls, acct: Expr) -> MaybeValue:
         """Get the number of existing boxes created by the account's app.
 
+        Requires program version 8 or higher.
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -175,6 +191,8 @@ class AccountParam:
     @classmethod
     def totalBoxBytes(cls, acct: Expr) -> MaybeValue:
         """Get the total number of bytes used by the account's app's box keys and values.
+
+        Requires program version 8 or higher.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.

--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -4,7 +4,6 @@ from pyteal.errors import verifyFieldVersion
 
 from pyteal.types import TealType, require_type
 from pyteal.ir import Op
-from pyteal.ast.leafexpr import LeafExpr
 from pyteal.ast.expr import Expr
 from pyteal.ast.maybe import MaybeValue
 
@@ -15,18 +14,18 @@ if TYPE_CHECKING:
 class AccountParamField(Enum):
     # fmt: off
     #                    id  |         name               |     type    |  min version
-    balance               = (0,  "AcctBalance",            TealType.uint64, 6)
-    min_balance           = (1,  "AcctMinBalance",         TealType.uint64, 6)
-    auth_addr             = (2,  "AcctAuthAddr",           TealType.bytes,  6)
-    total_num_uint        = (3,  "AcctTotalNumUint",       TealType.uint64, 8)
-    total_num_byte_slice  = (4,  "AcctTotalNumByteSlice",  TealType.uint64, 8)
-    total_extra_app_pages = (5,  "AcctTotalExtraAppPages", TealType.uint64, 8)
-    total_apps_created    = (6,  "AcctTotalAppsCreated",   TealType.uint64, 8)
-    total_apps_opted_in   = (7,  "AcctTotalAppsOptedIn",   TealType.uint64, 8)
-    total_assets_created  = (8,  "AcctTotalAssetsCreated", TealType.uint64, 8)
-    total_assets          = (9,  "AcctTotalAssets",        TealType.uint64, 8)
-    total_boxes           = (10, "AcctTotalBoxes",         TealType.uint64, 8)
-    total_box_bytes       = (11, "AcctTotalBoxBytes",      TealType.uint64, 8)
+    balance               = (0,  "AcctBalance",            TealType.uint64, 6)  # noqa: E221
+    min_balance           = (1,  "AcctMinBalance",         TealType.uint64, 6)  # noqa: E221
+    auth_addr             = (2,  "AcctAuthAddr",           TealType.bytes,  6)  # noqa: E221
+    total_num_uint        = (3,  "AcctTotalNumUint",       TealType.uint64, 8)  # noqa: E221
+    total_num_byte_slice  = (4,  "AcctTotalNumByteSlice",  TealType.uint64, 8)  # noqa: E221
+    total_extra_app_pages = (5,  "AcctTotalExtraAppPages", TealType.uint64, 8)  # noqa: E221
+    total_apps_created    = (6,  "AcctTotalAppsCreated",   TealType.uint64, 8)  # noqa: E221
+    total_apps_opted_in   = (7,  "AcctTotalAppsOptedIn",   TealType.uint64, 8)  # noqa: E221
+    total_assets_created  = (8,  "AcctTotalAssetsCreated", TealType.uint64, 8)  # noqa: E221
+    total_assets          = (9,  "AcctTotalAssets",        TealType.uint64, 8)  # noqa: E221
+    total_boxes           = (10, "AcctTotalBoxes",         TealType.uint64, 8)  # noqa: E221
+    total_box_bytes       = (11, "AcctTotalBoxBytes",      TealType.uint64, 8)  # noqa: E221
     # fmt: on
 
     def __init__(self, id: int, name: str, type: TealType, min_version: int) -> None:

--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -41,153 +41,141 @@ class AccountParamField(Enum):
 AccountParamField.__module__ = "pyteal"
 
 
-class AccountParamExpr(MaybeValue):
-    """A maybe value expression that accesses an account parameter field from a given account."""
+class AccountParam:
+    @staticmethod
+    def __makeAccountParamExpr(field: AccountParamField, acct: Expr) -> MaybeValue:
+        require_type(acct, TealType.anytype)
 
-    def __init__(self, field: AccountParamField, acct: Expr) -> None:
-        super().__init__(
+        def field_version_check(options: "CompileOptions"):
+            verifyFieldVersion(field.arg_name, field.min_version, options.version)
+
+        return MaybeValue(
             Op.acct_params_get,
             field.type_of(),
             immediate_args=[field.arg_name],
             args=[acct],
+            compile_check=field_version_check,
         )
-        require_type(acct, TealType.anytype)
 
-        self.field = field
-        self.acct = acct
-
-    def __str__(self):
-        return "(AccountParam {} {})".format(self.field.arg_name, self.acct)
-
-    def __teal__(self, options: "CompileOptions"):
-        verifyFieldVersion(self.field.arg_name, self.field.min_version, options.version)
-
-        return super().__teal__(options)
-
-
-AccountParamExpr.__module__ = "pyteal"
-
-
-class AccountParam:
     @classmethod
-    def balance(cls, acct: Expr) -> AccountParamExpr:
+    def balance(cls, acct: Expr) -> MaybeValue:
         """Get the current balance in microalgos an account.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.balance, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.balance, acct)
 
     @classmethod
-    def minBalance(cls, acct: Expr) -> AccountParamExpr:
+    def minBalance(cls, acct: Expr) -> MaybeValue:
         """Get the minimum balance in microalgos for an account.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.min_balance, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.min_balance, acct)
 
     @classmethod
-    def authAddr(cls, acct: Expr) -> AccountParamExpr:
+    def authAddr(cls, acct: Expr) -> MaybeValue:
         """Get the authorizing address for an account. If the account is not rekeyed, the empty addresss is returned.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.auth_addr, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.auth_addr, acct)
 
     @classmethod
-    def totalNumUint(cls, acct: Expr) -> AccountParamExpr:
+    def totalNumUint(cls, acct: Expr) -> MaybeValue:
         """Get the total number of uint64 values allocated by the account in Global and Local States.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_num_uint, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_num_uint, acct)
 
     @classmethod
-    def totalNumByteSlice(cls, acct: Expr) -> AccountParamExpr:
+    def totalNumByteSlice(cls, acct: Expr) -> MaybeValue:
         """Get the total number of byte array values allocated by the account in Global and Local States.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_num_byte_slice, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_num_byte_slice, acct)
 
     @classmethod
-    def totalExtraAppPages(cls, acct: Expr) -> AccountParamExpr:
+    def totalExtraAppPages(cls, acct: Expr) -> MaybeValue:
         """Get the number of extra app code pages used by the account.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_extra_app_pages, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_extra_app_pages, acct)
 
     @classmethod
-    def totalAppsCreated(cls, acct: Expr) -> AccountParamExpr:
+    def totalAppsCreated(cls, acct: Expr) -> MaybeValue:
         """Get the number of existing apps created by the account.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_apps_created, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_apps_created, acct)
 
     @classmethod
-    def totalAppsOptedIn(cls, acct: Expr) -> AccountParamExpr:
+    def totalAppsOptedIn(cls, acct: Expr) -> MaybeValue:
         """Get the number of apps the account is opted into.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_apps_opted_in, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_apps_opted_in, acct)
 
     @classmethod
-    def totalAssetsCreated(cls, acct: Expr) -> AccountParamExpr:
+    def totalAssetsCreated(cls, acct: Expr) -> MaybeValue:
         """Get the number of existing ASAs created by the account.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_assets_created, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_assets_created, acct)
 
     @classmethod
-    def totalAssets(cls, acct: Expr) -> AccountParamExpr:
+    def totalAssets(cls, acct: Expr) -> MaybeValue:
         """Get the number of ASAs held by the account (including ASAs the account created).
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_assets, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_assets, acct)
 
     @classmethod
-    def totalBoxes(cls, acct: Expr) -> AccountParamExpr:
+    def totalBoxes(cls, acct: Expr) -> MaybeValue:
         """Get the number of existing boxes created by the account's app.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_boxes, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_boxes, acct)
 
     @classmethod
-    def totalBoxBytes(cls, acct: Expr) -> AccountParamExpr:
+    def totalBoxBytes(cls, acct: Expr) -> MaybeValue:
         """Get the total number of bytes used by the account's app's box keys and values.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        return AccountParamExpr(AccountParamField.total_box_bytes, acct)
+        return cls.__makeAccountParamExpr(AccountParamField.total_box_bytes, acct)
 
 
 AccountParam.__module__ = "pyteal"
@@ -205,53 +193,53 @@ class AccountParamObject:
         """
         self._account: Final = account
 
-    def balance(self) -> AccountParamExpr:
+    def balance(self) -> MaybeValue:
         """Get the current balance in microAlgos for the account"""
         return AccountParam.balance(self._account)
 
-    def min_balance(self) -> AccountParamExpr:
+    def min_balance(self) -> MaybeValue:
         """Get the minimum balance in microAlgos for the account."""
         return AccountParam.minBalance(self._account)
 
-    def auth_address(self) -> AccountParamExpr:
+    def auth_address(self) -> MaybeValue:
         """Get the authorizing address for the account.
 
         If the account is not rekeyed, the empty address is returned."""
         return AccountParam.authAddr(self._account)
 
-    def total_num_uint(self) -> AccountParamExpr:
+    def total_num_uint(self) -> MaybeValue:
         """Get the total number of uint64 values allocated by the account in Global and Local States."""
         return AccountParam.totalNumUint(self._account)
 
-    def total_num_byte_slice(self) -> AccountParamExpr:
+    def total_num_byte_slice(self) -> MaybeValue:
         """Get the total number of byte array values allocated by the account in Global and Local States."""
         return AccountParam.totalNumByteSlice(self._account)
 
-    def total_extra_app_pages(self) -> AccountParamExpr:
+    def total_extra_app_pages(self) -> MaybeValue:
         """Get the number of extra app code pages used by the account."""
         return AccountParam.totalExtraAppPages(self._account)
 
-    def total_apps_created(self) -> AccountParamExpr:
+    def total_apps_created(self) -> MaybeValue:
         """Get the number of existing apps created by the account."""
         return AccountParam.totalAppsCreated(self._account)
 
-    def total_apps_opted_in(self) -> AccountParamExpr:
+    def total_apps_opted_in(self) -> MaybeValue:
         """Get the number of apps the account is opted into."""
         return AccountParam.totalAppsOptedIn(self._account)
 
-    def total_assets_created(self) -> AccountParamExpr:
+    def total_assets_created(self) -> MaybeValue:
         """Get the number of existing ASAs created by the account."""
         return AccountParam.totalAssetsCreated(self._account)
 
-    def total_assets(self) -> AccountParamExpr:
+    def total_assets(self) -> MaybeValue:
         """Get the number of ASAs held by the account (including ASAs the account created)."""
         return AccountParam.totalAssets(self._account)
 
-    def total_boxes(self) -> AccountParamExpr:
+    def total_boxes(self) -> MaybeValue:
         """Get the number of existing boxes created by the account's app."""
         return AccountParam.totalBoxes(self._account)
 
-    def total_box_bytes(self) -> AccountParamExpr:
+    def total_box_bytes(self) -> MaybeValue:
         """Get the total number of bytes used by the account's app's box keys and values."""
         return AccountParam.totalBoxBytes(self._account)
 

--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -50,7 +50,7 @@ class AccountParamExpr(MaybeValue):
             Op.acct_params_get,
             field.type_of(),
             immediate_args=[field.arg_name],
-            args=[acct]
+            args=[acct],
         )
         require_type(acct, TealType.anytype)
 
@@ -103,7 +103,7 @@ class AccountParam:
     @classmethod
     def totalNumUint(cls, acct: Expr) -> AccountParamExpr:
         """Get the total number of uint64 values allocated by the account in Global and Local States.
-        
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -113,7 +113,7 @@ class AccountParam:
     @classmethod
     def totalNumByteSlice(cls, acct: Expr) -> AccountParamExpr:
         """Get the total number of byte array values allocated by the account in Global and Local States.
-        
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -123,7 +123,7 @@ class AccountParam:
     @classmethod
     def totalExtraAppPages(cls, acct: Expr) -> AccountParamExpr:
         """Get the number of extra app code pages used by the account.
-        
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -143,17 +143,17 @@ class AccountParam:
     @classmethod
     def totalAppsOptedIn(cls, acct: Expr) -> AccountParamExpr:
         """Get the number of apps the account is opted into.
-        
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
         return AccountParamExpr(AccountParamField.total_apps_opted_in, acct)
-    
+
     @classmethod
     def totalAssetsCreated(cls, acct: Expr) -> AccountParamExpr:
         """Get the number of existing ASAs created by the account.
-        
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -163,18 +163,17 @@ class AccountParam:
     @classmethod
     def totalAssets(cls, acct: Expr) -> AccountParamExpr:
         """Get the number of ASAs held by the account (including ASAs the account created).
-        
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
         return AccountParamExpr(AccountParamField.total_assets, acct)
 
-
     @classmethod
     def totalBoxes(cls, acct: Expr) -> AccountParamExpr:
         """Get the number of existing boxes created by the account's app.
-        
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
@@ -184,12 +183,13 @@ class AccountParam:
     @classmethod
     def totalBoxBytes(cls, acct: Expr) -> AccountParamExpr:
         """Get the total number of bytes used by the account's app's box keys and values.
-        
+
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
         return AccountParamExpr(AccountParamField.total_box_bytes, acct)
+
 
 AccountParam.__module__ = "pyteal"
 

--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -220,5 +220,41 @@ class AccountParamObject:
         If the account is not rekeyed, the empty address is returned."""
         return AccountParam.authAddr(self._account)
 
+    def total_num_uint(self) -> AccountParamExpr:
+        """Get the total number of uint64 values allocated by the account in Global and Local States."""
+        return AccountParam.totalNumUint(self._account)
+
+    def total_num_byte_slice(self) -> AccountParamExpr:
+        """Get the total number of byte array values allocated by the account in Global and Local States."""
+        return AccountParam.totalNumByteSlice(self._account)
+
+    def total_extra_app_pages(self) -> AccountParamExpr:
+        """Get the number of extra app code pages used by the account."""
+        return AccountParam.totalExtraAppPages(self._account)
+
+    def total_apps_created(self) -> AccountParamExpr:
+        """Get the number of existing apps created by the account."""
+        return AccountParam.totalAppsCreated(self._account)
+
+    def total_apps_opted_in(self) -> AccountParamExpr:
+        """Get the number of apps the account is opted into."""
+        return AccountParam.totalAppsOptedIn(self._account)
+
+    def total_assets_created(self) -> AccountParamExpr:
+        """Get the number of existing ASAs created by the account."""
+        return AccountParam.totalAssetsCreated(self._account)
+
+    def total_assets(self) -> AccountParamExpr:
+        """Get the number of ASAs held by the account (including ASAs the account created)."""
+        return AccountParam.totalAssets(self._account)
+
+    def total_boxes(self) -> AccountParamExpr:
+        """Get the number of existing boxes created by the account's app."""
+        return AccountParam.totalBoxes(self._account)
+
+    def total_box_bytes(self) -> AccountParamExpr:
+        """Get the total number of bytes used by the account's app's box keys and values."""
+        return AccountParam.totalBoxBytes(self._account)
+
 
 AccountParamObject.__module__ = "pyteal"

--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -1,59 +1,104 @@
-from typing import Final
+from enum import Enum
+from typing import Final, TYPE_CHECKING
+from pyteal.errors import verifyFieldVersion
 
 from pyteal.types import TealType, require_type
 from pyteal.ir import Op
+from pyteal.ast.leafexpr import LeafExpr
 from pyteal.ast.expr import Expr
 from pyteal.ast.maybe import MaybeValue
+
+if TYPE_CHECKING:
+    from pyteal.compiler import CompileOptions
+
+
+class AccountParamField(Enum):
+    # fmt: off
+    #                    id  |         name               |     type    |  min version
+    balance               = (0,  "AcctBalance",            TealType.uint64, 6)
+    min_balance           = (1,  "AcctMinBalance",         TealType.uint64, 6)
+    auth_addr             = (2,  "AcctAuthAddr",           TealType.bytes,  6)
+    total_num_uint        = (3,  "AcctTotalNumUint",       TealType.uint64, 8)
+    total_num_byte_slice  = (4,  "AcctTotalNumByteSlice",  TealType.uint64, 8)
+    total_extra_app_pages = (5,  "AcctTotalExtraAppPages", TealType.uint64, 8)
+    total_apps_created    = (6,  "AcctTotalAppsCreated",   TealType.uint64, 8)
+    total_apps_opted_in   = (7,  "AcctTotalAppsOptedIn",   TealType.uint64, 8)
+    total_box_bytes       = (8,  "AcctTotalBoxBytes",      TealType.uint64, 8)
+    total_assets_created  = (9,  "AcctTotalAssetsCreated", TealType.uint64, 8)
+    total_assets          = (10, "AcctTotalAssets",        TealType.uint64, 8)
+    total_boxes           = (11, "AcctTotalBoxes",         TealType.uint64, 8)
+    # fmt: on
+
+    def __init__(self, id: int, name: str, type: TealType, min_version: int) -> None:
+        self.id = id
+        self.arg_name = name
+        self.type = type
+        self.min_version = min_version
+
+    def type_of(self) -> TealType:
+        return self.type
+
+
+AccountParamField.__module__ = "pyteal"
+
+
+class AccountParamExpr(MaybeValue):
+    """A maybe value expression that accesses an account parameter field from a given account."""
+
+    def __init__(self, field: AccountParamField, acct: Expr) -> None:
+        super().__init__(
+            Op.acct_params_get,
+            field.type_of(),
+            immediate_args=[field.arg_name],
+            args=[acct]
+        )
+        require_type(acct, TealType.anytype)
+
+        self.field = field
+        self.acct = acct
+
+    def __str__(self):
+        return "(AccountParam {} {})".format(self.field.arg_name, self.acct)
+
+    def __teal__(self, options: "CompileOptions"):
+        verifyFieldVersion(self.field.arg_name, self.field.min_version, options.version)
+
+        return super().__teal__(options)
+
+
+AccountParamExpr.__module__ = "pyteal"
 
 
 class AccountParam:
     @classmethod
-    def balance(cls, acct: Expr) -> MaybeValue:
+    def balance(cls, acct: Expr) -> AccountParamExpr:
         """Get the current balance in microalgos an account.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        require_type(acct, TealType.anytype)
-        return MaybeValue(
-            Op.acct_params_get,
-            TealType.uint64,
-            immediate_args=["AcctBalance"],
-            args=[acct],
-        )
+        return AccountParamExpr(AccountParamField.balance, acct)
 
     @classmethod
-    def minBalance(cls, acct: Expr) -> MaybeValue:
+    def minBalance(cls, acct: Expr) -> AccountParamExpr:
         """Get the minimum balance in microalgos for an account.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        require_type(acct, TealType.anytype)
-        return MaybeValue(
-            Op.acct_params_get,
-            TealType.uint64,
-            immediate_args=["AcctMinBalance"],
-            args=[acct],
-        )
+        return AccountParamExpr(AccountParamField.min_balance, acct)
 
     @classmethod
-    def authAddr(cls, acct: Expr) -> MaybeValue:
+    def authAddr(cls, acct: Expr) -> AccountParamExpr:
         """Get the authorizing address for an account. If the account is not rekeyed, the empty addresss is returned.
 
         Args:
             acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
                 May evaluate to uint64 or an address.
         """
-        require_type(acct, TealType.anytype)
-        return MaybeValue(
-            Op.acct_params_get,
-            TealType.bytes,
-            immediate_args=["AcctAuthAddr"],
-            args=[acct],
-        )
+        return AccountParamExpr(AccountParamField.auth_addr, acct)
 
 
 AccountParam.__module__ = "pyteal"
@@ -71,15 +116,15 @@ class AccountParamObject:
         """
         self._account: Final = account
 
-    def balance(self) -> MaybeValue:
+    def balance(self) -> AccountParamExpr:
         """Get the current balance in microAlgos for the account"""
         return AccountParam.balance(self._account)
 
-    def min_balance(self) -> MaybeValue:
+    def min_balance(self) -> AccountParamExpr:
         """Get the minimum balance in microAlgos for the account."""
         return AccountParam.minBalance(self._account)
 
-    def auth_address(self) -> MaybeValue:
+    def auth_address(self) -> AccountParamExpr:
         """Get the authorizing address for the account.
 
         If the account is not rekeyed, the empty address is returned."""

--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import Final, TYPE_CHECKING
-from pyteal.errors import verifyFieldVersion
+from pyteal.errors import verifyFieldVersion, verifyProgramVersion
 
 from pyteal.types import TealType, require_type
 from pyteal.ir import Op
@@ -46,7 +46,12 @@ class AccountParam:
     def __makeAccountParamExpr(field: AccountParamField, acct: Expr) -> MaybeValue:
         require_type(acct, TealType.anytype)
 
-        def field_version_check(options: "CompileOptions"):
+        def field_and_program_version_check(options: "CompileOptions"):
+            verifyProgramVersion(
+                minVersion=Op.acct_params_get.min_version,
+                version=options.version,
+                msg=f"{Op.acct_params_get.value} unavailable",
+            )
             verifyFieldVersion(field.arg_name, field.min_version, options.version)
 
         return MaybeValue(
@@ -54,7 +59,7 @@ class AccountParam:
             field.type_of(),
             immediate_args=[field.arg_name],
             args=[acct],
-            compile_check=field_version_check,
+            compile_check=field_and_program_version_check,
         )
 
     @classmethod

--- a/pyteal/ast/acct.py
+++ b/pyteal/ast/acct.py
@@ -23,10 +23,10 @@ class AccountParamField(Enum):
     total_extra_app_pages = (5,  "AcctTotalExtraAppPages", TealType.uint64, 8)
     total_apps_created    = (6,  "AcctTotalAppsCreated",   TealType.uint64, 8)
     total_apps_opted_in   = (7,  "AcctTotalAppsOptedIn",   TealType.uint64, 8)
-    total_box_bytes       = (8,  "AcctTotalBoxBytes",      TealType.uint64, 8)
-    total_assets_created  = (9,  "AcctTotalAssetsCreated", TealType.uint64, 8)
-    total_assets          = (10, "AcctTotalAssets",        TealType.uint64, 8)
-    total_boxes           = (11, "AcctTotalBoxes",         TealType.uint64, 8)
+    total_assets_created  = (8,  "AcctTotalAssetsCreated", TealType.uint64, 8)
+    total_assets          = (9,  "AcctTotalAssets",        TealType.uint64, 8)
+    total_boxes           = (10, "AcctTotalBoxes",         TealType.uint64, 8)
+    total_box_bytes       = (11, "AcctTotalBoxBytes",      TealType.uint64, 8)
     # fmt: on
 
     def __init__(self, id: int, name: str, type: TealType, min_version: int) -> None:
@@ -100,6 +100,96 @@ class AccountParam:
         """
         return AccountParamExpr(AccountParamField.auth_addr, acct)
 
+    @classmethod
+    def totalNumUint(cls, acct: Expr) -> AccountParamExpr:
+        """Get the total number of uint64 values allocated by the account in Global and Local States.
+        
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_num_uint, acct)
+
+    @classmethod
+    def totalNumByteSlice(cls, acct: Expr) -> AccountParamExpr:
+        """Get the total number of byte array values allocated by the account in Global and Local States.
+        
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_num_byte_slice, acct)
+
+    @classmethod
+    def totalExtraAppPages(cls, acct: Expr) -> AccountParamExpr:
+        """Get the number of extra app code pages used by the account.
+        
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_extra_app_pages, acct)
+
+    @classmethod
+    def totalAppsCreated(cls, acct: Expr) -> AccountParamExpr:
+        """Get the number of existing apps created by the account.
+
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_apps_created, acct)
+
+    @classmethod
+    def totalAppsOptedIn(cls, acct: Expr) -> AccountParamExpr:
+        """Get the number of apps the account is opted into.
+        
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_apps_opted_in, acct)
+    
+    @classmethod
+    def totalAssetsCreated(cls, acct: Expr) -> AccountParamExpr:
+        """Get the number of existing ASAs created by the account.
+        
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_assets_created, acct)
+
+    @classmethod
+    def totalAssets(cls, acct: Expr) -> AccountParamExpr:
+        """Get the number of ASAs held by the account (including ASAs the account created).
+        
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_assets, acct)
+
+
+    @classmethod
+    def totalBoxes(cls, acct: Expr) -> AccountParamExpr:
+        """Get the number of existing boxes created by the account's app.
+        
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_boxes, acct)
+
+    @classmethod
+    def totalBoxBytes(cls, acct: Expr) -> AccountParamExpr:
+        """Get the total number of bytes used by the account's app's box keys and values.
+        
+        Args:
+            acct: An index into Txn.accounts that corresponds to the application to check or an address available at runtime.
+                May evaluate to uint64 or an address.
+        """
+        return AccountParamExpr(AccountParamField.total_box_bytes, acct)
 
 AccountParam.__module__ = "pyteal"
 

--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -12,6 +12,15 @@ avm6Options = pt.CompileOptions(version=6)
         ("balance", "balance"),
         ("minBalance", "min_balance"),
         ("authAddr", "auth_addr"),
+        ("totalNumUint", "total_num_uint"),
+        ("totalNumByteSlice", "total_num_byte_slice"),
+        ("totalExtraAppPages", "total_extra_app_pages"),
+        ("totalAppsCreated", "total_apps_created"),
+        ("totalAppsOptedIn", "total_apps_opted_in"),
+        ("totalAssetsCreated", "total_assets_created"),
+        ("totalAssets", "total_assets"),
+        ("totalBoxes", "total_boxes"),
+        ("totalBoxBytes", "total_box_bytes"),
     ]
 )
 def test_acct_param_fields_valid(method_name, field_name):

--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -2,8 +2,6 @@ import pyteal as pt
 from pyteal.ast.maybe_test import assert_MaybeValue_equality
 
 options = pt.CompileOptions()
-avm4Options = pt.CompileOptions(version=4)
-avm5Options = pt.CompileOptions(version=5)
 avm6Options = pt.CompileOptions(version=6)
 
 

--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -5,6 +5,7 @@ from pyteal.ast.acct import AccountParamField
 from pyteal.ast.maybe_test import assert_MaybeValue_equality
 
 avm6Options = pt.CompileOptions(version=6)
+avm8Options = pt.CompileOptions(version=8)
 
 @pytest.mark.parametrize(
     "method_name,field_name",
@@ -76,4 +77,32 @@ def test_AccountParamObject():
         )
         assert_MaybeValue_equality(
             obj.auth_address(), pt.AccountParam.authAddr(account), avm6Options
+        )
+
+        assert_MaybeValue_equality(
+            obj.total_num_uint(), pt.AccountParam.totalNumUint(account), avm8Options
+        )
+        assert_MaybeValue_equality(
+            obj.total_num_byte_slice(), pt.AccountParam.totalNumByteSlice(account), avm8Options
+        )
+        assert_MaybeValue_equality(
+            obj.total_extra_app_pages(), pt.AccountParam.totalExtraAppPages(account), avm8Options
+        )
+        assert_MaybeValue_equality(
+            obj.total_apps_created(), pt.AccountParam.totalAppsCreated(account), avm8Options
+        )
+        assert_MaybeValue_equality(
+            obj.total_apps_opted_in(), pt.AccountParam.totalAppsOptedIn(account), avm8Options
+        )
+        assert_MaybeValue_equality(
+            obj.total_assets_created(), pt.AccountParam.totalAssetsCreated(account), avm8Options
+        )
+        assert_MaybeValue_equality(
+            obj.total_assets(), pt.AccountParam.totalAssets(account), avm8Options
+        )
+        assert_MaybeValue_equality(
+            obj.total_boxes(), pt.AccountParam.totalBoxes(account), avm8Options
+        )
+        assert_MaybeValue_equality(
+            obj.total_box_bytes(), pt.AccountParam.totalBoxBytes(account), avm8Options
         )

--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -86,6 +86,12 @@ def test_acct_param_auth_addr_valid():
         expr.__teal__(avm5Options)
 
 
+def test_acct_param_string():
+    assert str(pt.AccountParam.balance(pt.Int(1))) == "(AccountParam AcctBalance (Int 1))"
+    assert str(pt.AccountParam.minBalance(pt.Int(1))) == "(AccountParam AcctMinBalance (Int 1))"
+    assert str(pt.AccountParam.authAddr(pt.Int(1))) == "(AccountParam AcctAuthAddr (Int 1))"
+
+
 def test_AccountParamObject():
     for account in (
         pt.Int(7),

--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -1,7 +1,10 @@
+import pytest
+
 import pyteal as pt
 from pyteal.ast.maybe_test import assert_MaybeValue_equality
 
 options = pt.CompileOptions()
+avm5Options = pt.CompileOptions(version=5)
 avm6Options = pt.CompileOptions(version=6)
 
 
@@ -27,6 +30,9 @@ def test_acct_param_balance_valid():
     with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+    with pytest.raises(pt.TealInputError):
+        expr.__teal__(avm5Options)
+
 
 def test_acct_param_min_balance_valid():
     arg = pt.Int(0)
@@ -50,6 +56,9 @@ def test_acct_param_min_balance_valid():
     with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
 
+    with pytest.raises(pt.TealInputError):
+        expr.__teal__(avm5Options)
+
 
 def test_acct_param_auth_addr_valid():
     arg = pt.Int(1)
@@ -72,6 +81,9 @@ def test_acct_param_auth_addr_valid():
 
     with pt.TealComponent.Context.ignoreExprEquality():
         assert actual == expected
+
+    with pytest.raises(pt.TealInputError):
+        expr.__teal__(avm5Options)
 
 
 def test_AccountParamObject():

--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -62,15 +62,16 @@ def test_acct_param_fields_valid(method_name, field_name):
 
 def test_acct_param_string():
     assert (
-        str(pt.AccountParam.balance(pt.Int(1))) == "(AccountParam AcctBalance (Int 1))"
+        str(pt.AccountParam.balance(pt.Int(1)))
+        == "((acct_params_get AcctBalance (Int 1)) (StackStore slot#280) (StackStore slot#281))"
     )
     assert (
         str(pt.AccountParam.minBalance(pt.Int(1)))
-        == "(AccountParam AcctMinBalance (Int 1))"
+        == "((acct_params_get AcctMinBalance (Int 1)) (StackStore slot#282) (StackStore slot#283))"
     )
     assert (
         str(pt.AccountParam.authAddr(pt.Int(1)))
-        == "(AccountParam AcctAuthAddr (Int 1))"
+        == "((acct_params_get AcctAuthAddr (Int 1)) (StackStore slot#284) (StackStore slot#285))"
     )
 
 

--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -7,6 +7,7 @@ from pyteal.ast.maybe_test import assert_MaybeValue_equality
 avm6Options = pt.CompileOptions(version=6)
 avm8Options = pt.CompileOptions(version=8)
 
+
 @pytest.mark.parametrize(
     "method_name,field_name",
     [
@@ -22,7 +23,7 @@ avm8Options = pt.CompileOptions(version=8)
         ("totalAssets", "total_assets"),
         ("totalBoxes", "total_boxes"),
         ("totalBoxBytes", "total_box_bytes"),
-    ]
+    ],
 )
 def test_acct_param_fields_valid(method_name, field_name):
     arg = pt.Int(1)
@@ -42,7 +43,9 @@ def test_acct_param_fields_valid(method_name, field_name):
         ]
     )
 
-    supported_options_version = pt.CompileOptions(version=account_param_field.min_version)
+    supported_options_version = pt.CompileOptions(
+        version=account_param_field.min_version
+    )
     actual, _ = expr.__teal__(supported_options_version)
     actual.addIncoming()
     actual = pt.TealBlock.NormalizeBlocks(actual)
@@ -51,13 +54,24 @@ def test_acct_param_fields_valid(method_name, field_name):
         assert actual == expected
 
     with pytest.raises(pt.TealInputError):
-        unsupported_options_version = pt.CompileOptions(version=account_param_field.min_version - 1)
+        unsupported_options_version = pt.CompileOptions(
+            version=account_param_field.min_version - 1
+        )
         expr.__teal__(unsupported_options_version)
 
+
 def test_acct_param_string():
-    assert str(pt.AccountParam.balance(pt.Int(1))) == "(AccountParam AcctBalance (Int 1))"
-    assert str(pt.AccountParam.minBalance(pt.Int(1))) == "(AccountParam AcctMinBalance (Int 1))"
-    assert str(pt.AccountParam.authAddr(pt.Int(1))) == "(AccountParam AcctAuthAddr (Int 1))"
+    assert (
+        str(pt.AccountParam.balance(pt.Int(1))) == "(AccountParam AcctBalance (Int 1))"
+    )
+    assert (
+        str(pt.AccountParam.minBalance(pt.Int(1)))
+        == "(AccountParam AcctMinBalance (Int 1))"
+    )
+    assert (
+        str(pt.AccountParam.authAddr(pt.Int(1)))
+        == "(AccountParam AcctAuthAddr (Int 1))"
+    )
 
 
 def test_AccountParamObject():
@@ -83,19 +97,29 @@ def test_AccountParamObject():
             obj.total_num_uint(), pt.AccountParam.totalNumUint(account), avm8Options
         )
         assert_MaybeValue_equality(
-            obj.total_num_byte_slice(), pt.AccountParam.totalNumByteSlice(account), avm8Options
+            obj.total_num_byte_slice(),
+            pt.AccountParam.totalNumByteSlice(account),
+            avm8Options,
         )
         assert_MaybeValue_equality(
-            obj.total_extra_app_pages(), pt.AccountParam.totalExtraAppPages(account), avm8Options
+            obj.total_extra_app_pages(),
+            pt.AccountParam.totalExtraAppPages(account),
+            avm8Options,
         )
         assert_MaybeValue_equality(
-            obj.total_apps_created(), pt.AccountParam.totalAppsCreated(account), avm8Options
+            obj.total_apps_created(),
+            pt.AccountParam.totalAppsCreated(account),
+            avm8Options,
         )
         assert_MaybeValue_equality(
-            obj.total_apps_opted_in(), pt.AccountParam.totalAppsOptedIn(account), avm8Options
+            obj.total_apps_opted_in(),
+            pt.AccountParam.totalAppsOptedIn(account),
+            avm8Options,
         )
         assert_MaybeValue_equality(
-            obj.total_assets_created(), pt.AccountParam.totalAssetsCreated(account), avm8Options
+            obj.total_assets_created(),
+            pt.AccountParam.totalAssetsCreated(account),
+            avm8Options,
         )
         assert_MaybeValue_equality(
             obj.total_assets(), pt.AccountParam.totalAssets(account), avm8Options

--- a/pyteal/ast/acct_test.py
+++ b/pyteal/ast/acct_test.py
@@ -60,21 +60,6 @@ def test_acct_param_fields_valid(method_name, field_name):
         expr.__teal__(unsupported_options_version)
 
 
-def test_acct_param_string():
-    assert (
-        str(pt.AccountParam.balance(pt.Int(1)))
-        == "((acct_params_get AcctBalance (Int 1)) (StackStore slot#280) (StackStore slot#281))"
-    )
-    assert (
-        str(pt.AccountParam.minBalance(pt.Int(1)))
-        == "((acct_params_get AcctMinBalance (Int 1)) (StackStore slot#282) (StackStore slot#283))"
-    )
-    assert (
-        str(pt.AccountParam.authAddr(pt.Int(1)))
-        == "((acct_params_get AcctAuthAddr (Int 1)) (StackStore slot#284) (StackStore slot#285))"
-    )
-
-
 def test_AccountParamObject():
     for account in (
         pt.Int(7),

--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -1,4 +1,4 @@
-from typing import List, Union, TYPE_CHECKING
+from typing import Callable, List, Union, TYPE_CHECKING
 
 from pyteal.errors import verifyProgramVersion
 from pyteal.types import TealType
@@ -22,6 +22,7 @@ class MaybeValue(MultiValue):
         *,
         immediate_args: List[Union[int, str]] = None,
         args: List[Expr] = None,
+        compile_check: Callable[["CompileOptions"], None] = lambda _: None,
     ):
         """Create a new MaybeValue.
 
@@ -32,12 +33,13 @@ class MaybeValue(MultiValue):
             args (optional): Stack arguments for the op. Defaults to None.
         """
 
-        def local_version_check(option: "CompileOptions"):
+        def local_version_check(options: "CompileOptions"):
             verifyProgramVersion(
                 minVersion=op.min_version,
-                version=option.version,
+                version=options.version,
                 msg=f"{op.value} unavailable",
             )
+            compile_check(options)
 
         types = [type, TealType.uint64]
         super().__init__(

--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -22,7 +22,7 @@ class MaybeValue(MultiValue):
         *,
         immediate_args: List[Union[int, str]] = None,
         args: List[Expr] = None,
-        compile_check: Callable[["CompileOptions"], None] = lambda _: None,
+        compile_check: Callable[["CompileOptions"], None] = None,
     ):
         """Create a new MaybeValue.
 
@@ -31,15 +31,16 @@ class MaybeValue(MultiValue):
             type: The type of the returned value.
             immediate_args (optional): Immediate arguments for the op. Defaults to None.
             args (optional): Stack arguments for the op. Defaults to None.
+            compile_check (optional): Callable compile check. Defaults to program version check.
         """
 
+        # Default compile check if one is not given
         def local_version_check(options: "CompileOptions"):
             verifyProgramVersion(
                 minVersion=op.min_version,
                 version=options.version,
                 msg=f"{op.value} unavailable",
             )
-            compile_check(options)
 
         types = [type, TealType.uint64]
         super().__init__(
@@ -47,7 +48,9 @@ class MaybeValue(MultiValue):
             types,
             immediate_args=immediate_args,
             args=args,
-            compile_check=local_version_check,
+            compile_check=(
+                local_version_check if compile_check is None else compile_check
+            ),
         )
 
     def hasValue(self) -> ScratchLoad:

--- a/pyteal/ast/maybe.py
+++ b/pyteal/ast/maybe.py
@@ -32,6 +32,7 @@ class MaybeValue(MultiValue):
             immediate_args (optional): Immediate arguments for the op. Defaults to None.
             args (optional): Stack arguments for the op. Defaults to None.
             compile_check (optional): Callable compile check. Defaults to program version check.
+                This parameter overwrites the default program version check.
         """
 
         # Default compile check if one is not given


### PR DESCRIPTION
This PR adds new account parameters [introduced in AVM 8](https://github.com/algorand/go-algorand/pull/4491). To do so, the `AccountParam` class was extended to support versioned fields similar to [the existing version checks](https://github.com/algorand/pyteal/blob/master/pyteal/ast/txn.py#L146-L172) within `Txn` expressions.

Some other changes:
- `MaybeValue`s have been extended to support an optional `compile_check` parameter similar to what is currently available within `MultiValue`s.