### PR TITLE
Best Guess Sourcemapping when Partially Enabled

### DIFF
--- a/examples/application/abi/algobank.py
+++ b/examples/application/abi/algobank.py
@@ -2,6 +2,10 @@
 from pyteal import *
 import json
 
+from feature_gates import FeatureGates
+
+FeatureGates.set_sourcemap_enabled(True)
+
 
 @Subroutine(TealType.none)
 def assert_sender_is_creator() -> Expr:
@@ -125,3 +129,96 @@ if __name__ == "__main__":
 
     with open("algobank.json", "w") as f:
         f.write(json.dumps(contract.dictify(), indent=4))
+
+    sourcemaps = router.compile(
+        version=6,
+        optimize=OptimizeOptions(scratch_slots=True),
+        with_sourcemaps=True,
+        annotate_teal=True,
+    )
+    with open("algobank_with_sourcemap.teal", "w") as f:
+        f.write(sourcemaps.approval_sourcemap.annotated_teal)
+
+"""
+❯ python algobank.py
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-------------------
+WARNING: Error retrieving the best frame for source mapping.
+This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
+error: expected to have some frames but currently self._frames=[]
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(21: int NoOp // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(42: int NoOp // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(63: int NoOp // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(70: int OptIn // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(98: int NoOp // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(102: int OptIn // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(106: int CloseOut // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(110: int UpdateApplication // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+
+-----------------
+WARNING: Source mapping is unknown for the following:
+TealLine(114: int DeleteApplication // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))
+"""


### PR DESCRIPTION
As of #687, to enable source mapping one must `import FeatureGates from feature_gates` and then call `FeaturGates.set_sourcemap_enabled(True)`. One must do this _before_ any **PyTeal** imports as the `NatalStackFrame` embedded in `Expr`'s needs to be aware of the feature gate at construction time. Furthermore, as some expressions are statically derived at **PyTeal**'s importation, these end up lacking any stack frame information.

This PR aims to ameliorate this situation by providing stand-in `PyTealFrame`'s in the case that this has happened. In such cases, a **warning** is printed out alerting of the fact that `FeatureGate` must be imported and enabled before the PyTeal imports, but everything
else proceeds as before.

For example, I've temporarily modified [the AlgoBank example](https://github.com/algorand/pyteal/blob/3a7bfa2a1aa91b2713b5f96275b847c38b4313bd/examples/application/abi/algobank.py#L143) to illustrate what occurs in such a case. In particular, we will see the following error messages:

```sh
❯ python algobank.py
-------------------
WARNING: Error retrieving the best frame for source mapping.
This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
error: expected to have some frames but currently self._frames=[]

-------------------
WARNING: Error retrieving the best frame for source mapping.
This may occur because FeatureGates was imported and `FeatureGates.set_sourcemap_enabled(True)` called _AFTER_ pyteal was imported.
error: expected to have some frames but currently self._frames=[]

... more similar errors ...

-----------------
WARNING: Source mapping is unknown for the following:
TealLine(21: int NoOp // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))

-----------------
WARNING: Source mapping is unknown for the following:
TealLine(42: int NoOp // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))

-----------------
WARNING: Source mapping is unknown for the following:
TealLine(63: int NoOp // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))

-----------------
WARNING: Source mapping is unknown for the following:
TealLine(70: int OptIn // PyTeal: router.compile(version=6, optimize=OptimizeOptions(scratch_slots=True), with_sourcemaps=True, annotate_teal=True))

... more similar errors ...
```