### PR TITLE
Optimize `DupN` code generation & fix testing bug

### DIFF
--- a/pyteal/ast/frame.py
+++ b/pyteal/ast/frame.py
@@ -41,14 +41,7 @@ class LocalTypeSegment(Expr):
                 )
 
     def __teal__(self, options: "CompileOptions") -> tuple[TealBlock, TealSimpleBlock]:
-        if self.count == 1:
-            inst_srt, inst_end = self.auto_instance.__teal__(options)
-            return inst_srt, inst_end
-        else:
-            dupn_srt, dupn_end = DupN(self.auto_instance, self.count - 1).__teal__(
-                options
-            )
-            return dupn_srt, dupn_end
+        return DupN(self.auto_instance, self.count - 1).__teal__(options)
 
     def __str__(self) -> str:
         return f"(LocalTypeSegment: (type: {self.local_type}) (count: {self.count}))"
@@ -322,6 +315,14 @@ class DupN(Expr):
     """
 
     def __init__(self, value: Expr, repetition: int):
+        """Create a DupN expression.
+
+        Args:
+            value: The value to be duplicated.
+            repetition: How many additional times the value should be added to the stack. At the end
+                of this operation, `repetition+1` elements will be added to the stack. Zero can be
+                specified here to indicate no duplication.
+        """
         super().__init__()
         require_type(value, TealType.anytype)
         if repetition < 0:
@@ -330,6 +331,15 @@ class DupN(Expr):
         self.repetition = repetition
 
     def __teal__(self, options: "CompileOptions") -> tuple[TealBlock, TealSimpleBlock]:
+        if self.repetition == 0:
+            # no duplication required
+            return self.value.__teal__(options)
+
+        if self.repetition == 1:
+            # use normal dup op for just 1 duplication
+            op = TealOp(self, Op.dup)
+            return TealBlock.FromOp(options, op, self.value)
+
         verifyProgramVersion(
             Op.dupn.min_version,
             options.version,

--- a/pyteal/ast/frame_test.py
+++ b/pyteal/ast/frame_test.py
@@ -85,7 +85,44 @@ def test_frame_bury_invalid():
         FrameBury(pt.Int(1), 1).__teal__(avm7Options)
 
 
-def test_dupn():
+def test_dupn_zero():
+    byte_expr = pt.Bytes("Astartes")
+    expr = DupN(byte_expr, 0)
+    assert not expr.has_return()
+    assert expr.type_of() == byte_expr.type_of()
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(byte_expr, pt.Op.byte, '"Astartes"'),
+        ]
+    )
+    actual, _ = expr.__teal__(avm8Options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    assert actual == expected
+
+
+def test_dupn_single():
+    byte_expr = pt.Bytes("Astartes")
+    expr = DupN(byte_expr, 1)
+    assert not expr.has_return()
+    assert expr.type_of() == byte_expr.type_of()
+
+    expected = pt.TealSimpleBlock(
+        [
+            pt.TealOp(byte_expr, pt.Op.byte, '"Astartes"'),
+            pt.TealOp(expr, pt.Op.dup),
+        ]
+    )
+    actual, _ = expr.__teal__(avm8Options)
+    actual.addIncoming()
+    actual = pt.TealBlock.NormalizeBlocks(actual)
+
+    assert actual == expected
+
+
+def test_dupn_multiple():
     byte_expr = pt.Bytes("Astartes")
     expr = DupN(byte_expr, 4)
     assert not expr.has_return()
@@ -106,13 +143,13 @@ def test_dupn():
 
 def test_dupn_invalid():
     with pytest.raises(pt.TealTypeError):
-        DupN(pt.Seq(), 1)
+        DupN(pt.Seq(), 10)
 
     with pytest.raises(pt.TealInputError):
-        DupN(pt.Int(1), -1)
+        DupN(pt.Int(1), -10)
 
     with pytest.raises(pt.TealInputError):
-        DupN(pt.Int(1), 1).__teal__(avm7Options)
+        DupN(pt.Int(1), 10).__teal__(avm7Options)
 
 
 def test_local_type_segment_invalid():

--- a/tests/compile_asserts.py
+++ b/tests/compile_asserts.py
@@ -25,40 +25,12 @@ compiled it into {len(compiled)} characters. See the results in:
     return tealdir, name, compiled
 
 
-def process_line(line: str) -> str:
-    quote_types = ("'", '"')
-    comment_start = "/"
-
-    processed_end = len(line) - 1
-
-    current_quote: str | None = None
-    for i, char in enumerate(line):
-        for qt in quote_types:
-            if char == qt:
-                if current_quote == qt:
-                    # breaking out of quote
-                    current_quote = None
-                elif current_quote is None:
-                    current_quote = qt
-                    # entering a quote
-        if current_quote is None:
-            # not in a quote
-            if (
-                char == comment_start
-                and i + 1 < len(line)
-                and line[i + 1] == comment_start
-            ):
-                # a comment is about to start, ignore rest of line
-                processed_end = i - 1
-                break
-
-    return line[:processed_end].strip() + "\n"
-
-
 def assert_teal_as_expected(path2actual: Path, path2expected: Path):
-    with open(path2actual, "r") as fa, open(path2expected, "r") as fe:
-        actual_lines = [process_line(l) for l in fa.readlines()]
-        expected_lines = [process_line(l) for l in fe.readlines()]
+    with open(path2actual, "r") as f:
+        actual_lines = f.readlines()
+
+    with open(path2expected, "r") as f:
+        expected_lines = f.readlines()
 
     diff = list(
         unified_diff(

--- a/tests/integration/teal/roundtrip/app_roundtrip_()_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_()_v8.teal
@@ -16,9 +16,9 @@ tuplecomplement_0:
 proto 1 1
 byte ""
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 byte ""
 frame_bury 0
 retsub
@@ -29,9 +29,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool)[10]_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool)[10]_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -39,9 +39,9 @@ proto 1 1
 byte ""
 dupn 10
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -170,9 +170,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -39,9 +39,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,address,(uint64,bool),byte[10],bool[4],uint64)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,address,(uint64,bool),byte[10],bool[4],uint64)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 6
 byte ""
-dupn 1
+dup
 int 0
 dupn 97
 byte ""
@@ -91,9 +91,9 @@ proto 1 1
 byte ""
 dupn 4
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 2
@@ -140,7 +140,7 @@ byte ""
 int 0
 dupn 97
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -598,7 +598,7 @@ byte ""
 int 0
 dupn 5
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 extract_uint64
@@ -644,7 +644,7 @@ byte ""
 int 0
 dupn 11
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -805,7 +805,7 @@ byte ""
 int 0
 dupn 5
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 5
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -51,9 +51,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 4
 byte ""
-dupn 1
+dup
 int 0
 dupn 97
 byte ""
@@ -26,11 +26,11 @@ dupn 3
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 dupn 2
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -94,9 +94,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1
@@ -205,7 +205,7 @@ byte ""
 int 0
 dupn 97
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -663,7 +663,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,(address,(uint32,string[],bool[2],(byte),uint8)[2],string,bool[]))[]_2_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,(address,(uint32,string[],bool[2],(byte),uint8)[2],string,bool[]))[]_2_v8.teal
@@ -21,7 +21,7 @@ dupn 3
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 int 0
 dupn 97
 byte ""
@@ -29,10 +29,10 @@ dupn 3
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 0
@@ -132,7 +132,7 @@ dupn 2
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 frame_dig -1
@@ -264,9 +264,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1
@@ -375,7 +375,7 @@ byte ""
 int 0
 dupn 97
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -833,7 +833,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1
@@ -892,9 +892,9 @@ int 0
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 int 0
 dupn 97
 byte ""
@@ -1024,7 +1024,7 @@ byte ""
 int 0
 dupn 97
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -1479,7 +1479,7 @@ retsub
 tuplecomplement_11:
 proto 1 1
 byte ""
-dupn 1
+dup
 int 0
 dupn 3
 byte ""
@@ -1487,32 +1487,32 @@ dupn 4
 int 0
 dupn 2
 byte ""
-dupn 1
+dup
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 byte ""
-dupn 1
-int 0
-dupn 7
-byte ""
-dupn 1
-int 0
-byte ""
-dupn 1
+dup
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
+int 0
+byte ""
+dup
+int 0
+dupn 7
+byte ""
+dup
 int 0
 dupn 2
 byte ""
-dupn 1
+dup
 int 0
 byte ""
-dupn 1
+dup
 int 0
 dupn 7
 byte ""
@@ -1520,11 +1520,11 @@ dupn 3
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 extract_uint32
@@ -1595,9 +1595,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 frame_dig -1
 int 2
@@ -1699,7 +1699,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1
@@ -1766,7 +1766,7 @@ byte ""
 int 0
 dupn 4
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 0
@@ -1835,7 +1835,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1
@@ -1892,29 +1892,29 @@ dupn 3
 int 0
 dupn 2
 byte ""
-dupn 1
+dup
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 byte ""
-dupn 1
-int 0
-dupn 7
-byte ""
-dupn 1
-int 0
-byte ""
-dupn 1
+dup
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
+int 0
+byte ""
+dup
+int 0
+dupn 7
+byte ""
+dup
 int 0
 dupn 2
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 frame_dig -1
@@ -2120,7 +2120,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -2152,7 +2152,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbyte

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,uint64)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,byte,address,string,uint64)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 4
 byte ""
-dupn 1
+dup
 int 0
 dupn 97
 byte ""
@@ -26,11 +26,11 @@ dupn 3
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 dupn 4
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -104,9 +104,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1
@@ -215,7 +215,7 @@ byte ""
 int 0
 dupn 97
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -673,7 +673,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(bool,uint64,uint32)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(bool,uint64,uint32)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -60,9 +60,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(byte)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(byte)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbyte
@@ -39,9 +39,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(byte,bool,uint64)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(byte,bool,uint64)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbyte
@@ -61,9 +61,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(byte[4],(bool,bool),uint64,address)[]_7_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(byte[4],(bool,bool),uint64,address)[]_7_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 int 0
 dupn 13
 byte ""
@@ -26,11 +26,11 @@ dupn 3
 int 0
 dupn 5
 byte ""
-dupn 1
+dup
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 int 0
 dupn 90
 frame_dig -1
@@ -77,7 +77,7 @@ dupn 7
 int 0
 dupn 8
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 45
@@ -191,9 +191,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1
@@ -277,7 +277,7 @@ byte ""
 int 0
 dupn 13
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -343,7 +343,7 @@ byte ""
 int 0
 dupn 5
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -399,7 +399,7 @@ byte ""
 int 0
 dupn 33
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint16)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint16)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 extract_uint16
@@ -38,9 +38,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint16,uint8,byte)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint16,uint8,byte)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 extract_uint16
@@ -62,9 +62,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint32)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint32)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 extract_uint32
@@ -38,9 +38,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint32,uint16,uint8)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint32,uint16,uint8)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 extract_uint32
@@ -61,9 +61,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint64)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint64)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 btoi
 store 0
@@ -36,9 +36,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint64,uint32,uint16)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint64,uint32,uint16)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 extract_uint64
@@ -59,9 +59,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint8)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint8)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbyte
@@ -39,9 +39,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_(uint8,byte,bool)_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_(uint8,byte,bool)_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 7
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbyte
@@ -63,9 +63,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub tuplecomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_address[]_10_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_address[]_10_v8.teal
@@ -32,7 +32,7 @@ byte ""
 int 0
 dupn 33
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -491,7 +491,7 @@ dupn 10
 int 0
 dupn 11
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 32
@@ -647,9 +647,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_2
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_address_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_address_v8.teal
@@ -32,7 +32,7 @@ byte ""
 int 0
 dupn 33
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -489,9 +489,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[1]_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[1]_v8.teal
@@ -29,7 +29,7 @@ byte ""
 int 0
 dupn 2
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -50,9 +50,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[3][]_11_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[3][]_11_v8.teal
@@ -29,7 +29,7 @@ byte ""
 int 0
 dupn 4
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -72,7 +72,7 @@ dupn 11
 int 0
 dupn 12
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1
@@ -242,9 +242,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_2
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[42]_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[42]_v8.teal
@@ -29,7 +29,7 @@ byte ""
 int 0
 dupn 43
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 0
 getbit
@@ -460,9 +460,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[]_0_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[]_0_v8.teal
@@ -16,9 +16,9 @@ arraycomplement_0:
 proto 1 1
 byte ""
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 int 0
 int 0
 frame_bury 5
@@ -36,9 +36,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[]_1_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[]_1_v8.teal
@@ -29,7 +29,7 @@ byte ""
 int 0
 dupn 2
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 0
@@ -59,9 +59,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool[]_42_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool[]_42_v8.teal
@@ -29,7 +29,7 @@ byte ""
 int 0
 dupn 43
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 0
@@ -551,9 +551,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_bool_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_bool_v8.teal
@@ -33,7 +33,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub boolcomp_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_byte[16]_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_byte[16]_v8.teal
@@ -32,7 +32,7 @@ byte ""
 int 0
 dupn 17
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 1
 int 0
@@ -265,9 +265,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_byte[]_36_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_byte[]_36_v8.teal
@@ -32,7 +32,7 @@ byte ""
 int 0
 dupn 73
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1
@@ -624,9 +624,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_byte_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_byte_v8.teal
@@ -34,7 +34,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub numericalcomp_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_string_0_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_string_0_v8.teal
@@ -16,9 +16,9 @@ stringreverse_0:
 proto 1 1
 byte ""
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 int 0
 int 0
 frame_bury 5
@@ -36,9 +36,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub stringreverse_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_string_13_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_string_13_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 27
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1
@@ -203,9 +203,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub stringreverse_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_string_1_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_string_1_v8.teal
@@ -18,7 +18,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 1
@@ -47,9 +47,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub stringreverse_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint16_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint16_v8.teal
@@ -34,7 +34,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub numericalcomp_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint32_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint32_v8.teal
@@ -34,7 +34,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub numericalcomp_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint64[1]_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint64[1]_v8.teal
@@ -28,7 +28,7 @@ byte ""
 int 0
 dupn 2
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 8
 int 0
@@ -49,9 +49,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint64[42]_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint64[42]_v8.teal
@@ -28,7 +28,7 @@ byte ""
 int 0
 dupn 43
 byte ""
-dupn 1
+dup
 frame_dig -1
 int 8
 int 0
@@ -541,9 +541,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint64[]_0_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint64[]_0_v8.teal
@@ -16,9 +16,9 @@ arraycomplement_0:
 proto 1 1
 byte ""
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 int 0
 int 0
 frame_bury 5
@@ -36,9 +36,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint64[]_1_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint64[]_1_v8.teal
@@ -28,7 +28,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 8
@@ -58,9 +58,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint64[]_42_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint64[]_42_v8.teal
@@ -28,7 +28,7 @@ byte ""
 int 0
 dupn 85
 byte ""
-dupn 1
+dup
 int 0
 frame_dig -1
 int 8
@@ -632,9 +632,9 @@ proto 1 1
 byte ""
 dupn 2
 int 0
-dupn 1
+dup
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub arraycomplement_1
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint64_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint64_v8.teal
@@ -29,7 +29,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub numericalcomp_0
 frame_bury 1

--- a/tests/integration/teal/roundtrip/app_roundtrip_uint8_v8.teal
+++ b/tests/integration/teal/roundtrip/app_roundtrip_uint8_v8.teal
@@ -34,7 +34,7 @@ byte ""
 int 0
 dupn 3
 byte ""
-dupn 1
+dup
 frame_dig -1
 callsub numericalcomp_0
 frame_bury 1

--- a/tests/unit/teal/abi/lsig_fn_2mixed_arg_1ret.teal
+++ b/tests/unit/teal/abi/lsig_fn_2mixed_arg_1ret.teal
@@ -1,28 +1,28 @@
 #pragma version 6
-arg 0                           // [a]
-btoi                            // [btoi(a)]
-store 1                         // 1 -> btoi(a)
-arg 1                           // [b]
-store 2                         // 2 -> b
-load 1                          // [btoi(a)]
-int 2                           // [btoi(a), 2]
-callsub fn2mixedarg1ret_0       // [btoi(a)]
-store 0                         // 0 -> btoi(a)
-load 0                          // [btoi(a)]
-itob                            // [a]
-pop                             // []
-int 1                           // [1]
+arg 0
+btoi
+store 1
+arg 1
+store 2
+load 1
+int 2
+callsub fn2mixedarg1ret_0
+store 0
+load 0
+itob
+pop
+int 1
 return
 
 // fn_2mixed_arg_1ret
-fn2mixedarg1ret_0:              // [btoi(a), 2]
-store 4                         // 4 -> 2
-store 3                         // 3 -> btoi(a)
-load 4                          // [2]
-load 3                          // [2, btoi(a)]
-itob                            // [2, a]
-stores                          // 2 -> a
-load 3                          // [btoi(a)]
-store 5                         // 5 -> btoi(a)
-load 5                          // [btoi(a)]
+fn2mixedarg1ret_0:
+store 4
+store 3
+load 4
+load 3
+itob
+stores
+load 3
+store 5
+load 5
 retsub

--- a/tests/unit/teal/abi/lsig_fn_3mixed_args_0ret.teal
+++ b/tests/unit/teal/abi/lsig_fn_3mixed_args_0ret.teal
@@ -4,12 +4,12 @@ btoi
 store 0
 arg 1
 btoi
-store 1                         // 1 -> btoi(a)
+store 1
 arg 2
 store 2
-load 0                          // [a]
-int 1                           // [a, 1]
-load 2                          // [a, 1, b]
+load 0
+int 1
+load 2
 callsub fn3mixedargs0ret_0
 int 1
 return

--- a/tests/unit/teal/pre_v6/sub_logcat.teal
+++ b/tests/unit/teal/pre_v6/sub_logcat.teal
@@ -1,23 +1,23 @@
 #pragma version 5
-byte "hello"      //  >"hello"
-int 42            //  >"hello",42
-callsub logcat_0  //  >"hello42"
-byte "hello42"    //  >"hello42","hello42"
-==                //  >1
-assert            //  <<EMPTY>>
-int 1             //  >1
-return            //  <<SUCCESS>>
+byte "hello"
+int 42
+callsub logcat_0
+byte "hello42"
+==
+assert
+int 1
+return
 
 // logcat
-logcat_0:         //  >"hello",42
-store 1           //  1: 42
-store 0           //  0: "hello"
-load 0            //  >"hello"
-load 1            //  >"hello",42
-itob              //  >"hello","42"
-concat            //  >"hello42"
-store 2           //  2: "hello42"
-load 2            //  >"hello42"
+logcat_0:
+store 1
+store 0
+load 0
+load 1
+itob
+concat
+store 2
+load 2
 log
-load 2            //  >"hello42"
+load 2
 retsub

--- a/tests/unit/teal/user_guide/user_guide_snippet_ABIReturnSubroutine.teal
+++ b/tests/unit/teal/user_guide/user_guide_snippet_ABIReturnSubroutine.teal
@@ -1,7 +1,7 @@
 #pragma version 6
-txna ApplicationArgs 1      // x = abi.DynamicArray(abi.Uint64TypeSpec())
-store 0                     // 0: x
-load 0                      // [x]
+txna ApplicationArgs 1
+store 0
+load 0
 callsub abisum_0
 store 1
 byte 0x151f7c75
@@ -13,22 +13,22 @@ int 1
 return
 
 // abi_sum
-abisum_0:                   // [x]
-store 2                     // 2: x
-int 0                       // [0]
-store 3                     // 3: 0
-int 0                       // [0]
-store 4                     // 4: 0
-abisum_0_l1:                // []
+abisum_0:
+store 2
+int 0
+store 3
+int 0
+store 4
+abisum_0_l1:
 load 4
 load 2
-int 0                       // [0, x, 0]
-extract_uint16              // [0, len(x)]
-store 6                     // 6: len(x)
-load 6                      // [0, len(x)]
-<                           // [1]
-bz abisum_0_l3              // [0]
-load 2                      // ... looks promising ...
+int 0
+extract_uint16
+store 6
+load 6
+<
+bz abisum_0_l3
+load 2
 int 8
 load 4
 *
@@ -45,6 +45,6 @@ int 1
 +
 store 4
 b abisum_0_l1
-abisum_0_l3:                // []
-load 3                      // [0]
+abisum_0_l3:
+load 3
 retsub


### PR DESCRIPTION
Optimize code generated by the `DupN` expression.

Prior to this PR, that expression always used the `dupn` op. However, if only 1 additional value is needed, the `dup` op can be used to save a byte. And if no additional values are needed and you still use `DupN`, no additional op is needed.

While testing this change, I noticed a bug in the `assert_teal_as_expected` function from `tests/compile_asserts.py`. This function used to only check that the expected line of code prefixes the actual line, and unfortunately `dup` prefixes `dupn 1`. I decided to upgrade the comparison function by using the `difflib` package ~~and processing each line to strip away all auxiliary information.~~