### PR TITLE
Use asset/app IDs when accessing ABI reference args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changed
 
+* Stop using slot indexes for assets and apps when accessing properties of ABI reference type arguments. ([#701](https://github.com/algorand/pyteal/pull/701))
+
 # v0.24.0
 
 ## Added

--- a/pyteal/ast/abi/reference_type.py
+++ b/pyteal/ast/abi/reference_type.py
@@ -124,7 +124,7 @@ class Account(ReferenceType):
                 must evaluate to uint64).
         """
         if isinstance(asset, Asset):
-            asset_ref = asset.referenced_index()
+            asset_ref = asset.asset_id()
         else:
             asset_ref = asset
         return AssetHoldingObject(asset_ref, self.referenced_index())
@@ -172,11 +172,11 @@ class Asset(ReferenceType):
             account_ref = account.referenced_index()
         else:
             account_ref = account
-        return AssetHoldingObject(self.referenced_index(), account_ref)
+        return AssetHoldingObject(self.asset_id(), account_ref)
 
     def params(self) -> AssetParamObject:
         """Get information about the asset's parameters."""
-        return AssetParamObject(self.referenced_index())
+        return AssetParamObject(self.asset_id())
 
 
 Asset.__module__ = "pyteal.abi"
@@ -209,7 +209,7 @@ class Application(ReferenceType):
 
     def params(self) -> AppParamObject:
         """Get information about the application's parameters."""
-        return AppParamObject(self.referenced_index())
+        return AppParamObject(self.application_id())
 
 
 Application.__module__ = "pyteal.abi"

--- a/pyteal/ast/abi/reference_type_test.py
+++ b/pyteal/ast/abi/reference_type_test.py
@@ -147,7 +147,7 @@ def test_Account_params():
 def test_Account_asset_holding():
     value = abi.Account()
 
-    assets = ((pt.Int(6), pt.Int(6)), (a := abi.Asset(), a.referenced_index()))
+    assets = ((pt.Int(6), pt.Int(6)), (a := abi.Asset(), a.asset_id()))
 
     for asset, expected_asset in assets:
         holding = value.asset_holding(asset)
@@ -234,7 +234,7 @@ def test_Asset_holding():
 
         assert type(holding) is pt.AssetHoldingObject
 
-        expected_asset = value.referenced_index()
+        expected_asset = value.asset_id()
         actual_asset = holding._asset
 
         actual_account = holding._account
@@ -253,7 +253,7 @@ def test_Asset_params():
 
     assert type(params) is pt.AssetParamObject
 
-    expected = value.referenced_index()
+    expected = value.asset_id()
     actual = params._asset
 
     with pt.TealComponent.Context.ignoreExprEquality():
@@ -318,7 +318,7 @@ def test_Application_params():
 
     assert type(params) is pt.AppParamObject
 
-    expected = value.referenced_index()
+    expected = value.application_id()
     actual = params._app
 
     with pt.TealComponent.Context.ignoreExprEquality():


### PR DESCRIPTION
Changes PyTeal's generated code to use asset & app IDs instead of slot indexes when accessing fields on ABI reference args.