### PR TITLE
Fix node 12 deprecation CI message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - run: python3 --version
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Python dependencies, Build, and Test
@@ -30,7 +30,7 @@ jobs:
         python: ["3.10", "3.11"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
@@ -52,7 +52,7 @@ jobs:
         python: ["3.10"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
@@ -64,7 +64,7 @@ jobs:
         run: make bundle-docs
       - name: Archive docset
         if: ${{ !env.ACT }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pyteal.docset
           path: docs/pyteal.docset.tar.gz
@@ -76,7 +76,7 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - run: python3 --version
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check for code changes
@@ -35,7 +35,7 @@ jobs:
         python: ["3.10", "3.11"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check for code changes


### PR DESCRIPTION
We use some node 12 actions in our current CI. Github actions has now deprecated node 12 actions, and we receive warnings in our build, for example in https://github.com/algorand/pyteal/actions/runs/4735851473

This PR removes those warnings by updating the node 12 packages to a more recent version.