### PR TITLE
Add a missing arg for method sig in `OpUp` integration test

### DIFF
--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -27,6 +27,7 @@ def _dryrun(
         e.compile(pt.compiler.MAX_PROGRAM_VERSION),
         [],
         ExecutionMode.Application,
+        None,
         e.abi_argument_types(),
         e.abi_return_type(),
         txn_params=DryRunExecutor.transaction_params(


### PR DESCRIPTION
The build in https://github.com/algorand/pyteal/pull/605 accidentally failed for a missing arg in `OpUp` test for method signature.

Put a `None` to fill in the blank for `Optional` type.