### PR TITLE
Rename make commands to reflect move from sandbox to wwinder/algod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,14 +65,14 @@ jobs:
           sudo chmod +x /usr/local/bin/docker-compose
           sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
           docker-compose --version
-      - name: Create sandbox
-        run: make sandbox-dev-up
+      - name: Start algod
+        run: make algod-start
       - name: Install python dependencies
         run: make setup-development
       - name: Integration Tests Only
         run: make test-integration
-      - name: Stop running images
-        run: make sandbox-dev-stop
+      - name: Stop algod
+        run: make algod-stop
 
   build-docset:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ lint-and-test: check-generate-init lint test-unit
 
 # ---- Integration Tests (algod required) ---- #
 
-sandbox-dev-up:
+algod-start:
 	docker-compose up -d algod --wait
 
-sandbox-dev-stop:
+algod-stop:
 	docker-compose stop algod
 
 integration-run:


### PR DESCRIPTION
Extends #568 with an optional rename to rename `make` commands based on the move away from sandbox.

Treat optionally - Feel welcomed to close if we prefer as is.