### PR TITLE
allow app id to be none since it may be called during create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Fixed
+* Allowing the `MethodCall` and `ExecuteMethodCall` to be passed `None` as app_id argument in the case of an app create transaction ([#592](https://github.com/algorand/pyteal/pull/592))
+
+
 # 0.20.1
 
 ## Added

--- a/pyteal/ast/itxn.py
+++ b/pyteal/ast/itxn.py
@@ -1,7 +1,7 @@
 from enum import Enum
 import algosdk
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, Optional
 from pyteal.ast.int import EnumInt
 from pyteal.ast.for_ import For
 from pyteal.ast.int import Int
@@ -253,10 +253,10 @@ class InnerTxnBuilder:
     def ExecuteMethodCall(
         cls,
         *,
-        app_id: Expr,
+        app_id: Optional[Expr],
         method_signature: str,
         args: list[abi.BaseType | Expr | dict[TxnField, Expr | list[Expr]]],
-        extra_fields: dict[TxnField, Expr | list[Expr]] = None,
+        extra_fields: Optional[dict[TxnField, Expr | list[Expr]]] = None,
     ) -> Expr:
         """Performs a single app call transaction formatted as an ABI method call.
 
@@ -311,10 +311,10 @@ class InnerTxnBuilder:
     def MethodCall(
         cls,
         *,
-        app_id: Expr,
+        app_id: Optional[Expr],
         method_signature: str,
         args: list[abi.BaseType | Expr | dict[TxnField, Expr | list[Expr]]],
-        extra_fields: dict[TxnField, Expr | list[Expr]] = None,
+        extra_fields: Optional[dict[TxnField, Expr | list[Expr]]] = None,
     ) -> Expr:
         """Adds an ABI method call transaction to the current inner transaction group.
 

--- a/pyteal/ast/itxn.py
+++ b/pyteal/ast/itxn.py
@@ -277,6 +277,7 @@ class InnerTxnBuilder:
 
         Args:
             app_id: An expression that evaluates to a `TealType.uint64` corresponding to the application being called.
+                If the call is meant to create an application, the value `None` should be passed
             method_signature: A string representing the method signature of the method we're calling. This is used to do
                 type checking on the arguments passed and to create the method selector passed as the first argument.
             args: A list of arguments to pass to the application. The values in this list depend on the kind of argument you wish to pass:
@@ -323,6 +324,7 @@ class InnerTxnBuilder:
 
         Args:
             app_id: An expression that evaluates to a `TealType.uint64` corresponding to the application being called.
+                If the call is meant to create an application, the value `None` should be passed
             method_signature: A string representing the method signature of the method we're calling. This is used to do
                 type checking on the arguments passed and to create the method selector passed as the first argument.
             args: A list of arguments to pass to the application. The values in this list depend on the kind of argument you wish to pass:
@@ -344,13 +346,15 @@ class InnerTxnBuilder:
 
         from pyteal.ast.abi.util import type_spec_is_assignable_to
 
-        require_type(app_id, TealType.uint64)
-
-        # Default, always need these
+        # Start collecting the fields we'd like to set
         fields_to_set = [
             cls.SetField(TxnField.type_enum, TxnType.ApplicationCall),
-            cls.SetField(TxnField.application_id, app_id),
         ]
+
+        # In the case of an app create, the `app_id` arg may be `None`
+        if app_id is not None:
+            require_type(app_id, TealType.uint64)
+            fields_to_set.append(cls.SetField(TxnField.application_id, app_id))
 
         # We only care about the args
         arg_type_specs: list[abi.TypeSpec]

--- a/pyteal/ast/itxn.py
+++ b/pyteal/ast/itxn.py
@@ -1,7 +1,7 @@
 from enum import Enum
 import algosdk
 
-from typing import TYPE_CHECKING, cast, Optional
+from typing import TYPE_CHECKING, cast
 from pyteal.ast.int import EnumInt
 from pyteal.ast.for_ import For
 from pyteal.ast.int import Int
@@ -253,10 +253,10 @@ class InnerTxnBuilder:
     def ExecuteMethodCall(
         cls,
         *,
-        app_id: Optional[Expr],
+        app_id: Expr | None,
         method_signature: str,
         args: list[abi.BaseType | Expr | dict[TxnField, Expr | list[Expr]]],
-        extra_fields: Optional[dict[TxnField, Expr | list[Expr]]] = None,
+        extra_fields: dict[TxnField, Expr | list[Expr]] | None = None,
     ) -> Expr:
         """Performs a single app call transaction formatted as an ABI method call.
 
@@ -311,10 +311,10 @@ class InnerTxnBuilder:
     def MethodCall(
         cls,
         *,
-        app_id: Optional[Expr],
+        app_id: Expr | None,
         method_signature: str,
         args: list[abi.BaseType | Expr | dict[TxnField, Expr | list[Expr]]],
-        extra_fields: Optional[dict[TxnField, Expr | list[Expr]]] = None,
+        extra_fields: dict[TxnField, Expr | list[Expr]] | None = None,
     ) -> Expr:
         """Adds an ABI method call transaction to the current inner transaction group.
 

--- a/pyteal/ast/itxn_test.py
+++ b/pyteal/ast/itxn_test.py
@@ -330,6 +330,27 @@ ITXN_METHOD_CASES = (
         ),
         None,
     ),
+    # App create case
+    (
+        None,
+        "create(byte[],uint64)void",
+        [t6_1 := pt.abi.DynamicBytes(), t6_2 := pt.abi.Uint64()],
+        {TxnField.fee: pt.Int(0)},
+        pt.Seq(
+            pt.InnerTxnBuilder.SetFields(
+                {
+                    pt.TxnField.type_enum: TxnType.ApplicationCall,
+                    pt.TxnField.application_args: [
+                        pt.MethodSignature("create(byte[],uint64)void"),
+                        t6_1.encode(),
+                        t6_2.encode(),
+                    ],
+                    pt.TxnField.fee: pt.Int(0),
+                }
+            ),
+        ),
+        None,
+    ),
     # Error cases
     (
         pt.Int(1),


### PR DESCRIPTION
While answering a question in the forum, I realized I'd not considered the case where a MethodCall may be used to create an application. 

Since the AVM doesn't like the manual setting of AppId 0, we should allow app_id to be None and prevent setting the app id field