### PR TITLE
Add sanity check to test_override_names

### DIFF
--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -804,21 +804,37 @@ def test_build_program_clear_state_valid_config():
 
 
 def test_override_names():
+    r1 = pt.Router("test")
 
-    router = pt.Router("test")
-
-    @router.method(name="handle")
+    @r1.method(name="handle")
     def handle_asa(deposit: pt.abi.AssetTransferTransaction):
         """handles the deposit where the input is an asset transfer"""
         return pt.Assert(deposit.get().asset_amount() > pt.Int(0))
 
-    @router.method(name="handle")
+    @r1.method(name="handle")
     def handle_algo(deposit: pt.abi.PaymentTransaction):
         """handles the deposit where the input is a payment"""
         return pt.Assert(deposit.get().amount() > pt.Int(0))
 
-    _, _, contract = router.compile_program(version=7)
-    assert len(contract.methods) > 0
-    for meth in contract.methods:
+    ap1, cs1, c1 = r1.compile_program(version=pt.compiler.MAX_PROGRAM_VERSION)
+    assert len(c1.methods) == 2
+    for meth in c1.methods:
         dmeth = meth.dictify()
         assert dmeth["name"] == "handle"
+
+    # Confirm an equivalent router definition _without_ `name` overrides produces the same output.
+    r2 = pt.Router("test")
+
+    @r2.method()
+    def handle(deposit: pt.abi.AssetTransferTransaction):
+        """handles the deposit where the input is an asset transfer"""
+        return pt.Assert(deposit.get().asset_amount() > pt.Int(0))
+
+    @r2.method()
+    def handle(deposit: pt.abi.PaymentTransaction):  # noqa: F811
+        """handles the deposit where the input is a payment"""
+        return pt.Assert(deposit.get().amount() > pt.Int(0))
+
+    ap2, cs2, c2 = r2.compile_program(version=pt.compiler.MAX_PROGRAM_VERSION)
+
+    assert (ap1, cs1, c1) == (ap2, cs2, c2)


### PR DESCRIPTION
Extends https://github.com/algorand/pyteal/pull/550 by confirming construction through an equivalent approach yields the same contract + TEAL source.