### PR TITLE
`ABIReturnSubroutine` doc/test-case on `name_override` decorator

### DIFF
--- a/docs/abi.rst
+++ b/docs/abi.rst
@@ -682,6 +682,21 @@ Notice that even though the original :code:`get_account_status` function returns
 
 The only exception to this transformation is if the subroutine has no return value. Without a return value, a :code:`ComputedValue` is unnecessary and the subroutine will still return an :code:`Expr` to the caller. In this case, the :code:`@ABIReturnSubroutine` decorator acts identically the :code:`@Subroutine` decorator.
 
+The name of the subroutine constructed by the :code:`@ABIReturnSubroutine` decorator is by default the function name. In order to override the default subroutine name, the decorator :any:`ABIReturnSubroutine.name_override <ABIReturnSubroutine.name_override>` is introduced to construct a subroutine with its name overriden. An example is below:
+
+.. code-block:: python
+
+    from pyteal import *
+
+    @ABIReturnSubroutine.name_override("increment")
+    def add_by_one(prev: abi.Uint32, *, output: abi.Uint32) -> Expr:
+        return output.set(prev.get() + Int(1))
+
+    # NOTE! In this case, the `ABIReturnSubroutine` is initialized with a name "increment"
+    #       overriding its original name "add_by_one"
+    assert add_by_one.method_spec().dictify()["name"] == "increment"
+
+
 Creating an ARC-4 Program
 ----------------------------------------------------
 

--- a/docs/abi.rst
+++ b/docs/abi.rst
@@ -682,7 +682,7 @@ Notice that even though the original :code:`get_account_status` function returns
 
 The only exception to this transformation is if the subroutine has no return value. Without a return value, a :code:`ComputedValue` is unnecessary and the subroutine will still return an :code:`Expr` to the caller. In this case, the :code:`@ABIReturnSubroutine` decorator acts identically the :code:`@Subroutine` decorator.
 
-The name of the subroutine constructed by the :code:`@ABIReturnSubroutine` decorator is by default the function name. In order to override the default subroutine name, the decorator :any:`ABIReturnSubroutine.name_override <ABIReturnSubroutine.name_override>` is introduced to construct a subroutine with its name overriden. An example is below:
+The name of the subroutine constructed by the :code:`@ABIReturnSubroutine` decorator is by default the function name. In order to override the default subroutine name, the decorator :any:`ABIReturnSubroutine.name_override <ABIReturnSubroutine.name_override>` is introduced to construct a subroutine with its name overridden. An example is below:
 
 .. code-block:: python
 

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -1475,3 +1475,10 @@ def test_override_abi_method_name():
 
     mspec = ABIReturnSubroutine(abi_meth, overriding_name="add").method_spec().dictify()
     assert mspec["name"] == "add"
+
+    @ABIReturnSubroutine.name_override("overriden_add")
+    def abi_meth_2(a: pt.abi.Uint64, b: pt.abi.Uint64, *, output: pt.abi.Uint64):
+        return output.set(a.get() + b.get())
+
+    mspec = abi_meth_2.method_spec().dictify()
+    assert mspec["name"] == "overriden_add"


### PR DESCRIPTION
In response of this thread: https://github.com/algorand/pyteal/pull/550#discussion_r990196093, we created this PR into #550 for more documentation and testcases that reflect the decorator constructor `name_override` does override the default name of `ABIReturnSubroutine`.