### PR TITLE
Improve OpUp testing

### DIFF
--- a/pyteal/ast/opup.py
+++ b/pyteal/ast/opup.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, cast
 from pyteal.ast.app import OnComplete
 from pyteal.errors import TealInputError, TealTypeError
 from pyteal.ast.while_ import While
@@ -99,15 +99,14 @@ class OpUp:
                     "target_app_id must be specified in Explicit OpUp mode"
                 )
             require_type(target_app_id, TealType.uint64)
-            self.target_app_id = target_app_id
         elif mode == OpUpMode.OnCall:
             if target_app_id is not None:
                 raise TealInputError("target_app_id is not used in OnCall OpUp mode")
-            self.target_app_id = None
         else:
             raise TealInputError("Invalid OpUp mode provided")
 
         self.mode = mode
+        self.target_app_id = target_app_id
 
     def _construct_itxn(self, inner_fee: Optional[Expr]) -> Expr:
         fields: dict[TxnField, Expr | list[Expr]] = {
@@ -121,7 +120,7 @@ class OpUp:
             fields[TxnField.fee] = inner_fee
 
         if self.mode == OpUpMode.Explicit:
-            fields |= {TxnField.application_id: self.target_app_id}
+            fields |= {TxnField.application_id: cast(Expr, self.target_app_id)}
         else:
             fields |= {
                 TxnField.on_completion: OnComplete.DeleteApplication,

--- a/pyteal/ast/opup.py
+++ b/pyteal/ast/opup.py
@@ -103,6 +103,7 @@ class OpUp:
         elif mode == OpUpMode.OnCall:
             if target_app_id is not None:
                 raise TealInputError("target_app_id is not used in OnCall OpUp mode")
+            self.target_app_id = None
         else:
             raise TealInputError("Invalid OpUp mode provided")
 

--- a/pyteal/ast/opup_test.py
+++ b/pyteal/ast/opup_test.py
@@ -179,7 +179,7 @@ def test_OpUp_ensure_budget(
 
     with pytest.raises(pt.TealTypeError):
         opup.ensure_budget(
-            required_budget=required_budget, fee_source=pt.Bytes("fee_src")
+            required_budget=required_budget, fee_source=pt.Bytes("fee_src")  # type: ignore[arg-type]
         )
 
 
@@ -224,4 +224,4 @@ def test_OpUp_maximize_budget(
         opup.maximize_budget(fee=pt.Bytes("fee"))
 
     with pytest.raises(pt.TealTypeError):
-        opup.maximize_budget(fee=fee, fee_source=pt.Bytes("fee_src"))
+        opup.maximize_budget(fee=fee, fee_source=pt.Bytes("fee_src"))  # type: ignore[arg-type]

--- a/pyteal/ast/opup_test.py
+++ b/pyteal/ast/opup_test.py
@@ -1,124 +1,227 @@
 import pytest
-
-from pyteal.ast.opup import OpUp, OpUpFeeSource, OpUpMode
+from typing import NamedTuple
 
 import pyteal as pt
 
+avm6Options = pt.CompileOptions(version=6)
 
-def test_opup_explicit():
-    mode = OpUpMode.Explicit
-    with pytest.raises(pt.TealInputError) as err:
-        opup = OpUp(mode)
-    assert "target_app_id must be specified in Explicit OpUp mode" in str(err.value)
+
+def test_OpUp_init():
+    app_id = pt.Int(1)
+    opup_explicit = pt.OpUp(pt.OpUpMode.Explicit, target_app_id=app_id)
+    assert opup_explicit.mode is pt.OpUpMode.Explicit
+    assert opup_explicit.target_app_id is app_id
+
+    with pytest.raises(
+        pt.TealInputError, match="target_app_id must be specified in Explicit OpUp mode"
+    ):
+        pt.OpUp(pt.OpUpMode.Explicit)
 
     with pytest.raises(pt.TealTypeError):
-        opup = OpUp(mode, target_app_id=pt.Bytes("appid"))
+        pt.OpUp(pt.OpUpMode.Explicit, target_app_id=pt.Bytes("appid"))
 
-    opup = OpUp(mode, target_app_id=pt.Int(1))
+    opup_oncall = pt.OpUp(pt.OpUpMode.OnCall)
+    assert opup_oncall.mode is pt.OpUpMode.OnCall
+    assert opup_oncall.target_app_id is None
+
+    with pytest.raises(
+        pt.TealInputError, match="target_app_id is not used in OnCall OpUp mode"
+    ):
+        pt.OpUp(pt.OpUpMode.OnCall, target_app_id=app_id)
+
+    with pytest.raises(pt.TealInputError, match="Invalid OpUp mode provided"):
+        pt.OpUp(None)
+
+
+class OpUpTest(NamedTuple):
+    opup: pt.OpUp
+    fee_source: pt.OpUpFeeSource | None
+    expected_inner_fields: dict[pt.TxnField, pt.Expr | list[pt.Expr]]
+
+
+OP_UP_TEST_CASES: list[OpUpTest] = [
+    OpUpTest(
+        opup=pt.OpUp(pt.OpUpMode.Explicit, target_app_id=pt.Int(9)),
+        fee_source=None,
+        expected_inner_fields={
+            pt.TxnField.type_enum: pt.TxnType.ApplicationCall,
+            pt.TxnField.application_id: pt.Int(9),
+        },
+    ),
+    OpUpTest(
+        opup=pt.OpUp(pt.OpUpMode.Explicit, target_app_id=pt.Int(876)),
+        fee_source=pt.OpUpFeeSource.Any,
+        expected_inner_fields={
+            pt.TxnField.type_enum: pt.TxnType.ApplicationCall,
+            pt.TxnField.application_id: pt.Int(876),
+        },
+    ),
+    OpUpTest(
+        opup=pt.OpUp(pt.OpUpMode.Explicit, target_app_id=pt.Int(1000001)),
+        fee_source=pt.OpUpFeeSource.GroupCredit,
+        expected_inner_fields={
+            pt.TxnField.type_enum: pt.TxnType.ApplicationCall,
+            pt.TxnField.fee: pt.Int(0),
+            pt.TxnField.application_id: pt.Int(1000001),
+        },
+    ),
+    OpUpTest(
+        opup=pt.OpUp(pt.OpUpMode.Explicit, target_app_id=pt.Int(3)),
+        fee_source=pt.OpUpFeeSource.AppAccount,
+        expected_inner_fields={
+            pt.TxnField.type_enum: pt.TxnType.ApplicationCall,
+            pt.TxnField.fee: pt.Global.min_txn_fee(),
+            pt.TxnField.application_id: pt.Int(3),
+        },
+    ),
+    OpUpTest(
+        opup=pt.OpUp(pt.OpUpMode.OnCall),
+        fee_source=None,
+        expected_inner_fields={
+            pt.TxnField.type_enum: pt.TxnType.ApplicationCall,
+            pt.TxnField.on_completion: pt.OnComplete.DeleteApplication,
+            pt.TxnField.approval_program: pt.Bytes("base16", "068101"),
+            pt.TxnField.clear_state_program: pt.Bytes("base16", "068101"),
+        },
+    ),
+    OpUpTest(
+        opup=pt.OpUp(pt.OpUpMode.OnCall),
+        fee_source=pt.OpUpFeeSource.Any,
+        expected_inner_fields={
+            pt.TxnField.type_enum: pt.TxnType.ApplicationCall,
+            pt.TxnField.on_completion: pt.OnComplete.DeleteApplication,
+            pt.TxnField.approval_program: pt.Bytes("base16", "068101"),
+            pt.TxnField.clear_state_program: pt.Bytes("base16", "068101"),
+        },
+    ),
+    OpUpTest(
+        opup=pt.OpUp(pt.OpUpMode.OnCall),
+        fee_source=pt.OpUpFeeSource.GroupCredit,
+        expected_inner_fields={
+            pt.TxnField.type_enum: pt.TxnType.ApplicationCall,
+            pt.TxnField.fee: pt.Int(0),
+            pt.TxnField.on_completion: pt.OnComplete.DeleteApplication,
+            pt.TxnField.approval_program: pt.Bytes("base16", "068101"),
+            pt.TxnField.clear_state_program: pt.Bytes("base16", "068101"),
+        },
+    ),
+    OpUpTest(
+        opup=pt.OpUp(pt.OpUpMode.OnCall),
+        fee_source=pt.OpUpFeeSource.AppAccount,
+        expected_inner_fields={
+            pt.TxnField.type_enum: pt.TxnType.ApplicationCall,
+            pt.TxnField.fee: pt.Global.min_txn_fee(),
+            pt.TxnField.on_completion: pt.OnComplete.DeleteApplication,
+            pt.TxnField.approval_program: pt.Bytes("base16", "068101"),
+            pt.TxnField.clear_state_program: pt.Bytes("base16", "068101"),
+        },
+    ),
+]
+
+
+def test_OP_UP_TEST_CASES_is_exhaustive():
+    fee_sources: list[pt.OpUpFeeSource | None] = [fs for fs in pt.OpUpFeeSource]
+    fee_sources.append(None)
+
+    for mode, fee_source in zip(pt.OpUpMode, fee_sources):
+        found_combination = False
+
+        for test_case in OP_UP_TEST_CASES:
+            if test_case.opup.mode is mode and test_case.fee_source is fee_source:
+                found_combination = True
+                break
+
+        assert (
+            found_combination
+        ), f"Combination not found in test cases: mode={mode}, fee_source={fee_source}"
+
+
+@pytest.mark.parametrize("opup, fee_source, expected_inner_fields", OP_UP_TEST_CASES)
+def test_OpUp_ensure_budget(
+    opup: pt.OpUp,
+    fee_source: pt.OpUpFeeSource | None,
+    expected_inner_fields: dict[pt.TxnField, pt.Expr | list[pt.Expr]],
+):
+    required_budget = pt.Int(777)
+    expr = (
+        opup.ensure_budget(required_budget)
+        if fee_source is None
+        else opup.ensure_budget(required_budget, fee_source)
+    )
+    assert expr.type_of() == pt.TealType.none
+    assert expr.has_return() is False
+
+    intermediate_value = pt.ScratchVar()
+    expected_expr = pt.Seq(
+        intermediate_value.store(required_budget + pt.Int(10)),
+        pt.While(intermediate_value.load() > pt.Global.opcode_budget()).Do(
+            pt.InnerTxnBuilder.Execute(expected_inner_fields)
+        ),
+    )
+    expected, _ = expected_expr.__teal__(avm6Options)
+    expected.addIncoming()
+    expected = pt.TealBlock.NormalizeBlocks(expected)
+
+    actual, _ = expr.__teal__(avm6Options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    with pt.TealComponent.Context.ignoreScratchSlotEquality(), pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+    assert pt.TealBlock.MatchScratchSlotReferences(
+        pt.TealBlock.GetReferencedScratchSlots(actual),
+        pt.TealBlock.GetReferencedScratchSlots(expected),
+    )
 
     with pytest.raises(pt.TealTypeError):
         opup.ensure_budget(required_budget=pt.Bytes("budget"))
 
     with pytest.raises(pt.TealTypeError):
         opup.ensure_budget(
-            required_budget=pt.Int(1_000), fee_source=pt.Bytes("fee_src")
+            required_budget=required_budget, fee_source=pt.Bytes("fee_src")
         )
+
+
+@pytest.mark.parametrize("opup, fee_source, expected_inner_fields", OP_UP_TEST_CASES)
+def test_OpUp_maximize_budget(
+    opup: pt.OpUp,
+    fee_source: pt.OpUpFeeSource | None,
+    expected_inner_fields: dict[pt.TxnField, pt.Expr | list[pt.Expr]],
+):
+    fee = pt.Int(12345)
+    expr = (
+        opup.maximize_budget(fee)
+        if fee_source is None
+        else opup.maximize_budget(fee, fee_source)
+    )
+    assert expr.type_of() == pt.TealType.none
+    assert expr.has_return() is False
+
+    intermediate_value = pt.ScratchVar()
+    expected_expr = pt.For(
+        intermediate_value.store(pt.Int(0)),
+        intermediate_value.load() < fee / pt.Global.min_txn_fee(),
+        intermediate_value.store(intermediate_value.load() + pt.Int(1)),
+    ).Do(pt.InnerTxnBuilder.Execute(expected_inner_fields))
+    expected, _ = expected_expr.__teal__(avm6Options)
+    expected.addIncoming()
+    expected = pt.TealBlock.NormalizeBlocks(expected)
+
+    actual, _ = expr.__teal__(avm6Options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    with pt.TealComponent.Context.ignoreScratchSlotEquality(), pt.TealComponent.Context.ignoreExprEquality():
+        assert actual == expected
+
+    assert pt.TealBlock.MatchScratchSlotReferences(
+        pt.TealBlock.GetReferencedScratchSlots(actual),
+        pt.TealBlock.GetReferencedScratchSlots(expected),
+    )
 
     with pytest.raises(pt.TealTypeError):
         opup.maximize_budget(fee=pt.Bytes("fee"))
 
     with pytest.raises(pt.TealTypeError):
-        opup.maximize_budget(fee=pt.Int(1_000), fee_source=pt.Bytes("fee_src"))
-
-    assert opup.target_app_id == pt.Int(1)
-
-    # verify correct usage doesn't cause an error
-    opup = OpUp(mode, target_app_id=pt.Int(1))
-    _ = pt.Seq(
-        opup.ensure_budget(required_budget=pt.Int(500) + pt.Int(1000)),
-        pt.Return(pt.Int(1)),
-    )
-    _ = pt.Seq(
-        opup.ensure_budget(
-            required_budget=pt.Int(500) + pt.Int(1000), fee_source=OpUpFeeSource.Any
-        ),
-        pt.Return(pt.Int(1)),
-    )
-
-    opup = OpUp(mode, target_app_id=pt.Int(1))
-    _ = pt.Seq(
-        opup.maximize_budget(fee=pt.Txn.fee() - pt.Int(100)), pt.Return(pt.Int(1))
-    )
-    _ = pt.Seq(
-        opup.maximize_budget(
-            fee=pt.Txn.fee() - pt.Int(100), fee_source=OpUpFeeSource.Any
-        ),
-        pt.Return(pt.Int(1)),
-    )
-    _ = pt.Seq(
-        opup.maximize_budget(
-            fee=pt.Txn.fee() - pt.Int(100), fee_source=OpUpFeeSource.GroupCredit
-        ),
-        pt.Return(pt.Int(1)),
-    )
-    _ = pt.Seq(
-        opup.maximize_budget(
-            fee=pt.Txn.fee() - pt.Int(100), fee_source=OpUpFeeSource.AppAccount
-        ),
-        pt.Return(pt.Int(1)),
-    )
-
-
-def test_opup_oncall():
-    mode = OpUpMode.OnCall
-    opup = OpUp(mode)
-
-    with pytest.raises(pt.TealTypeError):
-        opup.ensure_budget(required_budget=pt.Bytes("budget"))
-
-    with pytest.raises(pt.TealTypeError):
-        opup.ensure_budget(
-            required_budget=pt.Int(1_000), fee_source=pt.Bytes("fee_src")
-        )
-
-    with pytest.raises(pt.TealTypeError):
-        opup.maximize_budget(fee=pt.Bytes("fee"))
-
-    with pytest.raises(pt.TealTypeError):
-        opup.maximize_budget(fee=pt.Int(1_000), fee_source=pt.Bytes("fee_src"))
-
-    # verify correct usage doesn't cause an error
-    opup = OpUp(mode)
-    _ = pt.Seq(
-        opup.ensure_budget(required_budget=pt.Int(500) + pt.Int(1000)),
-        pt.Return(pt.Int(1)),
-    )
-    _ = pt.Seq(
-        opup.ensure_budget(
-            required_budget=pt.Int(500) + pt.Int(1000), fee_source=OpUpFeeSource.Any
-        ),
-        pt.Return(pt.Int(1)),
-    )
-
-    opup = OpUp(mode)
-    _ = pt.Seq(
-        opup.maximize_budget(fee=pt.Txn.fee() - pt.Int(100)), pt.Return(pt.Int(1))
-    )
-    _ = pt.Seq(
-        opup.maximize_budget(
-            fee=pt.Txn.fee() - pt.Int(100), fee_source=OpUpFeeSource.Any
-        ),
-        pt.Return(pt.Int(1)),
-    )
-    _ = pt.Seq(
-        opup.maximize_budget(
-            fee=pt.Txn.fee() - pt.Int(100), fee_source=OpUpFeeSource.GroupCredit
-        ),
-        pt.Return(pt.Int(1)),
-    )
-    _ = pt.Seq(
-        opup.maximize_budget(
-            fee=pt.Txn.fee() - pt.Int(100), fee_source=OpUpFeeSource.AppAccount
-        ),
-        pt.Return(pt.Int(1)),
-    )
+        opup.maximize_budget(fee=fee, fee_source=pt.Bytes("fee_src"))


### PR DESCRIPTION
Child PR to #566

This PR enhances the OpUp tests by transforming expressions to the IR and comparing to expected results, like we do for other operations.

This is especially useful with the improvements from #566, since that adds more complexity to the existing operations.