### PR TITLE
fix: bump max supported AVM version to 11

### DIFF
--- a/pyteal/compiler/compiler.py
+++ b/pyteal/compiler/compiler.py
@@ -35,7 +35,7 @@ from pyteal.types import TealType
 from pyteal.util import algod_with_assertion
 
 
-MAX_PROGRAM_VERSION = 10
+MAX_PROGRAM_VERSION = 11
 FRAME_POINTERS_VERSION = 8
 DEFAULT_SCRATCH_SLOT_OPTIMIZE_VERSION = 9
 MIN_PROGRAM_VERSION = 2


### PR DESCRIPTION
Current version supports v11 opcodes but doesn't build, as the MAX_VERSION has been left to 10