### PR TITLE
Simplify build by switching from docker-compose to docker compose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,27 +44,6 @@ jobs:
           expected="${{ matrix.python }}"
           echo $installed
           [[ $installed =~ "Python ${expected}" ]] && echo "Configured Python" || (echo "Failed to configure Python" && exit 1)
-      - name: Local ACT Only - Install required os level applications
-        if: ${{ env.ACT }}
-        run: |
-          sudo apt update -y
-          sudo apt install -y curl
-          sudo apt -y install ca-certificates curl gnupg lsb-release
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt update
-          sudo apt -y install docker-ce docker-ce-cli containerd.io
-          sudo curl -L "https://github.com/docker/compose/releases/download/v2.11.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-          docker-compose --version
-      - name: Upgrade docker compose
-        run: |
-          sudo curl -SL "https://github.com/docker/compose/releases/download/v2.11.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-          docker-compose --version
       - name: Create sandbox
         run: make sandbox-dev-up
       - name: Install python dependencies

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ lint-and-test: check-generate-init lint test-unit
 # ---- Integration Tests (algod required) ---- #
 
 sandbox-dev-up:
-	docker-compose up -d algod --wait
+	docker compose up -d algod --wait
 
 sandbox-dev-stop:
-	docker-compose stop algod
+	docker compose stop algod
 
 integration-run:
 	pytest -n $(NUM_PROCS) --durations=10 -sv tests/integration


### PR DESCRIPTION
Proposes a build simplification by switching from `docker-compose` to `docker compose`.  Using `docker compose` removes the need for various build customizations.

I no longer recall _why_ the build uses `docker-compose`.   In any event, it's deprecated and I see no reason to keep using it (https://stackoverflow.com/questions/66514436/difference-between-docker-compose-and-docker-compose).

To confirm act still works, I tested locally via `act --container-architecture linux/amd64 -j run-integration-tests`.