### PR TITLE
Compile time failure for chained comparison expressions

### DIFF
--- a/pyteal/ast/expr.py
+++ b/pyteal/ast/expr.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Tuple, List, TYPE_CHECKING
 
 from pyteal.types import TealType
+from pyteal.errors import TealInternalError
 from pyteal.ir import TealBlock, TealSimpleBlock
 
 if TYPE_CHECKING:
@@ -128,6 +129,9 @@ class Expr(ABC):
         from pyteal.ast.binaryexpr import ShiftRight
 
         return ShiftRight(self, other)
+
+    def __bool__(self):
+        raise TealInternalError("Cannot coerce Expr to bool")
 
     def And(self, other: "Expr") -> "Expr":
         """Take the logical And of this expression and another one.

--- a/pyteal/ast/if_.py
+++ b/pyteal/ast/if_.py
@@ -36,8 +36,8 @@ class If(Expr):
         # Flag to denote and check whether the new If().Then() syntax is being used
         self.alternateSyntaxFlag = False
 
-        if thenBranch:
-            if elseBranch:
+        if thenBranch is not None:
+            if elseBranch is not None:
                 require_type(thenBranch, elseBranch.type_of())
             else:
                 # If there is only a thenBranch, then it should evaluate to none type
@@ -106,7 +106,7 @@ class If(Expr):
 
         thenBranch = _use_seq_if_multiple(thenBranch, *then_branch_multi)
 
-        if not self.elseBranch:
+        if self.elseBranch is None:
             self.thenBranch = thenBranch
         else:
             if not isinstance(self.elseBranch, If):
@@ -118,7 +118,7 @@ class If(Expr):
         if not self.alternateSyntaxFlag:
             raise TealInputError("Cannot mix two different If syntax styles")
 
-        if not self.elseBranch:
+        if self.elseBranch is None:
             self.elseBranch = If(cond)
         else:
             if not isinstance(self.elseBranch, If):
@@ -130,12 +130,12 @@ class If(Expr):
         if not self.alternateSyntaxFlag:
             raise TealInputError("Cannot mix two different If syntax styles")
 
-        if not self.thenBranch:
+        if self.thenBranch is None:
             raise TealInputError("Must set Then branch before Else branch")
 
         elseBranch = _use_seq_if_multiple(elseBranch, *else_branch_multi)
 
-        if not self.elseBranch:
+        if self.elseBranch is None:
             require_type(elseBranch, self.thenBranch.type_of())
             self.elseBranch = elseBranch
         else:

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -144,7 +144,7 @@ class OnCompleteAction:
     call_config: CallConfig = field(kw_only=True, default=CallConfig.NEVER)
 
     def __post_init__(self):
-        if bool(self.call_config) ^ bool(self.action):
+        if (self.call_config == CallConfig.NEVER) ^ (self.action is None):
             raise TealInputError(
                 f"action {self.action} and call_config {self.call_config!r} contradicts"
             )
@@ -172,7 +172,7 @@ class OnCompleteAction:
         return OnCompleteAction(action=f, call_config=CallConfig.ALL)
 
     def is_empty(self) -> bool:
-        return not self.action and self.call_config == CallConfig.NEVER
+        return self.action is None and self.call_config == CallConfig.NEVER
 
 
 OnCompleteAction.__module__ = "pyteal"
@@ -528,7 +528,7 @@ class Router:
 
         if bare_calls and not bare_calls.is_empty():
             bare_call_approval = bare_calls.approval_construction()
-            if bare_call_approval:
+            if bare_call_approval is not None:
                 self.approval_ast.conditions_n_branches.append(
                     CondNode(
                         Txn.application_args.length() == Int(0),
@@ -536,7 +536,7 @@ class Router:
                     )
                 )
             bare_call_clear = bare_calls.clear_state_construction()
-            if bare_call_clear:
+            if bare_call_clear is not None:
                 self.clear_state_ast.conditions_n_branches.append(
                     CondNode(
                         Txn.application_args.length() == Int(0),

--- a/pyteal/ast/scratch.py
+++ b/pyteal/ast/scratch.py
@@ -122,7 +122,7 @@ class ScratchLoad(Expr):
                 "Exactly one of slot or index_expressions must be provided"
             )
 
-        if index_expression:
+        if index_expression is not None:
             if not isinstance(index_expression, Expr):
                 raise TealInputError(
                     "index_expression must be an Expr but was of type {}".format(
@@ -185,7 +185,7 @@ class ScratchStore(Expr):
                 "Exactly one of slot or index_expressions must be provided"
             )
 
-        if index_expression:
+        if index_expression is not None:
             if not isinstance(index_expression, Expr):
                 raise TealInputError(
                     "index_expression must be an Expr but was of type {}".format(

--- a/tests/blackbox.py
+++ b/tests/blackbox.py
@@ -309,7 +309,7 @@ class PyTealDryRunExecutor:
             *(self._arg_prep_n_call(i, p) for i, p in enumerate(self.input_types))
         ]
         preps, calls = zip(*preps_n_calls) if preps_n_calls else ([], [])
-        preps = [p for p in preps if p]
+        preps = [p for p in preps if p is not None]
         return preps, calls
 
     def _handle_SubroutineFnWrapper(self):


### PR DESCRIPTION
@tzaffi pointed out that the code `Int(1) != Int(2) == Int(3)` is valid Python, yet it produces an unexpected result.

The [Python docs](https://docs.python.org/3/reference/expressions.html#comparisons) explain that a chained comparison of the form `a op b op c` should result in `a op b and b op c`. Yet for the above example, we actually get `Int(2) == Int(3)` (and this may rely on undefined behavior).

The core problem is that Python uses the native `and` operator to combine chained comparisons. Since this operator cannot be override, we can't produce correct code for chained comparisons in PyTeal.

This PR contains a potential solution to the issue by forbidding chained comparisons. It makes `Expr.__bool__` raise an error, which means using the native `and` operator on two PyTeal expressions is no longer possible.

To get this out of draft status, the following are needed:
- [ ] Unit tests to ensure the forbidden behavior actually produces the right error
- [ ] Thorough investigation of the codebase to ensure that all of our expression boolean coercion has been changed. I only found and changed what our unit tests cover, which may not be everything.
- [ ] Consideration for whether this changes breaks expected behavior for our consumers. If we commonly coerced expressions to booleans, perhaps our users do as well.