### PR TITLE
Final Nightly Build PR

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 name: "Nightly Build"
 on:
   schedule:
-    - cron: "10 * * * *"
+    - cron: "10 17 * * *"
 
 jobs:
   nightly-slow-unit-tests:


### PR DESCRIPTION
## What's the change?

The ONLY change here is for the job to to run nightly @ 17:10 UTC, now that I have confidence that it's triggering correctly. 

## When will this be merged?

I'm hoping to merge _AFTER_ I see that the [nightly build](https://github.com/algorand/pyteal/actions/workflows/nightly.yml) is actually respecting the requirement that the heavy portion of the job _NOT_ run after 24 hours of no commits.

## How to remove if we end up ditching the nightly job?

Originally, I was envisioning reverting all the commits. However, there have been permanent changes that I'm planning to keep. 

1. remove `.github/workflows/nightly.yml`
2. remove the `check-code-changes` and `nightly-slow` targets introduced to the `Makefile`

## What are the permanent changes?
* upgrading the github `setup-python` action to `v4`
* making the `Makefile` commands in the workflow, as succint as possible. I.e. introducing the following `Makefile` targets:
  * `algod-integration` for integration tests setup and running
  * `setup-build-test` for unit tests setup and running

## What feedback is being reqeusted?
Please have a look at this diff: https://github.com/algorand/pyteal/compare/v0.23.0...master

I'm proposing that changes to the `Makefile` be made permanent (except possibly for the `nightly-slow` and `check-code-changes` targets), as well as to `.github/workflows/build.yml` (no exceptions).

This PR provides an opportunity for anyone to comment on these permanent changes (and anything else).

## What's the difference between a _HEAVY_ nightly build job, and a _light_ one?
Compare the following 2 jobs:
1. No. 67 which ran at around 10:10 am EST on 2/16/2022: https://github.com/algorand/pyteal/actions/runs/4195384325/jobs/7274848756
2. No. 68 which ran at around 11:10 am EST on 2/16/2022: https://github.com/algorand/pyteal/actions/runs/4195932350/jobs/7276184010

The first job took around 4 minutes to run while the second job took less than 1 minute. That's because the last commit into `master` had occurred between 10:10 and 11:10 the day prior 2/15/2022.