### PR TITLE
CICD: fix quoting in python install in github actions file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Check out code
         uses: actions/checkout@v3
       - name: Install dependencies


### PR DESCRIPTION
# Summary

Didn't quote the python version which results in an error.

# Testing

Verify tagging publishes successfully.
