### PR TITLE
Minor changes for internal consistency

### DIFF
--- a/pyteal/ast/assert_.py
+++ b/pyteal/ast/assert_.py
@@ -62,7 +62,7 @@ class Assert(Expr):
         return condStart, end
 
     def __str__(self):
-        return "(Assert {})".format(self.cond)
+        return f"(Assert [{', '.join([str(cond) for cond in self.cond])}])"
 
     def type_of(self):
         return TealType.none

--- a/pyteal/ast/global_.py
+++ b/pyteal/ast/global_.py
@@ -19,13 +19,13 @@ class GlobalField(Enum):
     logic_sig_version = (5, "LogicSigVersion", TealType.uint64, 2)
     round = (6, "Round", TealType.uint64, 2)
     latest_timestamp = (7, "LatestTimestamp", TealType.uint64, 2)
-    current_app_id = (8, "CurrentApplicationID", TealType.uint64, 2)
+    current_application_id = (8, "CurrentApplicationID", TealType.uint64, 2)
     creator_address = (9, "CreatorAddress", TealType.bytes, 3)
-    current_app_address = (10, "CurrentApplicationAddress", TealType.bytes, 5)
+    current_application_address = (10, "CurrentApplicationAddress", TealType.bytes, 5)
     group_id = (11, "GroupID", TealType.bytes, 5)
     opcode_budget = (12, "OpcodeBudget", TealType.uint64, 6)
-    caller_app_id = (13, "CallerApplicationID", TealType.uint64, 6)
-    caller_app_address = (14, "CallerApplicationAddress", TealType.bytes, 6)
+    caller_application_id = (13, "CallerApplicationID", TealType.uint64, 6)
+    caller_application_address = (14, "CallerApplicationAddress", TealType.bytes, 6)
 
     def __init__(self, id: int, name: str, type: TealType, min_version: int) -> None:
         self.id = id
@@ -109,7 +109,7 @@ class Global(LeafExpr):
         """Get the ID of the current application executing.
 
         Fails during Signature mode."""
-        return cls(GlobalField.current_app_id)
+        return cls(GlobalField.current_application_id)
 
     @classmethod
     def creator_address(cls) -> "Global":
@@ -123,7 +123,7 @@ class Global(LeafExpr):
         """Get the address of that the current application controls.
 
         Fails during Signature mode. Requires program version 5 or higher."""
-        return cls(GlobalField.current_app_address)
+        return cls(GlobalField.current_application_address)
 
     @classmethod
     def group_id(cls) -> "Global":
@@ -148,7 +148,7 @@ class Global(LeafExpr):
         If not called from another app, this will return 0
 
         Requires program version 6 or higher."""
-        return cls(GlobalField.caller_app_id)
+        return cls(GlobalField.caller_application_id)
 
     @classmethod
     def caller_app_address(cls) -> "Global":
@@ -157,7 +157,7 @@ class Global(LeafExpr):
         If not called from another app, this will return the ZeroAddress
 
         Requires program version 6 or higher."""
-        return cls(GlobalField.caller_app_address)
+        return cls(GlobalField.caller_application_address)
 
 
 Global.__module__ = "pyteal"

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -733,6 +733,10 @@ class TxnObject:
         """
         return self.makeTxnExpr(TxnField.created_application_id)
 
+    def num_app_args(self) -> TxnExpr:
+        """Get the number of application arguments sent with a transaction."""
+        return self.makeTxnExpr(TxnField.num_app_args)
+
     def last_log(self) -> TxnExpr:
         """A convenience method for getting the last logged message from a transaction.
 


### PR DESCRIPTION
Working on something else I noticed we didn't provide direct access to the `num_app_args` Txn pseudo-field 

Currently we can still get this information with `Txn.application_args.length` so maybe this is by design? 

Other changes are:

-  Use the full name of the global field accessors instead of shortening application, the API stays the same when using the methods.
 - `__str__` method of assert should print out each of the conditions instead of the list 