### PR TITLE
Applying `type_spec_abi_is_assignable_to` to `ABI` computed type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Changed
 * Subroutines that take ABI type of Transaction now allow any Transaction type to be passed. ([#531](https://github.com/algorand/pyteal/pull/531))
 * Relaxing exact type check in `InnerTxnFieldExpr.MethodCall` by applying `abi.type_spec_is_assignable_to`. ([#561](https://github.com/algorand/pyteal/pull/561))
+* Relaxing exact type check in `abi` package by applying `abi.type_spec_is_assignable_to`. ([#567](https://github.com/algorand/pyteal/pull/567))
 
 # 0.18.1
 

--- a/pyteal/ast/abi/address.py
+++ b/pyteal/ast/abi/address.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Union, Sequence, Literal, cast
+from typing import Sequence, Literal, cast
 from collections.abc import Sequence as CollectionSequence
 
 from pyteal.errors import TealInputError
@@ -59,16 +59,14 @@ class Address(StaticArray[Byte, Literal[AddressLength.Bytes]]):
         """
         return self.stored_value.load()
 
-    def set(
+    def set(  # type: ignore[override]
         self,
-        value: Union[
-            str,
-            bytes,
-            Expr,
-            Sequence[Byte],
-            "Address",
-            ComputedValue["Address"],
-        ],
+        value: str
+        | bytes
+        | Expr
+        | Sequence[Byte]
+        | "Address"
+        | ComputedValue["Address"],
     ):
         """Set the value of this Address to the input value.
 

--- a/pyteal/ast/abi/address.py
+++ b/pyteal/ast/abi/address.py
@@ -93,6 +93,7 @@ class Address(StaticArray[Byte, Literal[AddressLength.Bytes]]):
 
         match value:
             case ComputedValue():
+                # TODO need to see again if we need to change on type system or not, _set_with_computed_type?
                 pts = value.produced_type_spec()
                 if pts == AddressTypeSpec() or pts == StaticArrayTypeSpec(
                     ByteTypeSpec(), AddressLength.Bytes
@@ -103,6 +104,7 @@ class Address(StaticArray[Byte, Literal[AddressLength.Bytes]]):
                     f"Got ComputedValue with type spec {pts}, expected AddressTypeSpec or StaticArray[Byte, Literal[AddressLength.Bytes]]"
                 )
             case BaseType():
+                # TODO need to see again if we need to change on type system or not
                 if (
                     value.type_spec() == AddressTypeSpec()
                     or value.type_spec()

--- a/pyteal/ast/abi/address_test.py
+++ b/pyteal/ast/abi/address_test.py
@@ -112,34 +112,6 @@ def test_Address_get():
     assert actual == expected
 
 
-def test_Address_set_StaticArray():
-    value_to_set = abi.StaticArray(
-        abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), abi.AddressLength.Bytes)
-    )
-    value = abi.Address()
-    expr = value.set(value_to_set)
-    assert expr.type_of() == pt.TealType.none
-    assert not expr.has_return()
-
-    expected = pt.TealSimpleBlock(
-        [
-            pt.TealOp(None, pt.Op.load, value_to_set.stored_value.slot),
-            pt.TealOp(None, pt.Op.store, value.stored_value.slot),
-        ]
-    )
-
-    actual, _ = expr.__teal__(options)
-    actual.addIncoming()
-    actual = pt.TealBlock.NormalizeBlocks(actual)
-
-    with pt.TealComponent.Context.ignoreExprEquality():
-        assert actual == expected
-
-    with pytest.raises(pt.TealInputError):
-        bogus = abi.StaticArray(abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 10))
-        value.set(bogus)
-
-
 def test_Address_set_str():
     for value_to_set in ("CEZZTYHNTVIZFZWT6X2R474Z2P3Q2DAZAKIRTPBAHL3LZ7W4O6VBROVRQA",):
         value = abi.Address()

--- a/pyteal/ast/abi/array_base.py
+++ b/pyteal/ast/abi/array_base.py
@@ -125,8 +125,12 @@ class Array(BaseType, Generic[T]):
             A PyTeal expression that stores encoded sequence of ABI values in its internal
             ScratchVar.
         """
+        from pyteal.ast.abi.util import type_spec_is_assignable_to
+
         for index, value in enumerate(values):
-            if self.type_spec().value_type_spec() != value.type_spec():
+            if not type_spec_is_assignable_to(
+                value.type_spec(), self.type_spec().value_type_spec()
+            ):
                 raise TealInputError(
                     "Cannot assign type {} at index {} to {}".format(
                         value.type_spec(),
@@ -220,7 +224,11 @@ class ArrayElement(ComputedValue[T]):
         Returns:
             An expression that stores the byte string of the array element into value `output`.
         """
-        if output.type_spec() != self.produced_type_spec():
+        from pyteal.ast.abi.util import type_spec_is_assignable_to
+
+        if not type_spec_is_assignable_to(
+            self.produced_type_spec(), output.type_spec()
+        ):
             raise TealInputError("Output type does not match value type")
 
         encodedArray = self.array.encode()

--- a/pyteal/ast/abi/array_dynamic.py
+++ b/pyteal/ast/abi/array_dynamic.py
@@ -71,11 +71,12 @@ class DynamicArray(Array[T]):
         Returns:
             An expression which stores the given value into this DynamicArray.
         """
+        from pyteal.ast.abi.util import type_spec_is_assignable_to
 
         if isinstance(values, ComputedValue):
             return self._set_with_computed_type(values)
         elif isinstance(values, BaseType):
-            if self.type_spec() != values.type_spec():
+            if not type_spec_is_assignable_to(values.type_spec(), self.type_spec()):
                 raise TealInputError(
                     f"Cannot assign type {values.type_spec()} to {self.type_spec()}"
                 )

--- a/pyteal/ast/abi/array_static.py
+++ b/pyteal/ast/abi/array_static.py
@@ -102,10 +102,12 @@ class StaticArray(Array[T], Generic[T, N]):
         Returns:
             An expression which stores the given value into this StaticArray.
         """
+        from pyteal.ast.abi.util import type_spec_is_assignable_to
+
         if isinstance(values, ComputedValue):
             return self._set_with_computed_type(values)
         elif isinstance(values, BaseType):
-            if self.type_spec() != values.type_spec():
+            if not type_spec_is_assignable_to(values.type_spec(), self.type_spec()):
                 raise TealInputError(
                     f"Cannot assign type {values.type_spec()} to {self.type_spec()}"
                 )

--- a/pyteal/ast/abi/bool.py
+++ b/pyteal/ast/abi/bool.py
@@ -68,6 +68,8 @@ class Bool(BaseType):
         Returns:
             An expression which stores the given value into this Bool.
         """
+        from pyteal.ast.abi.util import type_spec_is_assignable_to
+
         if isinstance(value, ComputedValue):
             return self._set_with_computed_type(value)
 
@@ -77,7 +79,7 @@ class Bool(BaseType):
             checked = True
 
         if isinstance(value, BaseType):
-            if value.type_spec() != self.type_spec():
+            if not type_spec_is_assignable_to(value.type_spec(), self.type_spec()):
                 raise TealInputError(
                     "Cannot set type bool to {}".format(value.type_spec())
                 )

--- a/pyteal/ast/abi/string.py
+++ b/pyteal/ast/abi/string.py
@@ -103,13 +103,13 @@ class String(DynamicArray[Byte]):
             An expression which stores the given value into this String.
         """
 
+        from pyteal.ast.abi.util import type_spec_is_assignable_to
+
         match value:
             case ComputedValue():
                 return self._set_with_computed_type(value)
             case BaseType():
-                if value.type_spec() == StringTypeSpec() or (
-                    value.type_spec() == DynamicArrayTypeSpec(ByteTypeSpec())
-                ):
+                if type_spec_is_assignable_to(value.type_spec(), StringTypeSpec()):
                     return self.stored_value.store(value.stored_value.load())
 
                 raise TealInputError(

--- a/pyteal/ast/abi/tuple.py
+++ b/pyteal/ast/abi/tuple.py
@@ -120,6 +120,8 @@ def _encode_tuple(values: Sequence[BaseType]) -> Expr:
 def _index_tuple(
     value_types: Sequence[TypeSpec], encoded: Expr, index: int, output: BaseType
 ) -> Expr:
+    from pyteal.ast.abi.util import type_spec_is_assignable_to
+
     if not (0 <= index < len(value_types)):
         raise ValueError("Index outside of range")
 
@@ -146,7 +148,7 @@ def _index_tuple(
         offset += typeBefore.byte_length_static()
 
     valueType = value_types[index]
-    if output.type_spec() != valueType:
+    if not type_spec_is_assignable_to(valueType, output.type_spec()):
         raise TypeError("Output type does not match value type")
 
     if type(output) is Bool:

--- a/pyteal/ast/abi/type.py
+++ b/pyteal/ast/abi/type.py
@@ -135,10 +135,12 @@ class BaseType(ABC):
         pass
 
     def _set_with_computed_type(self, value: "ComputedValue[BaseType]") -> Expr:
-        target_type_spec = value.produced_type_spec()
-        if self.type_spec() != target_type_spec:
+        from pyteal.ast.abi.util import type_spec_is_assignable_to
+
+        value_type_spec = value.produced_type_spec()
+        if not type_spec_is_assignable_to(value_type_spec, self.type_spec()):
             raise TealInputError(
-                f"Cannot set {self.type_spec()} with ComputedType of {target_type_spec}"
+                f"Cannot set {self.type_spec()} with ComputedType of {value_type_spec}"
             )
         return value.store_into(self)
 
@@ -215,7 +217,11 @@ class ReturnedValue(ComputedValue):
         return self.type_spec
 
     def store_into(self, output: BaseType) -> Expr:
-        if output.type_spec() != self.produced_type_spec():
+        from pyteal.ast.abi.util import type_spec_is_assignable_to
+
+        if not type_spec_is_assignable_to(
+            self.produced_type_spec(), output.type_spec()
+        ):
             raise TealInputError(
                 f"expected type_spec {self.produced_type_spec()} but get {output.type_spec()}"
             )

--- a/pyteal/ast/abi/util.py
+++ b/pyteal/ast/abi/util.py
@@ -514,22 +514,22 @@ def type_spec_is_assignable_to(a: TypeSpec, b: TypeSpec) -> bool:
 
     Some examples are illustrated as following:
 
-    =========================== =========================== ============= ====================================================================
+    =========================== =========================== ============= =========================================================================
     Type :code:`a`              Type :code:`b`              Assignable?   Reason
-    =========================== =========================== ============= ====================================================================
+    =========================== =========================== ============= =========================================================================
     :code:`DynamicArray[Byte]`  :code:`DynamicBytes`        :code:`True`  :code:`DynamicBytes` is as general as :code:`DynamicArray[Byte]`
     :code:`DynamicBytes`        :code:`DynamicArray[Byte]`  :code:`True`  :code:`DynamicArray[Byte]` is as general as :code:`DynamicBytes`
     :code:`StaticArray[Byte,N]` :code:`StaticBytes[N]`      :code:`True`  :code:`StaticBytes[N]` is as general as :code:`StaticArray[Byte,N]`
     :code:`StaticBytes[N]`      :code:`StaticArray[Byte,N]` :code:`True`  :code:`StaticArray[Byte,N]` is as general as :code:`StaticBytes[N]`
     :code:`String`              :code:`DynamicBytes`        :code:`True`  :code:`DynamicBytes` is more general than :code:`String`
     :code:`DynamicBytes`        :code:`String`              :code:`False` :code:`String` is more specific than :code:`DynamicBytes`
-    :code:`Address`             :code:`StaticBytes[32]`     :code:`True`  :code:`StaticBytes[32]` is more general than :code:`Address`
-    :code:`StaticBytes[32]`     :code:`Address`             :code:`False` :code:`Address` is more specific than :code:`StaticBytes[32]`
+    :code:`Address`             :code:`StaticBytes[32]`     :code:`False` :code:`StaticBytes[32]` cannot compare generality against :code:`Address`
+    :code:`StaticBytes[32]`     :code:`Address`             :code:`False` :code:`Address` cannot compare generality against :code:`StaticBytes[32]`
     :code:`PaymentTransaction`  :code:`Transaction`         :code:`True`  :code:`Transaction` is more general than :code:`PaymentTransaction`
     :code:`Transaction`         :code:`PaymentTransaction`  :code:`False` :code:`PaymentTransaction` is more specific than :code`Transaction`
     :code:`Uint8`               :code:`Byte`                :code:`True`  :code:`Uint8` is as general as :code:`Byte`
     :code:`Byte`                :code:`Uint8`               :code:`True`  :code:`Byte` is as general as :code:`Uint8`
-    =========================== =========================== ============= ====================================================================
+    =========================== =========================== ============= =========================================================================
 
     Args:
         a: The abi.TypeSpec of the value on the right hand side of the assignment.
@@ -569,10 +569,9 @@ def type_spec_is_assignable_to(a: TypeSpec, b: TypeSpec) -> bool:
                 return False
             match a, b:
                 case AddressTypeSpec(), StaticArrayTypeSpec():
-                    a, b = cast(AddressTypeSpec, a), cast(StaticArrayTypeSpec, b)
-                    return a.length_static() == b.length_static()
+                    return str(a) == str(b)
                 case StaticArrayTypeSpec(), AddressTypeSpec():
-                    return False
+                    return str(a) == str(b)
                 case StaticArrayTypeSpec(), StaticArrayTypeSpec():
                     a, b = cast(StaticArrayTypeSpec, a), cast(StaticArrayTypeSpec, b)
                     return a.length_static() == b.length_static()

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -920,8 +920,8 @@ SAFE_ASSIGNMENT_TEST_CASES: list[SafeAssignment] = [
         [abi.type_spec_from_annotation(NamedTDecl)],
     ),
     SafeAssignment(
-        abi.AddressTypeSpec(),
-        [abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 32), abi.StaticBytesTypeSpec(32)],
+        abi.StaticArrayTypeSpec(abi.StringTypeSpec(), 10),
+        [abi.StaticArrayTypeSpec(abi.DynamicBytesTypeSpec(), 10)],
     ),
 ] + [
     SafeAssignment(spec, [abi.TransactionTypeSpec()])
@@ -950,13 +950,17 @@ def test_type_spec_is_assignable_safe_assignment_full_coverage(ts: type):
         return False
 
     # Abstract types and types without safe assignments should _not_ appear in test cases.
-    # These typespecs are only assignable to themselves, and that forms a bidirectional assignment.
+    # These typespecs are either:
+    # - only assignable to themselves, and that forms a bidirectional assignment, or
+    # - only bidirectionally assignable to other types.
     # Otherwise, they are unsafe bidirectional with all the other non-abstract typespecs.
     if isabstract(ts) or ts in {
         abi.AccountTypeSpec,
         abi.ApplicationTypeSpec,
         abi.AssetTypeSpec,
         abi.BoolTypeSpec,
+        abi.AddressTypeSpec,
+        abi.StaticBytesTypeSpec,
         abi.ByteTypeSpec,
         abi.Uint8TypeSpec,
         abi.Uint16TypeSpec,
@@ -993,6 +997,12 @@ UNSAFE_BIDIRECTIONAL_TEST_CASES: list[UnsafeBidirectional] = [
     ),
     UnsafeBidirectional(
         [abi.DynamicBytesTypeSpec(), abi.DynamicArrayTypeSpec(abi.Uint16TypeSpec())]
+    ),
+    UnsafeBidirectional(
+        [abi.AddressTypeSpec(), abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 32)],
+    ),
+    UnsafeBidirectional(
+        [abi.AddressTypeSpec(), abi.StaticBytesTypeSpec(32)],
     ),
     UnsafeBidirectional(
         [abi.StaticBytesTypeSpec(7), abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 11)]

--- a/pyteal/ast/abi/util_test.py
+++ b/pyteal/ast/abi/util_test.py
@@ -840,9 +840,9 @@ SAFE_BIDIRECTIONAL_TEST_CASES: list[SafeBidirectional] = (
                         abi.Transaction,
                     ]
                 ),
-                abi.type_spec_from_annotation(NamedTDecl),
             ]
         ),
+        SafeBidirectional([abi.type_spec_from_annotation(NamedTDecl)]),
     ]
     + [
         SafeBidirectional([spec])
@@ -890,6 +890,10 @@ SAFE_ASSIGNMENT_TEST_CASES: list[SafeAssignment] = [
         [abi.DynamicBytesTypeSpec(), abi.DynamicArrayTypeSpec(abi.ByteTypeSpec())],
     ),
     SafeAssignment(
+        abi.AddressTypeSpec(),
+        [abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 32), abi.StaticBytesTypeSpec(32)],
+    ),
+    SafeAssignment(
         abi.type_spec_from_annotation(NamedTDecl),
         [
             abi.type_spec_from_annotation(
@@ -906,18 +910,20 @@ SAFE_ASSIGNMENT_TEST_CASES: list[SafeAssignment] = [
         ],
     ),
     SafeAssignment(
-        abi.type_spec_from_annotation(
-            abi.Tuple3[
-                abi.Uint64,
+        abi.type_spec_from_annotation(NamedTDecl),
+        [
+            abi.type_spec_from_annotation(
                 abi.Tuple3[
-                    abi.PaymentTransaction,
-                    abi.Address,
-                    abi.StaticArray[abi.Byte, Literal[16]],
-                ],
-                abi.PaymentTransaction,
-            ]
-        ),
-        [abi.type_spec_from_annotation(NamedTDecl)],
+                    abi.Uint64,
+                    abi.Tuple3[
+                        abi.PaymentTransaction,
+                        abi.Address,
+                        abi.StaticArray[abi.Byte, Literal[16]],
+                    ],
+                    abi.Transaction,
+                ]
+            ),
+        ],
     ),
     SafeAssignment(
         abi.StaticArrayTypeSpec(abi.StringTypeSpec(), 10),
@@ -950,17 +956,13 @@ def test_type_spec_is_assignable_safe_assignment_full_coverage(ts: type):
         return False
 
     # Abstract types and types without safe assignments should _not_ appear in test cases.
-    # These typespecs are either:
-    # - only assignable to themselves, and that forms a bidirectional assignment, or
-    # - only bidirectionally assignable to other types.
+    # These typespecs are only assignable to themselves, and that forms a bidirectional assignment.
     # Otherwise, they are unsafe bidirectional with all the other non-abstract typespecs.
     if isabstract(ts) or ts in {
         abi.AccountTypeSpec,
         abi.ApplicationTypeSpec,
         abi.AssetTypeSpec,
         abi.BoolTypeSpec,
-        abi.AddressTypeSpec,
-        abi.StaticBytesTypeSpec,
         abi.ByteTypeSpec,
         abi.Uint8TypeSpec,
         abi.Uint16TypeSpec,
@@ -997,12 +999,6 @@ UNSAFE_BIDIRECTIONAL_TEST_CASES: list[UnsafeBidirectional] = [
     ),
     UnsafeBidirectional(
         [abi.DynamicBytesTypeSpec(), abi.DynamicArrayTypeSpec(abi.Uint16TypeSpec())]
-    ),
-    UnsafeBidirectional(
-        [abi.AddressTypeSpec(), abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 32)],
-    ),
-    UnsafeBidirectional(
-        [abi.AddressTypeSpec(), abi.StaticBytesTypeSpec(32)],
     ),
     UnsafeBidirectional(
         [abi.StaticBytesTypeSpec(7), abi.StaticArrayTypeSpec(abi.ByteTypeSpec(), 11)]


### PR DESCRIPTION
lifting strict equality type spec check to relaxed type check