### PR TITLE
Add build check for python setup.py sdist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ flake8:
 mypy:
 	mypy
 
-lint: black flake8 mypy
+sdist-check:
+	python setup.py check -s
+	python setup.py check -s 2>&1 | (! grep -qEi 'error|warning')
+
+lint: black flake8 mypy sdist-check
 
 # ---- Unit Tests (no algod) ---- #
 


### PR DESCRIPTION
Addresses https://github.com/algorand/pyteal/issues/611 by adding a build check to confirm `python setup.py` passes without warnings or errors.

The PR ports the solution applied in py-algorand-sdk (https://github.com/algorand/py-algorand-sdk/pull/427/).