### PR TITLE
Clarify that `Approve` and `Reject` always exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+* Clarify that `Approve` and `Reject` always exit in the documentation.
+
 ## Fixed
 
 ## Changed

--- a/docs/control_structures.rst
+++ b/docs/control_structures.rst
@@ -20,7 +20,7 @@ is used, then the execution is marked as successful, and if :code:`Reject` is us
 is marked as unsuccessful.
 
 These expressions also work inside :ref:`subroutines <subroutine_expr>`. When used inside subroutines, they
-also cause the program to immediately exit, contrary to :code:`Return(...)` which just returns the subroutine.
+also cause the program to immediately exit, contrary to :code:`Return(...)` which just returns from the subroutine.
 
 .. _seq_expr:
 

--- a/docs/control_structures.rst
+++ b/docs/control_structures.rst
@@ -19,7 +19,8 @@ The :any:`Approve` and :any:`Reject` expressions cause the program to immediatel
 is used, then the execution is marked as successful, and if :code:`Reject` is used, then the execution
 is marked as unsuccessful.
 
-These expressions also work inside :ref:`subroutines <subroutine_expr>`.
+These expressions also work inside :ref:`subroutines <subroutine_expr>`. When used inside subroutines, they
+also cause the program to immediately exit, contrary to :code:`Return(...)` which just returns the subroutine.
 
 .. _seq_expr:
 


### PR DESCRIPTION
I made this PR following https://forum.algorand.org/t/innertxnbuilder-second-transaction-is-not-stored-in-the-blockchain/8893/2?u=fabrice