### PR TITLE
Fail Releasing when version isn't set correctly in `setup.py`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,10 +77,26 @@ jobs:
           name: pyteal.docset
           path: docs/pyteal.docset.tar.gz
 
+  validate-release:
+    runs-on: ubuntu-20.04
+    container: python:3.10
+    needs: ['build-test']
+    strategy:
+      matrix:
+        python: [ "3.10" ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Validate Release
+        run: make fail-if-unreleasable
+
+
   upload-to-pypi:
     runs-on: ubuntu-20.04
     container: python:3.10
-    needs: ['build-test', 'run-integration-tests', 'build-docset']
+    needs: ['build-test', 'validate-release', 'run-integration-tests', 'build-docset']
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     steps:
       - name: Check out code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  build-test:
+  build:
     runs-on: ubuntu-20.04
     container: python:${{ matrix.python }}
     strategy:
@@ -22,6 +22,15 @@ jobs:
           fetch-depth: 0
       - name: Install python dependencies
         run: make setup-development
+
+  build-test:
+    runs-on: ubuntu-20.04
+    container: python:${{ matrix.python }}
+    needs: ['build']
+    strategy:
+      matrix:
+        python: ["3.10"]
+    steps:
       - name: Build and Test
         run: make lint-and-test
 
@@ -80,7 +89,7 @@ jobs:
   validate-release:
     runs-on: ubuntu-20.04
     container: python:3.10
-    needs: ['build-test']
+    needs: ['build']
     strategy:
       matrix:
         python: [ "3.10" ]
@@ -96,7 +105,7 @@ jobs:
   upload-to-pypi:
     runs-on: ubuntu-20.04
     container: python:3.10
-    needs: ['build-test', 'validate-release', 'run-integration-tests', 'build-docset']
+    needs: ['validate-release', 'build-test', 'run-integration-tests', 'build-docset']
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     steps:
       - name: Check out code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  build:
+  build-test:
     runs-on: ubuntu-20.04
     container: python:${{ matrix.python }}
     strategy:
@@ -22,15 +22,6 @@ jobs:
           fetch-depth: 0
       - name: Install python dependencies
         run: make setup-development
-
-  build-test:
-    runs-on: ubuntu-20.04
-    container: python:${{ matrix.python }}
-    needs: ['build']
-    strategy:
-      matrix:
-        python: ["3.10"]
-    steps:
       - name: Build and Test
         run: make lint-and-test
 
@@ -89,7 +80,6 @@ jobs:
   validate-release:
     runs-on: ubuntu-20.04
     container: python:3.10
-    needs: ['build']
     strategy:
       matrix:
         python: [ "3.10" ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,7 @@ jobs:
   validate-release:
     runs-on: ubuntu-20.04
     container: python:3.10
-    strategy:
-      matrix:
-        python: [ "3.10" ]
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,25 @@
 # ---- Setup ---- #
 LOCAL_VERSION := "$(shell python setup.py --version)"
 REMOTE_VERSION := "$(lastword $(shell pip index versions pyteal))"
+RELEASEABLE := echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; print(0) if sys.argv[-2].split('.') <= sys.argv[-1].split('.') else print(1)"
+COND := 1
 
-releasable-version:
-ifeq ($(REMOTE_VERSION), $(LOCAL_VERSION))
-	@$(error Cannot release as remote version = local version = $(LOCAL_VERSION))
-else
-	@echo "COPACETIC"
-endif
+echo:
+	echo $(RELEASEABLE)
+
+# releasable-version:
+# ifeq ($(REMOTE_VERSION), $(LOCAL_VERSION))
+# 	@$(error Cannot release as remote version = local version = $(LOCAL_VERSION))
+# else
+# 	@echo "COPACETIC"
+# endif
+
+# releaseable-version:
+# 	$(ifeq ($(strip $(RELEASEABLE)), 1) ,,$(error Cannot release as remote version = $(REMOTE_VERSION) >= local version = $(LOCAL_VERSION)))
+
+fail-if-unreleasable:
+	@echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; a=sys.argv; f=lambda s: list(map(int, s.split('.'))); assert (x:=f(a[-2])) > (y:=f(a[-1])), f'cannot release as local={x} v. pipy={y}'"
+
 
 setup-development:
 	pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 LOCAL_VERSION := "$(shell python setup.py --version)"
 REMOTE_VERSION := "$(lastword $(shell pip index versions pyteal))"
 RELEASEABLE := echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; print(0) if sys.argv[-2].split('.') <= sys.argv[-1].split('.') else print(1)"
-COND := 1
 
 echo:
 	echo $(RELEASEABLE)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
 # ---- Setup ---- #
+LOCAL_VERSION := "$(shell python setup.py --version)"
+REMOTE_VERSION := "$(lastword $(shell pip index versions pyteal))"
+
+releasable-version:
+ifeq ($(REMOTE_VERSION), $(LOCAL_VERSION))
+	@$(error Cannot release as remote version = local version = $(LOCAL_VERSION))
+else
+	@echo "COPACETIC"
+endif
 
 setup-development:
 	pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ echo:
 
 fail-if-unreleasable:
 	@echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; a=sys.argv; f=lambda s: list(map(int, s.split('.'))); assert (x:=f(a[-2])) > (y:=f(a[-1])), f'cannot release as local={x} v. pipy={y}'"
+	@echo "You're all good to go. Enjoy releasing new_version=$(LOCAL_VERSION) (> pypi=$(REMOTE_VERSION))"
 
 
 setup-development:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # ---- Setup ---- #
 LOCAL_VERSION := "$(shell python setup.py --version)"
-REMOTE_VERSION := "$(lastword $(shell pip index versions pyteal))"
+REMOTE_VERSION := "$(shell pip index versions pyteal | xargs python -c 'import sys; a=sys.argv; print(".".join(map(str, max(map(lambda s: list(map(lambda i: int(i) if i.isnumeric() else -1, s.replace(",", "").split("."))), sys.argv)))))' )"
 
 fail-if-unreleasable:
+	@echo "VALIDATING new_version=$(LOCAL_VERSION) vs. pypi=$(REMOTE_VERSION)"
 	@echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; a=sys.argv; f=lambda s: list(map(int, s.split('.'))); assert (x:=f(a[-2])) > (y:=f(a[-1])), f'cannot release as local={x} v. pipy={y}'"
 	@echo "You're all good to go. Enjoy releasing new_version=$(LOCAL_VERSION) (> pypi=$(REMOTE_VERSION))"
 
@@ -83,11 +84,10 @@ all-tests: lint-and-test test-integration
 
 ACT_JOB = run-integration-tests
 local-gh-job:
-	act -j $(ACT_JOB)
+	act -j "$(ACT_JOB)"
 
 local-gh-simulate:
 	act
-
 
 # ---- Extras ---- #
 

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,6 @@
 LOCAL_VERSION := "$(shell python setup.py --version)"
 REMOTE_VERSION := "$(lastword $(shell pip index versions pyteal))"
 
-
-# RELEASEABLE := echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; print(0) if sys.argv[-2].split('.') <= sys.argv[-1].split('.') else print(1)"
-
-# echo:
-# 	echo $(RELEASEABLE)
-
-# releasable-version:
-# ifeq ($(REMOTE_VERSION), $(LOCAL_VERSION))
-# 	@$(error Cannot release as remote version = local version = $(LOCAL_VERSION))
-# else
-# 	@echo "COPACETIC"
-# endif
-
-# releaseable-version:
-# 	$(ifeq ($(strip $(RELEASEABLE)), 1) ,,$(error Cannot release as remote version = $(REMOTE_VERSION) >= local version = $(LOCAL_VERSION)))
-
 fail-if-unreleasable:
 	@echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; a=sys.argv; f=lambda s: list(map(int, s.split('.'))); assert (x:=f(a[-2])) > (y:=f(a[-1])), f'cannot release as local={x} v. pipy={y}'"
 	@echo "You're all good to go. Enjoy releasing new_version=$(LOCAL_VERSION) (> pypi=$(REMOTE_VERSION))"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 # ---- Setup ---- #
 LOCAL_VERSION := "$(shell python setup.py --version)"
 REMOTE_VERSION := "$(lastword $(shell pip index versions pyteal))"
-RELEASEABLE := echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; print(0) if sys.argv[-2].split('.') <= sys.argv[-1].split('.') else print(1)"
 
-echo:
-	echo $(RELEASEABLE)
+
+# RELEASEABLE := echo "$(LOCAL_VERSION) $(REMOTE_VERSION)" | xargs python -c "import sys; print(0) if sys.argv[-2].split('.') <= sys.argv[-1].split('.') else print(1)"
+
+# echo:
+# 	echo $(RELEASEABLE)
 
 # releasable-version:
 # ifeq ($(REMOTE_VERSION), $(LOCAL_VERSION))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyteal",
-    version="0.20.1",
+    version="0.20.2",
     author="Algorand",
     author_email="pypiservice@algorand.com",
     description="Algorand Smart Contracts in Python",


### PR DESCRIPTION
# Use `make fail-if-unreleasable`

### When `setup.py` version _is GREATER THAN_ PyPi's version
```sh
❯ make fail-if-unreleasable
... some annoying ignorable warnings ...
You're all good to go. Enjoy releasing new_version=0.20.2 (> pypi=0.20.1)
```

### When `setup.py` version _is NOT GREATER THAN_ PyPi's version

```sh
❯ make fail-if-unreleasable
... some annoying ignorable warnings ...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError: cannot release as local=[0, 20, 1] v. pipy=[0, 20, 1]
make: *** [fail-if-unreleasable] Error 1
```

## Testing Locally via `act` simulator:
Before running the following, comment out the line `if: ...` in the `validate-release:` section of `.github/workflows/build.yml`

```sh
❯ make local-gh-job ACT_JOB=validate-release
```