### PR TITLE
Prevent blackbox_test_runner from passing without invariant assertions

### DIFF
--- a/tests/integration/graviton_test.py
+++ b/tests/integration/graviton_test.py
@@ -513,6 +513,7 @@ def blackbox_test_runner(
     inputs, predicates = Invariant.inputs_and_invariants(
         scenario, exec_mode, raw_predicates=True
     )
+    assert predicates, "Must configure >= 1 predicate"
 
     # 3. execute dry run sequence:
     execute = DryRunExecutor.execute_one_dryrun


### PR DESCRIPTION
Adds an assertion to confirm `blackbox_test_runner` tests supply _at least_ 1 invariant.  The intent is to prevent a test from passing when it either does not declare invariants or structures invariant declaration incorrectly.

Notes:
* While reviewing #559, I discovered that _no_ invariant assertions happen in `test_blackbox_subroutines_as_apps` and `test_blackbox_subroutines_as_logic_sigs` because the tests configure invariants with key = `assertions` while `blackbox_test_runner` looks for key = `invariants`.
* Changing the test keys from `assertions` to `invariants` results in failed tests.  I open the PR to request help in fixing the broken assertions.  Once fixed, I'd like to add the defensive check shown here.
* Reviewing git history, I confirmed the key mismatch exists since the functionality was originally merged in https://github.com/algorand/pyteal/pull/249/.