### PR TITLE
Add graviton tests for OpUp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ algod-stop:
 	docker compose stop algod
 
 integration-run:
-	pytest -n $(NUM_PROCS) --durations=10 -sv tests/integration
+	pytest -n $(NUM_PROCS) --durations=10 -sv tests/integration -m "not serial"
+	pytest --durations=10 -sv tests/integration -m serial
 
 test-integration: integration-run
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    serial: marks tests requiring serial execution

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -119,7 +119,11 @@ def test_opup_maximize_budget(
 def test_opup_ensure_budget(
     source: pt.OpUpFeeSource, budget_added: int, with_funding: bool
 ):
-    inner_txn_count = int(budget_added / _application_opcode_budget) + 1 if budget_added % _application_opcode_budget == 0 else math.ceil(budget_added / _application_opcode_budget)
+    inner_txn_count = (
+        int(budget_added / _application_opcode_budget) + 1
+        if budget_added % _application_opcode_budget == 0
+        else math.ceil(budget_added / _application_opcode_budget)
+    )
 
     innerTxnFeeMicroAlgos = (
         inner_txn_count * algosdk.constants.min_txn_fee + algosdk.constants.min_txn_fee

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -51,6 +51,7 @@ def _expected_execution_cost_ops(
 @pytest.mark.parametrize("source", pt.OpUpFeeSource)
 @pytest.mark.parametrize("inner_txn_count", range(1, 5))
 @pytest.mark.parametrize("with_funding", [True, False])
+@pytest.mark.serial  # Serial due to reused account + application state
 def test_opup_maximize_budget(
     source: pt.OpUpFeeSource, inner_txn_count: int, with_funding: bool
 ):
@@ -116,6 +117,7 @@ def test_opup_maximize_budget(
 @pytest.mark.parametrize("source", [f for f in pt.OpUpFeeSource])
 @pytest.mark.parametrize("budget_added", range(0, 12_000, 2_000))
 @pytest.mark.parametrize("with_funding", [True, False])
+@pytest.mark.serial  # Serial due to reused account + application state
 def test_opup_ensure_budget(
     source: pt.OpUpFeeSource, budget_added: int, with_funding: bool
 ):

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -79,7 +79,7 @@ def test_opup_maximize_budget(
         sp = DryRunExecutor.SUGGESTED_PARAMS
         sp.fee = (
             innerTxnFeeMicroAlgos + algosdk.constants.min_txn_fee
-            if pt.OpUpFeeSource.GroupCredit
+            if source == pt.OpUpFeeSource.GroupCredit
             else sp.fee
         )
 
@@ -138,7 +138,7 @@ def test_opup_ensure_budget(
         sp = DryRunExecutor.SUGGESTED_PARAMS
         sp.fee = (
             innerTxnFeeMicroAlgos + algosdk.constants.min_txn_fee
-            if pt.OpUpFeeSource.GroupCredit
+            if source == pt.OpUpFeeSource.GroupCredit
             else sp.fee
         )
 

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -1,0 +1,166 @@
+import graviton.models
+import pytest
+import math
+
+from typing import cast
+import pyteal as pt
+from tests.blackbox import (
+    Blackbox,
+    PyTealDryRunExecutor,
+)
+import tests
+from graviton.blackbox import DryRunExecutor, DryRunInspector, ExecutionMode
+from tests.blackbox import BlackboxWrapper
+
+from algosdk.v2client.models import Account
+import algosdk
+
+
+def _dryrun(
+    bw: BlackboxWrapper,
+    sp: algosdk.future.transaction.SuggestedParams,
+    accounts: list[Account],
+) -> DryRunInspector:
+    e = PyTealDryRunExecutor(bw, pt.Mode.Application)
+    return DryRunExecutor.execute_one_dryrun(
+        tests.blackbox.algod_with_assertion(),
+        e.compile(pt.compiler.MAX_PROGRAM_VERSION),
+        [],
+        ExecutionMode.Application,
+        e.abi_argument_types(),
+        e.abi_return_type(),
+        txn_params=DryRunExecutor.transaction_params(
+            sender=graviton.models.ZERO_ADDRESS,
+            sp=sp,
+            index=DryRunExecutor.EXISTING_APP_CALL,
+            on_complete=algosdk.future.transaction.OnComplete.NoOpOC,
+        ),
+        accounts=accounts,
+    )
+
+
+_application_opcode_budget = 700
+
+
+@pytest.mark.parametrize("source", [f for f in pt.OpUpFeeSource])
+@pytest.mark.parametrize("inner_txn_count", list(range(1, 5)))
+@pytest.mark.parametrize("with_funding", [True, False])
+def test_opup_maximize_budget(
+    source: pt.OpUpFeeSource, inner_txn_count: int, with_funding: bool
+):
+    innerTxnFeeMicroAlgos = inner_txn_count * algosdk.constants.min_txn_fee
+
+    @Blackbox(input_types=[])
+    @pt.Subroutine(pt.TealType.uint64)
+    def maximize_budget():
+        return pt.Seq(
+            pt.OpUp(mode=pt.OpUpMode.OnCall).maximize_budget(
+                pt.Int(innerTxnFeeMicroAlgos), source
+            ),
+            pt.Global.opcode_budget(),
+        )
+
+    if with_funding:
+        accounts = (
+            [
+                Account(
+                    address=algosdk.logic.get_application_address(
+                        DryRunExecutor.EXISTING_APP_CALL
+                    ),
+                    status="Offline",
+                    amount=innerTxnFeeMicroAlgos,
+                    amount_without_pending_rewards=innerTxnFeeMicroAlgos,
+                )
+            ]
+            if source == pt.OpUpFeeSource.AppAccount
+            else []
+        )
+
+        sp = DryRunExecutor.SUGGESTED_PARAMS
+        sp.fee = (
+            innerTxnFeeMicroAlgos + algosdk.constants.min_txn_fee
+            if pt.OpUpFeeSource.GroupCredit
+            else sp.fee
+        )
+
+        result = _dryrun(maximize_budget, sp, accounts)
+
+        assert result.passed()
+        assert result.budget_added() == _application_opcode_budget * inner_txn_count
+    else:
+        # Withholding account and/or transaction fee funding fails the
+        # transaction.
+        sp = DryRunExecutor.SUGGESTED_PARAMS
+        sp.flat_fee = True
+        sp.fee = algosdk.constants.min_txn_fee
+        result = _dryrun(maximize_budget, DryRunExecutor.SUGGESTED_PARAMS, [])
+        assert not result.passed()
+
+
+@pytest.mark.parametrize("source", [f for f in pt.OpUpFeeSource])
+@pytest.mark.parametrize("budget_added", list(range(1_000, 20_000, 2_500)))
+@pytest.mark.parametrize("with_funding", [True, False])
+def test_opup_ensure_budget(
+    source: pt.OpUpFeeSource, budget_added: int, with_funding: bool
+):
+    inner_txn_count = math.ceil(budget_added / _application_opcode_budget)
+    innerTxnFeeMicroAlgos = (
+        inner_txn_count * algosdk.constants.min_txn_fee + algosdk.constants.min_txn_fee
+    )
+    dryrun_starting_budget = 70_000  # https://github.com/algorand/go-algorand/blob/3a5e5847bebc21bfcae1f5fe056a78067b16c781/daemon/algod/api/server/v2/dryrun.go#L408
+
+    @Blackbox(input_types=[])
+    @pt.Subroutine(pt.TealType.uint64)
+    def ensure_budget():
+        return pt.Seq(
+            pt.OpUp(mode=pt.OpUpMode.OnCall).ensure_budget(
+                pt.Int(dryrun_starting_budget + budget_added), source
+            ),
+            pt.Global.opcode_budget(),
+        )
+
+    if with_funding:
+        accounts = (
+            [
+                Account(
+                    address=algosdk.logic.get_application_address(
+                        DryRunExecutor.EXISTING_APP_CALL
+                    ),
+                    status="Offline",
+                    amount=innerTxnFeeMicroAlgos,
+                    amount_without_pending_rewards=innerTxnFeeMicroAlgos,
+                )
+            ]
+            if source == pt.OpUpFeeSource.AppAccount
+            else []
+        )
+
+        sp = DryRunExecutor.SUGGESTED_PARAMS
+        sp.fee = (
+            innerTxnFeeMicroAlgos + algosdk.constants.min_txn_fee
+            if pt.OpUpFeeSource.GroupCredit
+            else sp.fee
+        )
+
+        result = _dryrun(ensure_budget, sp, accounts)
+
+        assert result.passed(), result.report()
+        # Since ensure_budget guarantees _at least_ the required budget, the
+        # assertions confirm minimum expected budget added without significantly
+        # overshooting the mark.
+        assert (
+            cast(int, result.budget_added())
+            >= _application_opcode_budget * inner_txn_count
+        )
+        assert (
+            cast(int, result.budget_added())
+            <= _application_opcode_budget * inner_txn_count + _application_opcode_budget
+        )
+    else:
+        # Withholding account and/or transaction fee funding fails the
+        # transaction.
+        sp = DryRunExecutor.SUGGESTED_PARAMS
+        sp.flat_fee = True
+        sp.fee = algosdk.constants.min_txn_fee
+        result = _dryrun(ensure_budget, DryRunExecutor.SUGGESTED_PARAMS, [])
+        assert not result.passed()

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -6,11 +6,11 @@ from typing import cast
 import pyteal as pt
 from tests.blackbox import (
     Blackbox,
+    BlackboxWrapper,
     PyTealDryRunExecutor,
 )
 import tests
 from graviton.blackbox import DryRunExecutor, DryRunInspector, ExecutionMode
-from tests.blackbox import BlackboxWrapper
 
 from algosdk.v2client.models import Account
 import algosdk

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -43,7 +43,7 @@ _application_opcode_budget = 700
 
 
 @pytest.mark.parametrize("source", pt.OpUpFeeSource)
-@pytest.mark.parametrize("inner_txn_count", list(range(1, 5)))
+@pytest.mark.parametrize("inner_txn_count", range(1, 5))
 @pytest.mark.parametrize("with_funding", [True, False])
 def test_opup_maximize_budget(
     source: pt.OpUpFeeSource, inner_txn_count: int, with_funding: bool

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -42,6 +42,12 @@ def _dryrun(
 _application_opcode_budget = 700
 
 
+def _expected_execution_cost_ops(
+    base_cost_ops: int, per_transaction_cost_ops: int, inner_txn_count: int
+) -> int:
+    return base_cost_ops + inner_txn_count * per_transaction_cost_ops
+
+
 @pytest.mark.parametrize("source", pt.OpUpFeeSource)
 @pytest.mark.parametrize("inner_txn_count", range(1, 5))
 @pytest.mark.parametrize("with_funding", [True, False])
@@ -87,6 +93,16 @@ def test_opup_maximize_budget(
 
         assert result.passed()
         assert result.budget_added() == _application_opcode_budget * inner_txn_count
+
+        expected_costs = {
+            pt.OpUpFeeSource.Any: (18, 22),
+            pt.OpUpFeeSource.AppAccount: (18, 24),
+            pt.OpUpFeeSource.GroupCredit: (19, 24),
+        }
+        base, per_txn = expected_costs[source]
+        assert result.budget_consumed() == _expected_execution_cost_ops(
+            base, per_txn, inner_txn_count
+        )
     else:
         # Withholding account and/or transaction fee funding fails the
         # transaction.
@@ -98,12 +114,13 @@ def test_opup_maximize_budget(
 
 
 @pytest.mark.parametrize("source", [f for f in pt.OpUpFeeSource])
-@pytest.mark.parametrize("budget_added", range(1_000, 20_000, 2_500))
+@pytest.mark.parametrize("budget_added", range(0, 12_000, 2_000))
 @pytest.mark.parametrize("with_funding", [True, False])
 def test_opup_ensure_budget(
     source: pt.OpUpFeeSource, budget_added: int, with_funding: bool
 ):
-    inner_txn_count = math.ceil(budget_added / _application_opcode_budget)
+    inner_txn_count = int(budget_added / _application_opcode_budget) + 1 if budget_added % _application_opcode_budget == 0 else math.ceil(budget_added / _application_opcode_budget)
+
     innerTxnFeeMicroAlgos = (
         inner_txn_count * algosdk.constants.min_txn_fee + algosdk.constants.min_txn_fee
     )
@@ -151,6 +168,16 @@ def test_opup_ensure_budget(
         actual = cast(int, result.budget_added())
         threshold = _application_opcode_budget * inner_txn_count
         assert threshold <= actual <= threshold + _application_opcode_budget
+
+        expected_costs = {
+            pt.OpUpFeeSource.Any: (18, 16),
+            pt.OpUpFeeSource.AppAccount: (18, 18),
+            pt.OpUpFeeSource.GroupCredit: (18, 18),
+        }
+        base, per_txn = expected_costs[source]
+        assert result.budget_consumed() == _expected_execution_cost_ops(
+            base, per_txn, inner_txn_count
+        )
     else:
         # Withholding account and/or transaction fee funding fails the
         # transaction.

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -42,7 +42,7 @@ def _dryrun(
 _application_opcode_budget = 700
 
 
-@pytest.mark.parametrize("source", [f for f in pt.OpUpFeeSource])
+@pytest.mark.parametrize("source", pt.OpUpFeeSource)
 @pytest.mark.parametrize("inner_txn_count", list(range(1, 5)))
 @pytest.mark.parametrize("with_funding", [True, False])
 def test_opup_maximize_budget(

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -95,7 +95,6 @@ def test_opup_maximize_budget(
         sp.fee = algosdk.constants.min_txn_fee
         result = _dryrun(maximize_budget, DryRunExecutor.SUGGESTED_PARAMS, [])
         assert not result.passed()
-        assert result.budget_added() == 0
 
 
 @pytest.mark.parametrize("source", [f for f in pt.OpUpFeeSource])

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -95,6 +95,7 @@ def test_opup_maximize_budget(
         sp.fee = algosdk.constants.min_txn_fee
         result = _dryrun(maximize_budget, DryRunExecutor.SUGGESTED_PARAMS, [])
         assert not result.passed()
+        assert result.budget_added() == 0
 
 
 @pytest.mark.parametrize("source", [f for f in pt.OpUpFeeSource])
@@ -148,14 +149,9 @@ def test_opup_ensure_budget(
         # Since ensure_budget guarantees _at least_ the required budget, the
         # assertions confirm minimum expected budget added without significantly
         # overshooting the mark.
-        assert (
-            cast(int, result.budget_added())
-            >= _application_opcode_budget * inner_txn_count
-        )
-        assert (
-            cast(int, result.budget_added())
-            <= _application_opcode_budget * inner_txn_count + _application_opcode_budget
-        )
+        actual = cast(int, result.budget_added())
+        threshold = _application_opcode_budget * inner_txn_count
+        assert threshold <= actual <= threshold + _application_opcode_budget
     else:
         # Withholding account and/or transaction fee funding fails the
         # transaction.

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -98,7 +98,7 @@ def test_opup_maximize_budget(
 
 
 @pytest.mark.parametrize("source", [f for f in pt.OpUpFeeSource])
-@pytest.mark.parametrize("budget_added", list(range(1_000, 20_000, 2_500)))
+@pytest.mark.parametrize("budget_added", range(1_000, 20_000, 2_500))
 @pytest.mark.parametrize("with_funding", [True, False])
 def test_opup_ensure_budget(
     source: pt.OpUpFeeSource, budget_added: int, with_funding: bool


### PR DESCRIPTION
Adds graviton-based tests for OpUp to defend against AVM execution regressions.

Prior to the PR, pyteal contains _no_ tests proving OpUp evaluation increases opcode budget as designed.  The PR leverages https://github.com/algorand/graviton/releases/tag/v0.5.0 for asserting on `budget_added`.