### PR TITLE
PR for Py-SDK version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Starting with program version 9, when `scratch_slots` flag isn't provided to `OptimizeOptions`, default to optimizing. For versions 8 and earlier the default is and remains to _not_ optimize. ([#613](https://github.com/algorand/pyteal/pull/613))
 * Replaced the usage of `typing.NamedTuple` with `dataclass` for `class OpType` in the **ir** package in order to avoid [a regression coming in Python 3.11.1](https://github.com/python/cpython/issues/100098). ([#615](https://github.com/algorand/pyteal/pull/615))
 * Upgrade mypy to v0.991. ([#618](https://github.com/algorand/pyteal/pull/618))
+* Upgrade py-algorand-sdk to v2.0.0. ([#626](https://github.com/algorand/pyteal/pull/626))
 
 # 0.20.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 flake8==5.0.4
 flake8-tidy-imports==4.6.0
-graviton@git+https://github.com/algorand/graviton@v0.5.0
+graviton@git+https://github.com/algorand/graviton@v0.7.1
 mypy==0.991
 pytest==7.2.0
 pytest-cov==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     ),
     install_requires=[
         # when changing this list, also update docs/requirements.txt
-        "py-algorand-sdk>=1.9.0,<2.0.0",
+        "py-algorand-sdk>=2.0.0,<3.0.0",
         "semantic-version>=2.9.0,<3.0.0",
         "docstring-parser==0.14.1",
     ],

--- a/tests/integration/opup_test.py
+++ b/tests/integration/opup_test.py
@@ -18,7 +18,7 @@ import algosdk
 
 def _dryrun(
     bw: BlackboxWrapper,
-    sp: algosdk.future.transaction.SuggestedParams,
+    sp: algosdk.transaction.SuggestedParams,
     accounts: list[Account],
 ) -> DryRunInspector:
     e = PyTealDryRunExecutor(bw, pt.Mode.Application)
@@ -33,7 +33,7 @@ def _dryrun(
             sender=graviton.models.ZERO_ADDRESS,
             sp=sp,
             index=DryRunExecutor.EXISTING_APP_CALL,
-            on_complete=algosdk.future.transaction.OnComplete.NoOpOC,
+            on_complete=algosdk.transaction.OnComplete.NoOpOC,
         ),
         accounts=accounts,
     )


### PR DESCRIPTION
This should be blocked by https://github.com/algorand/py-algorand-sdk/issues/384, for pyteal is using py-sdk as a runtime dependency.

Merge in after https://github.com/algorand/py-algorand-sdk/issues/384 is resolved.

This PR upgrading runtime dependency should favor some type alert in `abi.Contract` in pyteal.