### PR TITLE
`OptimizeOptions` Takes Over `frame_pointers` Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 # Changed
 * Introducing `AbstractVar` to abstract value access: store, load, and stack type. ([#584](https://github.com/algorand/pyteal/pull/584))
   * NOTE: a backwards incompatable change was imposed in this PR: previous ABI value's public member `stored_value` with type `ScratchVar`, is now changed to protected member `_stored_value` with type `AbstractVar`.
-* Starting with program version 9, defaulting `scratch_slots == True` in the `OptimizeOptions`. For versions earlier than 8, default is and remains `False`. ([#613](https://github.com/algorand/pyteal/pull/613))
+* Starting with program version 9, when `scratch_slots` flag isn't provided to `OptimizeOptions`, default to optimizing. For versions 8 and earlier the default is and remains to _not_ optimize. ([#613](https://github.com/algorand/pyteal/pull/613))
 
 # 0.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Added
 * Added frame pointer support for subroutine arguments, replacing the previous usage of scratch. ([#562](https://github.com/algorand/pyteal/pull/562))
+* Added `frame_pointers` property in `OptimizeOptions` to optimize away scratch slots during subroutine calls. This defaults to frame pointer usage when not specified. ([#613](https://github.com/algorand/pyteal/pull/613))
 
 # Fixed
 * Allowing the `MethodCall` and `ExecuteMethodCall` to be passed `None` as app_id argument in the case of an app create transaction ([#592](https://github.com/algorand/pyteal/pull/592))
@@ -9,6 +10,7 @@
 # Changed
 * Introducing `AbstractVar` to abstract value access: store, load, and stack type. ([#584](https://github.com/algorand/pyteal/pull/584))
   * NOTE: a backwards incompatable change was imposed in this PR: previous ABI value's public member `stored_value` with type `ScratchVar`, is now changed to protected member `_stored_value` with type `AbstractVar`.
+* Starting with program version 9, defaulting `scratch_slots == True` in the `OptimizeOptions`. For versions earlier than 8, default is and remains `False`. ([#613](https://github.com/algorand/pyteal/pull/613))
 
 # 0.20.1
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ local-gh-job:
 local-gh-simulate:
 	act
 
-
 # ---- Extras ---- #
 
 coverage:

--- a/docs/compiler_optimization.rst
+++ b/docs/compiler_optimization.rst
@@ -12,7 +12,7 @@ Optimizer Usage
 
 The compiler determines which optimizations to apply based on the provided :any:`OptimizeOptions` object as
 shown in the code block below. Both :any:`compileTeal` as well as the :any:`Router.compile_program` method
-can receive an `:any:optimize` parameter of type :any:`OptimizeOptions`.
+can receive an :code:`optimize` parameter of type :any:`OptimizeOptions`.
 
 
 .. code-block:: python
@@ -32,9 +32,7 @@ Default Behavior
 
 The :any:`OptimizeOptions` constructor receives keyword arguments representing flags for particular optimizations.
 If an argument is not provided to the constructor of :any:`OptimizeOptions`, a default program version dependent 
-optimization behavior is used in its place according to the table below. When no :any:`OptimizeOptions` is provided
-to :any:`compileTeal` or :any:`Router.compile_program`, all parameters conform progrem dependent defaults
-described below.
+optimization behavior is used in its place according to the table below. 
 
 
 .. list-table::
@@ -93,10 +91,19 @@ described below.
      - Frame pointers not applied
    
 
+When the :code:`optimize` parameter is omitted in :any:`compileTeal` 
+or :any:`Router.compile_program`, all parameters conform to program version dependent defaults
+as defined in the above table. For example:
+
 .. code-block:: python
 
     # apply default optimization behavior by NOT providing `OptimizeOptions`
-    # for version 9 as shown, this is equivalent to passing in 
-    # `optimize=OptimizeOptions(scratch_slots=True, frame_pointers=True)`
+    # for version 9 as shown next, this is equivalent to passing in 
+    # optimize=OptimizeOptions(scratch_slots=True, frame_pointers=True)
 
     compileTeal(approval_program(), mode=Mode.Application, version=9)
+
+    # for version 8 as shown next, this is equivalent to passing in 
+    # optimize=OptimizeOptions(scratch_slots=False, frame_pointers=True)
+
+    compileTeal(approval_program(), mode=Mode.Application, version=8)

--- a/docs/compiler_optimization.rst
+++ b/docs/compiler_optimization.rst
@@ -2,8 +2,6 @@
 
 Compiler Optimization
 ========================
-**The optimizer is at an early stage and is disabled by default. Backwards compatability cannot be
-guaranteed at this point.**
 
 The optimizer is a tool for improving performance and reducing resource consumption. In this context,
 the terms *performance* and *resource* can apply across multiple dimensions, including but not limited
@@ -13,10 +11,15 @@ Optimizer Usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The compiler determines which optimizations to apply based on the provided :any:`OptimizeOptions` object as
-shown in the code block below. The :any:`OptimizeOptions` constructor receives a set of keyword arguments 
-representing flags corresponding to particular optimizations. If arguments are not provided to the
-constructor or no :any:`OptimizeOptions` object is passed to :any:`compileTeal` then the default behavior is
-that no optimizations are applied.
+shown in the code block below. Both :any:`compileTeal` as well as the :any:`Router.compile_program` method
+can receive an `:any:optimize` parameter of type :any:`OptimizeOptions`.
+
+
+.. code-block:: python
+
+    # optimize scratch slots for all program versions (shown is version 4)
+    optimize_options = OptimizeOptions(scratch_slots=True)
+    compileTeal(approval_program(), mode=Mode.Application, version=4, optimize=optimize_options)
 
 ============================== ================================================================================ ===========================
 Optimization Flag              Description                                                                      Default
@@ -24,7 +27,76 @@ Optimization Flag              Description                                      
 :code:`scratch_slots`          A boolean describing whether or not scratch slot optimization should be applied. :code:`False`
 ============================== ================================================================================ ===========================
 
+Default Behavior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :any:`OptimizeOptions` constructor receives keyword arguments representing flags for particular optimizations.
+If an argument is not provided to the constructor of :any:`OptimizeOptions`, a default program version dependent 
+optimization behavior is used in its place according to the table below. When no :any:`OptimizeOptions` is provided
+to :any:`compileTeal` or :any:`Router.compile_program`, all parameters conform progrem dependent defaults
+described below.
+
+
+.. list-table::
+   :widths: 25 25 25 25 25
+   :header-rows: 1
+
+   * - Optimization Flag
+     - Value
+     - Interpretation
+     - Program Version
+     - Behavior
+   * - :code:`scratch_slots`
+     - :code:`None`
+     - Default
+     - ≥ 9
+     - Scratch slot optimization is applied
+   * -
+     - :code:`None`
+     - Default
+     - ≤ 8
+     - Scratch slot optimization is *not* applied
+   * -
+     - :code:`True`
+     - Enable
+     - *any*
+     - Scratch slot optimization is applied
+   * -
+     - :code:`False`
+     - Disable
+     - *any*
+     - Scratch slot optimization is *not* applied
+   * - :code:`frame_pointers`
+     - :code:`None`
+     - Default
+     - ≥ 8
+     - Frame pointers available and are therefore applied
+   * -
+     - :code:`None`
+     - Default
+     - ≤ 7
+     - Frame pointers not available and not applied
+   * -
+     - :code:`True`
+     - Enable
+     - ≥ 8
+     - Frame pointers available and applied
+   * -
+     - :code:`True`
+     - *attempt*
+     - ≤ 7
+     - An error occurs when attempting to compile as frame pointers are not available
+   * -
+     - :code:`False`
+     - Disable
+     - *any*
+     - Frame pointers not applied
+   
+
 .. code-block:: python
 
-    optimize_options = OptimizeOptions(scratch_slots=True)
-    compileTeal(approval_program(), mode=Mode.Application, version=4, optimize=optimize_options)
+    # apply default optimization behavior by NOT providing `OptimizeOptions`
+    # for version 9 as shown, this is equivalent to passing in 
+    # `optimize=OptimizeOptions(scratch_slots=True, frame_pointers=True)`
+
+    compileTeal(approval_program(), mode=Mode.Application, version=9)

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -724,7 +724,6 @@ class Router:
         version: int = DEFAULT_TEAL_VERSION,
         assemble_constants: bool = False,
         optimize: OptimizeOptions = None,
-        frame_pointers: Optional[bool] = None,
     ) -> tuple[str, str, sdk_abi.Contract]:
         """
         Constructs and compiles approval and clear-state programs from the registered methods and
@@ -750,7 +749,6 @@ class Router:
             version=version,
             assembleConstants=assemble_constants,
             optimize=optimize,
-            frame_pointers=frame_pointers,
         )
         csp_compiled = compileTeal(
             csp,
@@ -758,7 +756,6 @@ class Router:
             version=version,
             assembleConstants=assemble_constants,
             optimize=optimize,
-            frame_pointers=frame_pointers,
         )
         return ap_compiled, csp_compiled, contract
 

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -723,7 +723,7 @@ class Router:
         *,
         version: int = DEFAULT_TEAL_VERSION,
         assemble_constants: bool = False,
-        optimize: OptimizeOptions = None,
+        optimize: Optional[OptimizeOptions] = None,
     ) -> tuple[str, str, sdk_abi.Contract]:
         """
         Constructs and compiles approval and clear-state programs from the registered methods and

--- a/pyteal/ast/subroutine_test.py
+++ b/pyteal/ast/subroutine_test.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 import pyteal as pt
 from pyteal.ast.frame import Proto
 from pyteal.ast.subroutine import ABIReturnSubroutine, SubroutineEval
-from pyteal.compiler.compiler import FRAME_POINTER_VERSION
+from pyteal.compiler.compiler import FRAME_POINTERS_VERSION
 
 options = pt.CompileOptions(version=5)
 options_v8 = pt.CompileOptions(version=8)
@@ -1549,5 +1549,5 @@ def test_override_abi_method_name():
 
 def test_frame_option_version_range_well_formed():
     assert (
-        pt.Op.callsub.min_version < FRAME_POINTER_VERSION < pt.MAX_PROGRAM_VERSION + 1
+        pt.Op.callsub.min_version < FRAME_POINTERS_VERSION < pt.MAX_PROGRAM_VERSION + 1
     )

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -51,7 +51,7 @@ class CompileOptions:
         self.mode: Mode = mode
         self.version: int = version
         self.optimize: OptimizeOptions = optimize or OptimizeOptions()
-        self.use_frame_pointer: bool = self.optimize.use_frame_pointers(self.version)
+        self.use_frame_pointers: bool = self.optimize.use_frame_pointers(self.version)
 
         self.currentSubroutine: Optional[SubroutineDefinition] = None
 
@@ -158,14 +158,14 @@ def compileSubroutine(
     if (
         currentSubroutine
         and currentSubroutine.get_declaration_by_option(
-            options.use_frame_pointer
+            options.use_frame_pointers
         ).deferred_expr
     ):
         # this represents code that should be inserted before each retsub op
         deferred_expr = cast(
             Expr,
             currentSubroutine.get_declaration_by_option(
-                options.use_frame_pointer
+                options.use_frame_pointers
             ).deferred_expr,
         )
 
@@ -218,7 +218,7 @@ def compileSubroutine(
     newSubroutines = referencedSubroutines - subroutine_start_blocks.keys()
     for subroutine in sorted(newSubroutines, key=lambda subroutine: subroutine.id):
         compileSubroutine(
-            subroutine.get_declaration_by_option(options.use_frame_pointer),
+            subroutine.get_declaration_by_option(options.use_frame_pointers),
             options,
             subroutineGraph,
             subroutine_start_blocks,

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -26,7 +26,7 @@ from pyteal.compiler.subroutines import (
 from pyteal.compiler.constants import createConstantBlocks
 
 MAX_PROGRAM_VERSION = 8
-FRAME_POINTER_VERSION = 8
+FRAME_POINTERS_VERSION = 8
 DEFAULT_SCRATCH_SLOT_OPTIMIZE_VERSION = 9
 MIN_PROGRAM_VERSION = 2
 DEFAULT_PROGRAM_VERSION = MIN_PROGRAM_VERSION

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -246,7 +246,7 @@ def compileTeal(
     *,
     version: int = DEFAULT_PROGRAM_VERSION,
     assembleConstants: bool = False,
-    optimize: OptimizeOptions = None,
+    optimize: Optional[OptimizeOptions] = None,
 ) -> str:
     """Compile a PyTeal expression into TEAL assembly.
 

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -51,7 +51,9 @@ class CompileOptions:
         self.mode: Final[Mode] = mode
         self.version: Final[int] = version
         self.optimize: Final[OptimizeOptions] = optimize or OptimizeOptions()
-        self.use_frame_pointers: Final[bool] = self.optimize.use_frame_pointers(self.version)
+        self.use_frame_pointers: Final[bool] = self.optimize.use_frame_pointers(
+            self.version
+        )
 
         self.currentSubroutine: Optional[SubroutineDefinition] = None
 

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -46,7 +46,7 @@ class CompileOptions:
         *,
         mode: Mode = Mode.Signature,
         version: int = DEFAULT_PROGRAM_VERSION,
-        optimize: OptimizeOptions = None,
+        optimize: Optional[OptimizeOptions] = None,
     ) -> None:
         self.mode: Mode = mode
         self.version: int = version

--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Set, Dict, Optional, cast
+from typing import Final, List, Tuple, Set, Dict, Optional, cast
 
 from pyteal.compiler.optimizer import OptimizeOptions, apply_global_optimizations
 
@@ -48,10 +48,10 @@ class CompileOptions:
         version: int = DEFAULT_PROGRAM_VERSION,
         optimize: Optional[OptimizeOptions] = None,
     ) -> None:
-        self.mode: Mode = mode
-        self.version: int = version
-        self.optimize: OptimizeOptions = optimize or OptimizeOptions()
-        self.use_frame_pointers: bool = self.optimize.use_frame_pointers(self.version)
+        self.mode: Final[Mode] = mode
+        self.version: Final[int] = version
+        self.optimize: Final[OptimizeOptions] = optimize or OptimizeOptions()
+        self.use_frame_pointers: Final[bool] = self.optimize.use_frame_pointers(self.version)
 
         self.currentSubroutine: Optional[SubroutineDefinition] = None
 

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -2352,7 +2352,7 @@ def test_router_app():
             version=6, optimize=pt.OptimizeOptions(frame_pointers=True)
         )
 
-    assert "Try to use frame pointer with an insufficient version 6" in str(e)
+    assert "Frame pointers aren't available" in str(e.value)
 
     _router_with_oc = pt.Router(
         "ASimpleQuestionablyRobustContract", on_completion_actions

--- a/pyteal/compiler/compiler_test.py
+++ b/pyteal/compiler/compiler_test.py
@@ -2349,7 +2349,7 @@ def test_router_app():
 
     with pytest.raises(pt.TealInputError) as e:
         pt.Router("will-error", on_completion_actions).compile_program(
-            version=6, frame_pointers=True
+            version=6, optimize=pt.OptimizeOptions(frame_pointers=True)
         )
 
     assert "Try to use frame pointer with an insufficient version 6" in str(e)

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -48,14 +48,14 @@ class OptimizeOptions:
         return self._scratch_slots
 
     def use_frame_pointers(self, version: int) -> bool:
-        from pyteal.compiler.compiler import FRAME_POINTER_VERSION
+        from pyteal.compiler.compiler import FRAME_POINTERS_VERSION
 
         if self._frame_pointers is None:
-            return version >= FRAME_POINTER_VERSION
+            return version >= FRAME_POINTERS_VERSION
 
         if self._frame_pointers:
             verifyProgramVersion(
-                FRAME_POINTER_VERSION,
+                FRAME_POINTERS_VERSION,
                 version,
                 f"Frame pointers aren't available when compiling to TEAL version {version}",
             )

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -59,7 +59,7 @@ class OptimizeOptions:
             verifyProgramVersion(
                 FRAME_POINTERS_VERSION,
                 version,
-                f"Frame pointers aren't available when compiling to TEAL version {version}",
+                f"Frame pointers aren't available when compiling to program version {version}",
             )
 
         return self._frame_pointers

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set
+from typing import Set
 
 from pyteal.ast import ScratchSlot
 from pyteal.ir import TealBlock, TealOp, Op

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -26,7 +26,7 @@ class OptimizeOptions:
         frame_opinters
     """
 
-    def __init__(self, *, scratch_slots: bool = False, frame_pointers: bool = True):
+    def __init__(self, *, scratch_slots: bool = False, frame_pointers: bool = False):
         self.scratch_slots: bool = scratch_slots
         self.frame_pointers: bool = frame_pointers
         self._skip_slots: Set[ScratchSlot] = set()

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import Final, Set
 
 from pyteal.ast import ScratchSlot
 from pyteal.ir import TealBlock, TealOp, Op
@@ -27,8 +27,8 @@ class OptimizeOptions:
     """
 
     def __init__(self, *, scratch_slots: bool = False, frame_pointers: bool = False):
-        self.scratch_slots: bool = scratch_slots
-        self.frame_pointers: bool = frame_pointers
+        self.scratch_slots: Final[bool] = scratch_slots
+        self.frame_pointers: Final[bool] = frame_pointers
         self._skip_slots: Set[ScratchSlot] = set()
 
     @classmethod

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -22,7 +22,9 @@ class OptimizeOptions:
     Args:
 
         scratch_slots (optional): cancel contiguous store/load operations
-            that have no load dependencies elsewhere.
+            that have no load dependencies elsewhere. Starting TEAL version 9, defaults to optimizing.
+        frame_pointers (optional): employ frame pointers instead of scratch slots during compilation.
+            Available only starting in version 8. Defaults to optimizing starting TEAL version 8.
     """
 
     def __init__(

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -22,9 +22,9 @@ class OptimizeOptions:
     Args:
 
         scratch_slots (optional): cancel contiguous store/load operations
-            that have no load dependencies elsewhere. Starting TEAL version 9, defaults to optimizing.
+            that have no load dependencies elsewhere. Starting with program version 9, defaults to optimizing.
         frame_pointers (optional): employ frame pointers instead of scratch slots during compilation.
-            Available only starting in version 8. Defaults to optimizing starting TEAL version 8.
+            Available only starting in program version 8. Defaults to optimizing starting in program version 8.
     """
 
     def __init__(

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -38,9 +38,6 @@ class OptimizeOptions:
 
         self._skip_slots: Set[ScratchSlot] = set()
 
-        # deprecated field kept for backwards compatibility - not used. Shall I remove altogether?
-        self.scratch_slots: Final[bool] = bool(scratch_slots)
-
     def optimize_scratch_slots(self, version: int) -> bool:
         from pyteal.compiler.compiler import DEFAULT_SCRATCH_SLOT_OPTIMIZE_VERSION
 

--- a/pyteal/compiler/optimizer/optimizer.py
+++ b/pyteal/compiler/optimizer/optimizer.py
@@ -23,7 +23,6 @@ class OptimizeOptions:
 
         scratch_slots (optional): cancel contiguous store/load operations
             that have no load dependencies elsewhere.
-        frame_opinters
     """
 
     def __init__(self, *, scratch_slots: bool = False, frame_pointers: bool = False):

--- a/pyteal/compiler/optimizer/optimizer_test.py
+++ b/pyteal/compiler/optimizer/optimizer_test.py
@@ -559,6 +559,7 @@ return""".strip()
     )
     assert actual == expected
 
+
 def test_optimize_default_for_version_etc():
     oo = OptimizeOptions()
     assert oo.scratch_slots is False

--- a/pyteal/compiler/optimizer/optimizer_test.py
+++ b/pyteal/compiler/optimizer/optimizer_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pyteal.compiler.optimizer.optimizer import OptimizeOptions, _apply_slot_to_stack
 
 import pyteal as pt
@@ -562,17 +564,34 @@ return""".strip()
 
 def test_optimize_default_for_version_etc():
     oo = OptimizeOptions()
-    assert oo.scratch_slots is False
-    assert oo.frame_pointers is False
+    assert oo.optimize_scratch_slots(7) is False
+    assert oo.use_frame_pointers(7) is False
 
-    oo = OptimizeOptions.maximize()
-    assert oo.scratch_slots is True
-    assert oo.frame_pointers is True
+    assert oo.optimize_scratch_slots(8) is False
+    assert oo.use_frame_pointers(8) is True
 
-    oo = OptimizeOptions.default_for_version(7)
-    assert oo.scratch_slots is False
-    assert oo.frame_pointers is False
+    assert oo.optimize_scratch_slots(9) is True
+    assert oo.use_frame_pointers(9) is True
 
-    oo = OptimizeOptions.default_for_version(8)
-    assert oo.scratch_slots is False
-    assert oo.frame_pointers is True
+    oo = OptimizeOptions(scratch_slots=True)
+    assert oo.optimize_scratch_slots(7) is True
+    assert oo.optimize_scratch_slots(8) is True
+    assert oo.optimize_scratch_slots(9) is True
+
+    oo = OptimizeOptions(scratch_slots=False)
+    assert oo.optimize_scratch_slots(7) is False
+    assert oo.optimize_scratch_slots(8) is False
+    assert oo.optimize_scratch_slots(9) is False
+
+    oo = OptimizeOptions(frame_pointers=False)
+    assert oo.use_frame_pointers(7) is False
+    assert oo.use_frame_pointers(8) is False
+    assert oo.use_frame_pointers(9) is False
+
+    oo = OptimizeOptions(frame_pointers=True)
+    with pytest.raises(pt.TealInputError) as tie:
+        oo.use_frame_pointers(7)
+    assert "Frame pointers aren't available" in str(tie.value)
+
+    assert oo.use_frame_pointers(8) is True
+    assert oo.use_frame_pointers(9) is True

--- a/pyteal/compiler/optimizer/optimizer_test.py
+++ b/pyteal/compiler/optimizer/optimizer_test.py
@@ -558,3 +558,20 @@ return""".strip()
         program, version=4, mode=pt.Mode.Application, optimize=optimize_options
     )
     assert actual == expected
+
+def test_optimize_default_for_version_etc():
+    oo = OptimizeOptions()
+    assert oo.scratch_slots is False
+    assert oo.frame_pointers is False
+
+    oo = OptimizeOptions.maximize()
+    assert oo.scratch_slots is True
+    assert oo.frame_pointers is True
+
+    oo = OptimizeOptions.default_for_version(7)
+    assert oo.scratch_slots is False
+    assert oo.frame_pointers is False
+
+    oo = OptimizeOptions.default_for_version(8)
+    assert oo.scratch_slots is False
+    assert oo.frame_pointers is True


### PR DESCRIPTION
# Summary

Removing the `frame_pointers` parameter in `Router.compile_program()` and `CompileOptions.__init__()` and adding it to `OptimizeOptions`