### PR TITLE
`OpType(Enum)` falls down on python 3.11.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     container: python:${{ matrix.python }}
     strategy:
       matrix:
-        python: ["3.10"]
+        python: ["3.10", "3.11"]
     steps:
       - run: python3 --version
       - name: Check out code
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [ "3.10" ]
+        python: ["3.10", "3.11"]
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Introducing `AbstractVar` to abstract value access: store, load, and stack type. ([#584](https://github.com/algorand/pyteal/pull/584))
   * NOTE: a backwards incompatable change was imposed in this PR: previous ABI value's public member `stored_value` with type `ScratchVar`, is now changed to protected member `_stored_value` with type `AbstractVar`.
 * Starting with program version 9, when `scratch_slots` flag isn't provided to `OptimizeOptions`, default to optimizing. For versions 8 and earlier the default is and remains to _not_ optimize. ([#613](https://github.com/algorand/pyteal/pull/613))
+* Replaced the usage of `typing.NamedTuple` with `dataclass` for `class OpType` in the **ir** package in order to avoid [a regression coming in Python 3.11.1](https://github.com/python/cpython/issues/100098) ([#615](https://github.com/algorand/pyteal/pull/615)).
 
 # 0.20.1
 

--- a/pyteal/ir/ops.py
+++ b/pyteal/ir/ops.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from dataclasses import dataclass
 from enum import Enum, Flag, auto
 
 
@@ -11,7 +11,12 @@ class Mode(Flag):
 
 Mode.__module__ = "pyteal"
 
-OpType = NamedTuple("OpType", [("value", str), ("mode", Mode), ("min_version", int)])
+
+@dataclass
+class OpType:
+    value: str
+    mode: Mode
+    min_version: int
 
 
 class Op(Enum):


### PR DESCRIPTION
# The Problem

There is [a regression on python 3.11.1](https://github.com/python/cpython/issues/100098) which breaks the way we're using `NamedTuple`s as an `OpType(Enum)` base type.
Even though it is expected that python 3.11.2 will fix the regression, there is a simple solution: swap in a dataclass instead.

## Testing
I'm also introducing python 3.11 workflows to [demonstrate the problem](https://github.com/algorand/pyteal/actions/runs/3708935444/jobs/6287006734#step:6:21536) and ensure confidence in the fix. I propose that we _keep these workflows in place_ to help detect future regressions. Please note that the example error occurred _without any code changes_, i.e. all I did was introduce the python 3.11.1 workflow. You can validate with this commit: https://github.com/algorand/pyteal/pull/615/commits/df9219719ceba76e8f1bcd5c097788c651e8b7c0