### PR TITLE
Added TealSeqError for better error reporting.

### DIFF
--- a/pyteal/__init__.py
+++ b/pyteal/__init__.py
@@ -18,6 +18,7 @@ from pyteal.types import TealType
 from pyteal.errors import (
     TealInternalError,
     TealTypeError,
+    TealSeqError,
     TealInputError,
     TealCompileError,
     TealPragmaError,
@@ -47,6 +48,7 @@ __all__ = (
         "TealType",
         "TealInternalError",
         "TealTypeError",
+        "TealSeqError",
         "TealInputError",
         "TealCompileError",
         "TealPragmaError",

--- a/pyteal/__init__.pyi
+++ b/pyteal/__init__.pyi
@@ -21,6 +21,7 @@ from pyteal.types import TealType
 from pyteal.errors import (
     TealInternalError,
     TealTypeError,
+    TealSeqError,
     TealInputError,
     TealCompileError,
     TealPragmaError,
@@ -210,6 +211,7 @@ __all__ = [
     "TealLabel",
     "TealOp",
     "TealPragmaError",
+    "TealSeqError",
     "TealSimpleBlock",
     "TealType",
     "TealTypeError",

--- a/pyteal/ast/seq.py
+++ b/pyteal/ast/seq.py
@@ -1,7 +1,7 @@
 from typing import List, TYPE_CHECKING, overload
 
 from pyteal.types import TealType, require_type
-from pyteal.errors import TealInputError
+from pyteal.errors import TealInputError, TealTypeError, TealSeqError
 from pyteal.ir import TealSimpleBlock
 from pyteal.ast.expr import Expr
 
@@ -51,7 +51,17 @@ class Seq(Expr):
             if not isinstance(expr, Expr):
                 raise TealInputError("{} is not a pyteal expression.".format(expr))
             if i + 1 < len(exprs):
-                require_type(expr, TealType.none)
+                try:
+                    require_type(expr, TealType.none)
+                except TealTypeError:
+                    message = "{} must have a return type of TealType.none. ".format(
+                        expr
+                    )
+                    message += (
+                        "Only the last entry of a Seq array can have a return value."
+                    )
+                    seq_error = TealSeqError(message)
+                    raise seq_error
 
         self.args = exprs
 

--- a/pyteal/ast/seq_test.py
+++ b/pyteal/ast/seq_test.py
@@ -90,13 +90,13 @@ def test_seq_has_return():
 
 
 def test_seq_invalid():
-    with pytest.raises(pt.TealTypeError):
+    with pytest.raises(pt.TealSeqError):
         pt.Seq([pt.Int(1), pt.Pop(pt.Int(2))])
 
-    with pytest.raises(pt.TealTypeError):
+    with pytest.raises(pt.TealSeqError):
         pt.Seq([pt.Int(1), pt.Int(2)])
 
-    with pytest.raises(pt.TealTypeError):
+    with pytest.raises(pt.TealSeqError):
         pt.Seq([pt.Seq([pt.Pop(pt.Int(1)), pt.Int(2)]), pt.Int(3)])
 
 

--- a/pyteal/errors.py
+++ b/pyteal/errors.py
@@ -26,6 +26,17 @@ class TealTypeError(Exception):
 TealTypeError.__module__ = "pyteal"
 
 
+class TealSeqError(TealTypeError):
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+TealSeqError.__module__ = "pyteal"
+
+
 class TealInputError(Exception):
     def __init__(self, msg: str) -> None:
         self.message = msg


### PR DESCRIPTION
Syntax errors on `Seq` arrays do not clearly indicate where the syntax error is when the return type of a non-final expression is not `TealType.none` and will only point to the parent `Seq` statement. This change will reference the offending statement in the error message.

This code:
```
Seq([
    InnerTxnBuilder.Begin(),
    InnerTxnBuilder.SetFields({
        TxnField.type_enum: TxnType.AssetTransfer,
        TxnField.xfer_asset: Txn.assets[0],
        TxnField.asset_amount: Int(0) ,
        TxnField.asset_receiver: Global.current_application_address()
    }),
    InnerTxnBuilder.Submit(),
    #create box:
    App.box_create(Itob(Txn.assets[0]),Int(16)),
    App.globalPut(Bytes("AssetsRatioTotal"),  Btoi(Txn.application_args[1])),
])
```
Will now produce this error:
```
  ...
  File "/home/user/my_contract.py", line 210, in generate_approval_program_v1
    Seq([
  File "/home/user/ENV3/lib/python3.10/site-packages/pyteal/ast/seq.py", line 60, in __init__
    raise e
  File "/home/user/ENV3/lib/python3.10/site-packages/pyteal/ast/seq.py", line 55, in __init__
    require_type(expr, TealType.none)
  File "/home/user/ENV3/lib/python3.10/site-packages/pyteal/types.py", line 38, in require_type
    raise TealTypeError(actual, expected)
pyteal.TealSeqError: (box_create (Itob (Txna Assets 0)) (Int 16)) must have a return type of TealType.none. Only the last entry of a Seq array can have a return value.
```