### PR TITLE
Adding `asdict()` to Router's `BareCallActions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 
 ## Added
+
 * Improved error handling for tuple type mismatch: added information on position and expected type. ([#655](https://github.com/algorand/pyteal/pull/655))
+* Added an `asdict()` method to `ast.router.BareCallActions`. ([#656](https://github.com/algorand/pyteal/pull/656))
 
 ## Fixed
 

--- a/pyteal/ast/router.py
+++ b/pyteal/ast/router.py
@@ -197,6 +197,16 @@ class BareCallActions:
                 "https://pyteal.readthedocs.io/en/latest/abi.html#registering-bare-app-calls"
             )
 
+    def asdict(self) -> dict[str, OnCompleteAction]:
+        return {
+            "clear_state": self.clear_state,
+            "close_out": self.close_out,
+            "delete_application": self.delete_application,
+            "no_op": self.no_op,
+            "opt_in": self.opt_in,
+            "update_application": self.update_application,
+        }
+
     def is_empty(self) -> bool:
         for action_field in fields(self):
             action: OnCompleteAction = getattr(self, action_field.name)

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -378,6 +378,35 @@ def test_bare_call_config_clear_state_failure():
     assert "Attempt to construct clear state program from bare app call" in str(tie)
 
 
+def test_bare_call_actions_asdict():
+    no_action = pt.OnCompleteAction()
+    del_action = pt.OnCompleteAction(action=pt.Int(1), call_config=pt.CallConfig.ALL)
+    close_action = pt.OnCompleteAction(action=pt.Int(2), call_config=pt.CallConfig.CALL)
+
+    bca = pt.BareCallActions(
+        delete_application=del_action,
+        close_out=close_action,
+    )
+
+    bcad = bca.asdict()
+    assert set(bcad.keys()) == {
+        "clear_state",
+        "close_out",
+        "delete_application",
+        "no_op",
+        "opt_in",
+        "update_application",
+    }
+    assert bcad == {
+        "clear_state": no_action,
+        "close_out": close_action,
+        "delete_application": del_action,
+        "no_op": no_action,
+        "opt_in": no_action,
+        "update_application": no_action,
+    }
+
+
 def test_router_register_method_clear_state_failure():
     router = pt.Router("doomedToFail")
 

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -397,14 +397,15 @@ def test_bare_call_actions_asdict():
         "opt_in",
         "update_application",
     }
-    assert bcad == {
-        "clear_state": no_action,
-        "close_out": close_action,
-        "delete_application": del_action,
-        "no_op": no_action,
-        "opt_in": no_action,
-        "update_application": no_action,
-    }
+    with pt.TealComponent.Context.ignoreExprEquality():
+        assert bcad == {
+            "clear_state": no_action,
+            "close_out": close_action,
+            "delete_application": del_action,
+            "no_op": no_action,
+            "opt_in": no_action,
+            "update_application": no_action,
+        }
 
 
 def test_router_register_method_clear_state_failure():

--- a/pyteal/ast/router_test.py
+++ b/pyteal/ast/router_test.py
@@ -397,15 +397,14 @@ def test_bare_call_actions_asdict():
         "opt_in",
         "update_application",
     }
-    with pt.TealComponent.Context.ignoreExprEquality():
-        assert bcad == {
-            "clear_state": no_action,
-            "close_out": close_action,
-            "delete_application": del_action,
-            "no_op": no_action,
-            "opt_in": no_action,
-            "update_application": no_action,
-        }
+    assert bcad == {
+        "clear_state": no_action,
+        "close_out": close_action,
+        "delete_application": del_action,
+        "no_op": no_action,
+        "opt_in": no_action,
+        "update_application": no_action,
+    }
 
 
 def test_router_register_method_clear_state_failure():


### PR DESCRIPTION
# Summary

In anticipation to some changes being brought on by #650, and wanting to maintain compatibility with Beaker, I'm proposing to explicitly provide the underlying dictionary.

## Beaker Companion PR
https://github.com/algorand-devrel/beaker/pull/190