### PR TITLE
Source Map Bugfix: Just getcwd() instead of relpath hackery

### DIFF
--- a/pyteal/stack_frame.py
+++ b/pyteal/stack_frame.py
@@ -543,11 +543,7 @@ class PyTealFrame(StackFrame):
         return os.path.relpath(path) if self.rel_paths else path
 
     def root(self) -> str:
-        if not self.frame_info:
-            return ""
-
-        path = self.frame_info.filename
-        return path[: -len(self.file())]
+        return os.getcwd()
 
     def code_qualname(self) -> str:
         return (

--- a/pyteal/stack_frame.py
+++ b/pyteal/stack_frame.py
@@ -500,6 +500,8 @@ class PyTealFrame(StackFrame):
 
         self._raw_code: str | None = None
         self._status: PyTealFrameStatus | None = None
+        self._file: str | None = None
+        self._root: str | None = None
 
     def __repr__(self) -> str:
         """
@@ -536,14 +538,20 @@ class PyTealFrame(StackFrame):
         return f"{self.file()}:{self.lineno()}" if self.frame_info else ""
 
     def file(self) -> str:
-        if not self.frame_info:
-            return ""
+        if self._file is None:
+            if not self.frame_info:
+                self._file = ""
+            else:
+                path = self.frame_info.filename
+                self._file = os.path.relpath(path) if self.rel_paths else path
 
-        path = self.frame_info.filename
-        return os.path.relpath(path) if self.rel_paths else path
+        return self._file
 
     def root(self) -> str:
-        return os.getcwd()
+        if self._root is None:
+            self._root = os.getcwd()
+
+        return self._root
 
     def code_qualname(self) -> str:
         return (

--- a/pyteal/stack_frame_test.py
+++ b/pyteal/stack_frame_test.py
@@ -1,8 +1,11 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from pyteal.stack_frame import NatalStackFrame, PyTealFrame, StackFrame
 
 
+@pytest.mark.serial
 def test_is_pyteal():
     FrameInfo = Mock()
     FrameInfo.return_value = Mock()
@@ -20,6 +23,7 @@ def test_is_pyteal():
     assert not sf._is_pyteal()
 
 
+@pytest.mark.serial
 def test_file():
     FrameInfo = Mock()
     FrameInfo.return_value = Mock()

--- a/pyteal/stack_frame_test.py
+++ b/pyteal/stack_frame_test.py
@@ -30,19 +30,26 @@ def test_file():
 
     FrameInfo.return_value.filename = "not_pyteal.py"
     ptf = PyTealFrame(FrameInfo(), None, NatalStackFrame(), None)
+    assert ptf._file is None
     assert ptf.file() == "not_pyteal.py"
+    assert ptf._file == "not_pyteal.py"
 
     from_root = "/Users/AMAZINGalgodev/github/algorand/beaker/beaker/"
     FrameInfo.return_value.filename = from_root + "client/application_client.py"
     ptf = PyTealFrame(FrameInfo(), None, NatalStackFrame(), None)
-    assert ptf.file().endswith(
+    assert ptf._file is None
+    ending = (
         "../AMAZINGalgodev/github/algorand/beaker/beaker/client/application_client.py"
     )
+    assert ptf.file().endswith(ending)
+    assert ptf._file == ptf.file()
 
     with patch("os.path.relpath", return_value="FOOFOO"):
         FrameInfo.return_value.filename = from_root + "client/application_client.py"
         ptf = PyTealFrame(FrameInfo(), None, NatalStackFrame(), None)
+        assert ptf._file is None
         assert ptf.file() == "FOOFOO"
+        assert ptf._file == "FOOFOO"
 
 
 def test_root():
@@ -50,5 +57,7 @@ def test_root():
     FrameInfo.return_value = Mock()
     ptf = PyTealFrame(FrameInfo(), None, NatalStackFrame(), None)
 
+    assert ptf._root is None
     with patch("os.getcwd", return_value="FOOFOO"):
         assert ptf.root() == "FOOFOO"
+        assert ptf._root == "FOOFOO"

--- a/pyteal/stack_frame_test.py
+++ b/pyteal/stack_frame_test.py
@@ -1,6 +1,6 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from pyteal.stack_frame import NatalStackFrame, StackFrame
+from pyteal.stack_frame import NatalStackFrame, PyTealFrame, StackFrame
 
 
 def test_is_pyteal():
@@ -18,3 +18,33 @@ def test_is_pyteal():
     FrameInfo.return_value.filename = "blahblah/pyteal/not_really..."
     sf = StackFrame(FrameInfo(), None, NatalStackFrame())
     assert not sf._is_pyteal()
+
+
+def test_file():
+    FrameInfo = Mock()
+    FrameInfo.return_value = Mock()
+
+    FrameInfo.return_value.filename = "not_pyteal.py"
+    ptf = PyTealFrame(FrameInfo(), None, NatalStackFrame(), None)
+    assert ptf.file() == "not_pyteal.py"
+
+    from_root = "/Users/AMAZINGalgodev/github/algorand/beaker/beaker/"
+    FrameInfo.return_value.filename = from_root + "client/application_client.py"
+    ptf = PyTealFrame(FrameInfo(), None, NatalStackFrame(), None)
+    assert ptf.file().endswith(
+        "../AMAZINGalgodev/github/algorand/beaker/beaker/client/application_client.py"
+    )
+
+    with patch("os.path.relpath", return_value="FOOFOO"):
+        FrameInfo.return_value.filename = from_root + "client/application_client.py"
+        ptf = PyTealFrame(FrameInfo(), None, NatalStackFrame(), None)
+        assert ptf.file() == "FOOFOO"
+
+
+def test_root():
+    FrameInfo = Mock()
+    FrameInfo.return_value = Mock()
+    ptf = PyTealFrame(FrameInfo(), None, NatalStackFrame(), None)
+
+    with patch("os.getcwd", return_value="FOOFOO"):
+        assert ptf.root() == "FOOFOO"


### PR DESCRIPTION
## Problem

@barnjamin pointed out a bug when running the source mapper in [Beaker](https://github.com/algorand-devrel/beaker/pull/217):

```sh
❯ pwd
/Users/zeph/github/algorand/beaker
❯ cd examples/simple
❯ python hello.py
Traceback (most recent call last):
  File "/Users/zeph/github/algorand/beaker/examples/simple/hello.py", line 48, in <module>
    demo()
  File "/Users/zeph/github/algorand/beaker/examples/simple/hello.py", line 23, in demo
    app_client = client.ApplicationClient(
  File "/Users/zeph/github/algorand/beaker/beaker/client/application_client.py", line 55, in __init__
    self.app = app.build(client)
  File "/Users/zeph/github/algorand/beaker/beaker/application.py", line 1067, in build
    compile_results = router.compile(
  File "/Users/zeph/github/algorand/beaker/.venv/lib/python3.10/site-packages/pyteal/ast/router.py", line 1213, in compile
    return self._build_impl(input).get_results()
  File "/Users/zeph/github/algorand/beaker/.venv/lib/python3.10/site-packages/pyteal/ast/router.py", line 1221, in _build_impl
    abundle = input.get_compilation(ap)._compile_impl(
  File "/Users/zeph/github/algorand/beaker/.venv/lib/python3.10/site-packages/pyteal/compiler/compiler.py", line 492, in _compile_impl
    source_mapper = _PyTealSourceMapper(
  File "/Users/zeph/github/algorand/beaker/.venv/lib/python3.10/site-packages/pyteal/compiler/sourcemap.py", line 717, in __init__
    self.build()
  File "/Users/zeph/github/algorand/beaker/.venv/lib/python3.10/site-packages/pyteal/compiler/sourcemap.py", line 837, in build
    self._build_r3sourcemap()
  File "/Users/zeph/github/algorand/beaker/.venv/lib/python3.10/site-packages/pyteal/compiler/sourcemap.py", line 884, in _build_r3sourcemap
    assert all(
AssertionError: inconsistent sourceRoot - aborting
```

This PR aims to fix the issue by defining the source map's _source root_ to be the current working directory. This really should have been the logic to begin with, but instead, the root was calculated using a path comparison algorithm that broke on relative paths.

## Testing

Unit tests were added and I confirmed locally that when depending on this branch everything was copacetic:

```sh
❯ python hello.py
Deployed app in txid MYBYTUF3TL64R5L7EVKUIY6LV6FH4HMAF2HIEU7IPLVV7XNJGUTQ
        App ID: 5 
        Address: 2SYXFSCZAQCZ7YIFUCUZYOVR7G6Y3UBGSJIWT4EZ4CO3T6WVYTMHVSANOY 
    
Hello, Beaker
```